### PR TITLE
fix(proxy): read macOS system proxy via SystemConfiguration on Finder/Dock launch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ base64 = "0.22"
 aes = "0.8"
 # macOS-only
 pbkdf2 = { version = "0.12", default-features = false, features = ["hmac", "sha1"] }
+system-configuration = "0.6"
 hmac = "0.12"
 sha1 = "0.10"
 cbc = { version = "0.1", features = ["alloc"] }

--- a/crates/claudepot-cli/src/commands/doctor.rs
+++ b/crates/claudepot-cli/src/commands/doctor.rs
@@ -21,6 +21,7 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
                 "desktop_version": report.desktop_version,
                 "beta_header": report.beta_header,
                 "api_reachable": matches!(report.api_status, doctor_service::ApiStatus::Reachable),
+                "proxy_source": report.proxy_source,
                 "accounts": report.account_health.iter().map(|a| {
                     serde_json::json!({
                         "email": a.email,
@@ -109,6 +110,9 @@ pub async fn run(ctx: &AppContext) -> Result<()> {
 
     // Beta header
     ok("Beta header", &report.beta_header);
+
+    // Proxy
+    ok("Proxy", &report.proxy_source);
 
     // API
     match &report.api_status {

--- a/crates/claudepot-core/Cargo.toml
+++ b/crates/claudepot-core/Cargo.toml
@@ -51,6 +51,7 @@ pbkdf2.workspace = true
 hmac.workspace = true
 sha1.workspace = true
 cbc.workspace = true
+system-configuration.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 aes-gcm.workspace = true

--- a/crates/claudepot-core/src/lib.rs
+++ b/crates/claudepot-core/src/lib.rs
@@ -56,6 +56,7 @@ pub mod migrations;
 pub mod oauth;
 pub mod onboard;
 pub mod path_utils;
+pub mod proxy;
 pub mod paths;
 pub mod pricing;
 pub mod project;

--- a/crates/claudepot-core/src/oauth/mod.rs
+++ b/crates/claudepot-core/src/oauth/mod.rs
@@ -11,23 +11,12 @@ static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 /// Shared HTTP client for all OAuth API calls. Connection-pooled, TLS-reused.
 pub fn http_client() -> Result<&'static reqwest::Client, OAuthError> {
     Ok(HTTP_CLIENT.get_or_init(|| {
-        let mut builder = reqwest::Client::builder()
+        let config = crate::proxy::detect();
+        let builder = reqwest::Client::builder()
             .user_agent("claudepot/0.1.0")
             .timeout(std::time::Duration::from_secs(15));
-
-        // rustls-tls doesn't read macOS system proxy automatically; read env
-        // vars explicitly so Surge / Clash / etc. work when launched from GUI.
-        // Filter empty strings — HTTPS_PROXY="" short-circuits or_else chains.
-        let proxy_url = ["HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"]
-            .iter()
-            .filter_map(|var| std::env::var(var).ok())
-            .find(|v| !v.is_empty());
-        if let Some(url) = proxy_url {
-            if let Ok(proxy) = reqwest::Proxy::all(&url) {
-                builder = builder.proxy(proxy.no_proxy(reqwest::NoProxy::from_env()));
-            }
-        }
-
-        builder.build().expect("failed to build HTTP client")
+        crate::proxy::apply(builder, &config)
+            .build()
+            .expect("failed to build HTTP client")
     }))
 }

--- a/crates/claudepot-core/src/proxy.rs
+++ b/crates/claudepot-core/src/proxy.rs
@@ -1,0 +1,222 @@
+//! Outbound proxy detection for HTTPS requests.
+//!
+//! Priority order:
+//! 1. Environment variables — `HTTPS_PROXY`, `https_proxy`, `ALL_PROXY`,
+//!    `all_proxy` (first non-empty value wins). Works when the app is
+//!    launched from a shell that already has the vars set (e.g. `pnpm tauri dev`).
+//! 2. macOS `SystemConfiguration` framework — `SCDynamicStoreCopyProxies` via
+//!    `SCDynamicStore::get_proxies()`. Covers the Finder/Dock launch path where
+//!    shell env is absent.
+//! 3. No proxy.
+//!
+//! `NO_PROXY`/`no_proxy` exclusions are honoured at every level: env-var
+//! path reads them from the environment; macOS path translates the system
+//! `ExceptionsList` to the same comma-separated format.
+
+/// Where the proxy configuration came from — reported by `doctor` so
+/// support tickets are diagnosable without guessing the launch context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProxySource {
+    /// A shell environment variable (name shown, e.g. `"https_proxy"`).
+    EnvVar(String),
+    /// macOS `SystemConfiguration` framework (`SCDynamicStoreCopyProxies`).
+    #[cfg(target_os = "macos")]
+    MacosSystem,
+    /// No proxy configured anywhere.
+    None,
+}
+
+impl std::fmt::Display for ProxySource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProxySource::EnvVar(name) => write!(f, "env-var: {name}"),
+            #[cfg(target_os = "macos")]
+            ProxySource::MacosSystem => write!(f, "SystemConfiguration"),
+            ProxySource::None => write!(f, "none"),
+        }
+    }
+}
+
+/// Resolved proxy configuration ready to pass to a `reqwest::ClientBuilder`.
+#[derive(Debug, Clone)]
+pub struct ProxyConfig {
+    /// Proxy URL (e.g. `http://127.0.0.1:6152`), or `None` if no proxy.
+    pub url: Option<String>,
+    /// Comma-separated exclusion list for `reqwest::NoProxy::from_string`,
+    /// or `None` if there are no exclusions.
+    pub no_proxy: Option<String>,
+    /// Diagnostic: which detection path produced this result.
+    pub source: ProxySource,
+}
+
+/// Detect the proxy configuration for outbound HTTPS requests.
+///
+/// See module-level docs for the priority order.
+pub fn detect() -> ProxyConfig {
+    // 1. Environment variables
+    let env_proxy = ["HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"]
+        .iter()
+        .find_map(|var| {
+            let val = std::env::var(var).ok()?;
+            if val.is_empty() {
+                None
+            } else {
+                Some((var.to_string(), val))
+            }
+        });
+
+    if let Some((var_name, url)) = env_proxy {
+        return ProxyConfig {
+            url: Some(url),
+            no_proxy: no_proxy_from_env(),
+            source: ProxySource::EnvVar(var_name),
+        };
+    }
+
+    // 2. macOS system proxy via SystemConfiguration
+    #[cfg(target_os = "macos")]
+    if let Some((url, no_proxy)) = macos_system_proxy() {
+        return ProxyConfig {
+            url: Some(url),
+            no_proxy,
+            source: ProxySource::MacosSystem,
+        };
+    }
+
+    // 3. No proxy
+    ProxyConfig {
+        url: None,
+        no_proxy: None,
+        source: ProxySource::None,
+    }
+}
+
+/// Apply a `ProxyConfig` to a `reqwest::ClientBuilder`.
+///
+/// Does nothing if `config.url` is `None`. If the URL is present but
+/// unparseable as a proxy URI, the builder is returned unchanged (silent
+/// degradation — the request will attempt a direct connection).
+pub fn apply(builder: reqwest::ClientBuilder, config: &ProxyConfig) -> reqwest::ClientBuilder {
+    let Some(ref url) = config.url else {
+        return builder;
+    };
+    let Ok(proxy) = reqwest::Proxy::all(url) else {
+        return builder;
+    };
+    let no_proxy = config
+        .no_proxy
+        .as_deref()
+        .and_then(reqwest::NoProxy::from_string)
+        .or_else(reqwest::NoProxy::from_env);
+    builder.proxy(proxy.no_proxy(no_proxy))
+}
+
+fn no_proxy_from_env() -> Option<String> {
+    ["NO_PROXY", "no_proxy"].iter().find_map(|var| {
+        let val = std::env::var(var).ok()?;
+        if val.is_empty() {
+            None
+        } else {
+            Some(val)
+        }
+    })
+}
+
+// ─── macOS system proxy via SystemConfiguration ──────────────────────────────
+
+/// Read the HTTPS proxy from the macOS `SystemConfiguration` framework using
+/// `SCDynamicStoreCopyProxies`. Returns `(proxy_url, no_proxy_list)` or
+/// `None` if HTTPS proxy is not enabled.
+#[cfg(target_os = "macos")]
+fn macos_system_proxy() -> Option<(String, Option<String>)> {
+    use system_configuration::{
+        core_foundation::{
+            array::CFArray,
+            base::TCFType,
+            number::CFNumber,
+            string::CFString,
+        },
+        dynamic_store::SCDynamicStoreBuilder,
+    };
+
+    let store = SCDynamicStoreBuilder::new("claudepot").build();
+    let dict = store.get_proxies()?;
+
+    // Helper: look up a key and downcast to CFNumber → i64
+    let get_num = |key: &str| -> Option<i64> {
+        let cf_key = CFString::new(key);
+        let val = dict.find(&cf_key)?;
+        val.downcast::<CFNumber>()?.to_i64()
+    };
+
+    // Helper: look up a key and downcast to CFString → String
+    let get_str = |key: &str| -> Option<String> {
+        let cf_key = CFString::new(key);
+        let val = dict.find(&cf_key)?;
+        Some(val.downcast::<CFString>()?.to_string())
+    };
+
+    // Check HTTPSEnable = 1
+    if get_num("HTTPSEnable").unwrap_or(0) != 1 {
+        return None;
+    }
+
+    let host = get_str("HTTPSProxy")?;
+    let port = get_num("HTTPSPort").filter(|&p| p > 0)?;
+
+    if host.is_empty() {
+        return None;
+    }
+
+    let proxy_url = format!("http://{}:{}", host, port);
+
+    // ExceptionsList → comma-separated no_proxy string.
+    // CFArray<CFString> does not implement ConcreteCFType; downcast to the
+    // untyped CFArray<*const c_void> and re-wrap each element as CFString.
+    let no_proxy = {
+        use std::ffi::c_void;
+        let exc_key = CFString::new("ExceptionsList");
+        dict.find(&exc_key).and_then(|val| {
+            let arr = val.downcast::<CFArray<*const c_void>>()?;
+            let items: Vec<String> = arr
+                .iter()
+                .filter_map(|ptr| {
+                    if ptr.is_null() {
+                        return None;
+                    }
+                    // SAFETY: every element in ExceptionsList is a CFString.
+                    let s: CFString = unsafe { TCFType::wrap_under_get_rule(*ptr as _) };
+                    Some(s.to_string())
+                })
+                .collect();
+            if items.is_empty() {
+                None
+            } else {
+                Some(items.join(","))
+            }
+        })
+    };
+
+    Some((proxy_url, no_proxy))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_does_not_panic() {
+        let _ = detect();
+    }
+
+    #[test]
+    fn test_proxy_source_display() {
+        assert_eq!(ProxySource::None.to_string(), "none");
+        assert_eq!(
+            ProxySource::EnvVar("https_proxy".into()).to_string(),
+            "env-var: https_proxy"
+        );
+        #[cfg(target_os = "macos")]
+        assert_eq!(ProxySource::MacosSystem.to_string(), "SystemConfiguration");
+    }
+}

--- a/crates/claudepot-core/src/services/doctor_service.rs
+++ b/crates/claudepot-core/src/services/doctor_service.rs
@@ -22,6 +22,9 @@ pub struct HealthReport {
     pub account_health: Vec<AccountHealth>,
     pub desktop_profiles: Vec<ProfileInfo>,
     pub db_error: Option<String>,
+    /// Which proxy path was used for the API reachability check.
+    /// Displayed as `env-var: HTTPS_PROXY`, `SystemConfiguration`, or `none`.
+    pub proxy_source: String,
 }
 
 #[derive(Debug)]
@@ -68,8 +71,12 @@ pub async fn check_health(store: &AccountStore) -> HealthReport {
     // Beta header
     let beta_header = crate::oauth::beta_header::get_or_default().to_string();
 
+    // Proxy detection (once, shared with API check)
+    let proxy_config = crate::proxy::detect();
+    let proxy_source = proxy_config.source.to_string();
+
     // API reachability
-    let api_status = check_api(&beta_header).await;
+    let api_status = check_api(&beta_header, &proxy_config).await;
 
     // Account health
     let (accounts, db_error) = match store.list() {
@@ -95,6 +102,7 @@ pub async fn check_health(store: &AccountStore) -> HealthReport {
         account_health,
         desktop_profiles,
         db_error,
+        proxy_source,
     }
 }
 
@@ -203,17 +211,9 @@ fn build_profile_info(accounts: &[crate::account::Account]) -> Vec<ProfileInfo> 
         .collect()
 }
 
-async fn check_api(beta_header: &str) -> ApiStatus {
-    let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(10));
-    let proxy_url = ["HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"]
-        .iter()
-        .filter_map(|var| std::env::var(var).ok())
-        .find(|v| !v.is_empty());
-    if let Some(url) = proxy_url {
-        if let Ok(proxy) = reqwest::Proxy::all(&url) {
-            builder = builder.proxy(proxy.no_proxy(reqwest::NoProxy::from_env()));
-        }
-    }
+async fn check_api(beta_header: &str, proxy_config: &crate::proxy::ProxyConfig) -> ApiStatus {
+    let builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(10));
+    let builder = crate::proxy::apply(builder, proxy_config);
     match builder.build() {
         Err(_) => ApiStatus::Unreachable("failed to build HTTP client".into()),
         Ok(client) => {


### PR DESCRIPTION
## Summary

- Gates `system-configuration` under `[target.'cfg(target_os = "macos")'.dependencies]` in both workspace `Cargo.toml` and `claudepot-core/Cargo.toml` — Windows/Linux builds are unaffected
- All macOS-specific proxy detection code is wrapped in `#[cfg(target_os = "macos")]` blocks
- `reqwest` with `rustls-tls` does not auto-read system proxies; this fix adds a 3-level cascade: env vars → `SCDynamicStoreCopyProxies` → none
- `proxy_source` field added to `HealthReport` so `claudepot doctor` reports which proxy path was used

## Problem

When launched from Finder or the Dock (no shell environment), `HTTPS_PROXY` / `https_proxy` env vars are not set, so `reqwest` had no proxy configuration and API calls failed for users behind a system proxy.

## Test plan

- [ ] `cargo check --workspace` passes on macOS, Linux, and Windows
- [ ] `claudepot doctor` shows `proxy: SystemConfiguration` when a system HTTPS proxy is configured on macOS
- [ ] `claudepot doctor` shows `proxy: none` when no proxy is configured
- [ ] App launched from Dock can reach the Anthropic API through a system proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)