### PR TITLE
fix(proxy): read proxy env vars explicitly for rustls-tls clients

### DIFF
--- a/crates/claudepot-core/src/oauth/mod.rs
+++ b/crates/claudepot-core/src/oauth/mod.rs
@@ -11,10 +11,23 @@ static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 /// Shared HTTP client for all OAuth API calls. Connection-pooled, TLS-reused.
 pub fn http_client() -> Result<&'static reqwest::Client, OAuthError> {
     Ok(HTTP_CLIENT.get_or_init(|| {
-        reqwest::Client::builder()
+        let mut builder = reqwest::Client::builder()
             .user_agent("claudepot/0.1.0")
-            .timeout(std::time::Duration::from_secs(15))
-            .build()
-            .expect("failed to build HTTP client")
+            .timeout(std::time::Duration::from_secs(15));
+
+        // rustls-tls doesn't read macOS system proxy automatically; read env
+        // vars explicitly so Surge / Clash / etc. work when launched from GUI.
+        // Filter empty strings — HTTPS_PROXY="" short-circuits or_else chains.
+        let proxy_url = ["HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"]
+            .iter()
+            .filter_map(|var| std::env::var(var).ok())
+            .find(|v| !v.is_empty());
+        if let Some(url) = proxy_url {
+            if let Ok(proxy) = reqwest::Proxy::all(&url) {
+                builder = builder.proxy(proxy);
+            }
+        }
+
+        builder.build().expect("failed to build HTTP client")
     }))
 }

--- a/crates/claudepot-core/src/oauth/mod.rs
+++ b/crates/claudepot-core/src/oauth/mod.rs
@@ -24,7 +24,7 @@ pub fn http_client() -> Result<&'static reqwest::Client, OAuthError> {
             .find(|v| !v.is_empty());
         if let Some(url) = proxy_url {
             if let Ok(proxy) = reqwest::Proxy::all(&url) {
-                builder = builder.proxy(proxy);
+                builder = builder.proxy(proxy.no_proxy(reqwest::NoProxy::from_env()));
             }
         }
 

--- a/crates/claudepot-core/src/services/doctor_service.rs
+++ b/crates/claudepot-core/src/services/doctor_service.rs
@@ -204,10 +204,17 @@ fn build_profile_info(accounts: &[crate::account::Account]) -> Vec<ProfileInfo> 
 }
 
 async fn check_api(beta_header: &str) -> ApiStatus {
-    match reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-    {
+    let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(10));
+    let proxy_url = ["HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"]
+        .iter()
+        .filter_map(|var| std::env::var(var).ok())
+        .find(|v| !v.is_empty());
+    if let Some(url) = proxy_url {
+        if let Ok(proxy) = reqwest::Proxy::all(&url) {
+            builder = builder.proxy(proxy);
+        }
+    }
+    match builder.build() {
         Err(_) => ApiStatus::Unreachable("failed to build HTTP client".into()),
         Ok(client) => {
             match client

--- a/crates/claudepot-core/src/services/doctor_service.rs
+++ b/crates/claudepot-core/src/services/doctor_service.rs
@@ -211,7 +211,7 @@ async fn check_api(beta_header: &str) -> ApiStatus {
         .find(|v| !v.is_empty());
     if let Some(url) = proxy_url {
         if let Ok(proxy) = reqwest::Proxy::all(&url) {
-            builder = builder.proxy(proxy);
+            builder = builder.proxy(proxy.no_proxy(reqwest::NoProxy::from_env()));
         }
     }
     match builder.build() {


### PR DESCRIPTION
## Problem

`reqwest` built with `rustls-tls` + `default-features = false` does not automatically read system proxy settings. When the app is launched from a terminal with `https_proxy` set (e.g. Surge, Clash), two bugs prevent the proxy from being used:

1. **`or_else` short-circuit on empty string** — `HTTPS_PROXY=""` (set but empty) causes `std::env::var("HTTPS_PROXY")` to return `Ok("")`, short-circuiting the `or_else` chain so `https_proxy` (which has the actual value) is never reached.
2. **No explicit proxy injection** — even when the correct value is found, it was never passed to the `reqwest::ClientBuilder`.

The result: `api.anthropic.com` is unreachable, the Add Account preflight fails with _"HTTP request failed: error sending request"_, and Import from Claude Code is permanently blocked.

## Fix

Replace the `or_else` chain with an iterator approach that skips empty values, then call `.proxy()` on the builder with the first non-empty value found among `HTTPS_PROXY`, `https_proxy`, `ALL_PROXY`, `all_proxy`.

Applied to both the shared OAuth HTTP client (`oauth/mod.rs`) and the one-off client in `doctor_service.rs`.

## Known limitation

This fix only works when the app inherits the proxy env var from the shell (e.g. `pnpm tauri dev` from a terminal). When launched from Finder/Dock the env vars are absent. A follow-up should read the macOS `SystemConfiguration` system proxy instead.

## Test plan

- [ ] Launch app from a terminal with `https_proxy` set and Surge/Clash running
- [ ] Open Add Account — preflight should succeed and show the current CC identity
- [ ] Launch app from Dock (no env vars) — preflight will still fail; confirm no regression vs. before