### PR TITLE
Editable system prompt + assign Ada as moderator + /office/policy

### DIFF
--- a/web/editorial/rubric.yml
+++ b/web/editorial/rubric.yml
@@ -273,7 +273,7 @@ extensions:
 # rate than ClauDepot, and routing.feed_threshold acts as a per-persona bar.
 persona_overlays:
   ada:
-    description: "Evidence-first skeptic. Asks 'where's the eval?'. Strongest on engineer / infra-shipper content."
+    description: "Evidence-first skeptic. Asks 'where's the eval?'. Strongest on engineer / infra-shipper content. Also serves as the platform's AI policy moderator (the synchronous policy gate every submission and comment passes through before publish — see /office/policy)."
     multipliers:
       evidence_quality:      1.5
       mechanism_specificity: 1.2

--- a/web/src/app/(reader)/admin/policy-prompt/PolicyPromptEditor.tsx
+++ b/web/src/app/(reader)/admin/policy-prompt/PolicyPromptEditor.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useActionState, useState, useTransition } from "react";
+
+import {
+  publishPolicyPromptFormAction,
+  previewPolicyPromptAction,
+  type PolicyPromptActionState,
+  type PreviewFixtureResult,
+} from "@/lib/actions/policy-prompt";
+
+const INIT: PolicyPromptActionState = { ok: true, message: "" };
+
+interface Props {
+  initialSystemPrompt: string;
+  suggestedVersion: string;
+}
+
+/**
+ * Editor for the AI policy moderator's system prompt.
+ *
+ * Two actions:
+ *   - "Preview" runs the draft against four fixture cases (good
+ *     submission, spam, doxxing, security-research-as-FP-risk) and
+ *     shows whether each scored as expected. Costs ~$0.0005 per
+ *     run, takes ~5–10s.
+ *   - "Activate" inserts a new row in moderation_prompts with the
+ *     given version label and atomically flips it active. The next
+ *     moderate() call picks up the new prompt within ~60s (cache
+ *     TTL) — the server action also clears the in-process cache so
+ *     warm processes pick it up immediately.
+ */
+export function PolicyPromptEditor({
+  initialSystemPrompt,
+  suggestedVersion,
+}: Props) {
+  const [systemPrompt, setSystemPrompt] = useState(initialSystemPrompt);
+  const [version, setVersion] = useState(suggestedVersion);
+  const [note, setNote] = useState("");
+  const [previewResults, setPreviewResults] = useState<PreviewFixtureResult[] | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewPending, startPreview] = useTransition();
+
+  const [publishState, publishAction, publishPending] = useActionState(
+    publishPolicyPromptFormAction,
+    INIT,
+  );
+
+  function handlePreview() {
+    setPreviewError(null);
+    setPreviewResults(null);
+    startPreview(async () => {
+      const result = await previewPolicyPromptAction({ systemPrompt });
+      if (result.ok) {
+        setPreviewResults(result.results);
+      } else {
+        setPreviewError(formatPreviewError(result));
+      }
+    });
+  }
+
+  const matchedCount = previewResults
+    ? previewResults.filter((r) => r.matched).length
+    : 0;
+  const totalCount = previewResults?.length ?? 0;
+  const previewMismatchWarn =
+    previewResults !== null && matchedCount < totalCount;
+
+  return (
+    <section className="proto-section">
+      <h2>Edit the system prompt</h2>
+      <p className="proto-dek">
+        Saving creates a new version and activates it immediately. The
+        previous version is preserved in history (it just becomes
+        inactive). Run <strong>Preview</strong> first — it scores four
+        known fixtures with the draft prompt so you can see the
+        verdicts before a real submission hits it in production.
+      </p>
+
+      <form action={publishAction} className="proto-policy-prompt-form">
+        <label htmlFor="systemPrompt" className="proto-form-label">
+          System prompt
+        </label>
+        <textarea
+          id="systemPrompt"
+          name="systemPrompt"
+          value={systemPrompt}
+          onChange={(e) => setSystemPrompt(e.target.value)}
+          rows={24}
+          minLength={200}
+          maxLength={16_000}
+          required
+          disabled={publishPending}
+          className="proto-policy-prompt-textarea"
+        />
+        <p className="proto-form-hint">
+          {systemPrompt.length} characters. The user prompt template
+          and JSON-schema response format stay in code (changing them
+          is a code change). Categories and category descriptions
+          live here.
+        </p>
+
+        <div className="proto-form-row">
+          <label htmlFor="version" className="proto-form-label">
+            Version label
+          </label>
+          <input
+            id="version"
+            name="version"
+            value={version}
+            onChange={(e) => setVersion(e.target.value)}
+            required
+            disabled={publishPending}
+            pattern="[A-Za-z0-9_.\-]+"
+            maxLength={40}
+            className="proto-form-input"
+          />
+        </div>
+
+        <div className="proto-form-row">
+          <label htmlFor="note" className="proto-form-label">
+            Note (optional)
+          </label>
+          <input
+            id="note"
+            name="note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            maxLength={500}
+            placeholder="e.g. tighten doxxing definition; loosen spam threshold"
+            disabled={publishPending}
+            className="proto-form-input"
+          />
+        </div>
+
+        <div className="proto-form-actions">
+          <button
+            type="button"
+            onClick={handlePreview}
+            disabled={previewPending || systemPrompt.length < 200}
+            className="proto-btn"
+          >
+            {previewPending ? "Previewing…" : "Preview"}
+          </button>
+          <button
+            type="submit"
+            disabled={publishPending}
+            className="proto-btn proto-btn-primary"
+          >
+            {publishPending ? "Activating…" : "Activate"}
+          </button>
+          {publishState.message ? (
+            <span
+              className={
+                publishState.ok
+                  ? "proto-form-flash proto-form-flash-ok"
+                  : "proto-form-flash proto-form-flash-err"
+              }
+              role={publishState.ok ? "status" : "alert"}
+            >
+              {publishState.message}
+            </span>
+          ) : null}
+        </div>
+      </form>
+
+      {previewMismatchWarn ? (
+        <p className="proto-form-flash proto-form-flash-err" role="alert">
+          ⚠ Preview: {totalCount - matchedCount}/{totalCount} fixtures
+          scored differently than expected. Review before activating.
+        </p>
+      ) : null}
+
+      {previewError ? (
+        <p className="proto-form-flash proto-form-flash-err" role="alert">
+          {previewError}
+        </p>
+      ) : null}
+
+      {previewResults ? (
+        <table className="proto-mod-table">
+          <caption>
+            Preview: {matchedCount}/{totalCount} fixtures matched expected.
+          </caption>
+          <thead>
+            <tr>
+              <th>Fixture</th>
+              <th>Expected</th>
+              <th>Actual</th>
+              <th>Confidence</th>
+              <th>One-line-why</th>
+              <th>ms</th>
+            </tr>
+          </thead>
+          <tbody>
+            {previewResults.map((r) => {
+              const actualLabel = r.actual
+                ? r.actual.verdict === "reject"
+                  ? `reject:${r.actual.category}`
+                  : "pass"
+                : "(error)";
+              return (
+                <tr key={r.label}>
+                  <td>{r.label}</td>
+                  <td>
+                    <code>{r.expected}</code>
+                  </td>
+                  <td>
+                    <code
+                      className={
+                        r.matched
+                          ? "proto-state-pill proto-state-pill-pending"
+                          : "proto-state-pill proto-state-pill-pending proto-mod-btn-remove"
+                      }
+                    >
+                      {actualLabel}
+                    </code>
+                  </td>
+                  <td>{r.actual?.confidence ?? "—"}</td>
+                  <td className="proto-mod-reason">
+                    {r.actual?.oneLineWhy ?? r.error ?? "—"}
+                  </td>
+                  <td>{r.elapsedMs}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      ) : null}
+    </section>
+  );
+}
+
+function formatPreviewError(
+  result: { reason: "forbidden" | "validation" | "no_api_key"; detail?: string },
+): string {
+  switch (result.reason) {
+    case "forbidden":
+      return "Not authorized.";
+    case "validation":
+      return result.detail ?? "Invalid input.";
+    case "no_api_key":
+      return "OPENAI_API_KEY is not set in this environment — preview cannot run.";
+  }
+}

--- a/web/src/app/(reader)/admin/policy-prompt/page.tsx
+++ b/web/src/app/(reader)/admin/policy-prompt/page.tsx
@@ -1,0 +1,148 @@
+import Link from "next/link";
+
+import { staffGate } from "@/lib/staff-gate";
+import { relativeTime } from "@/lib/format";
+import { loadPolicyPromptHistory } from "@/lib/actions/policy-prompt";
+import { FALLBACK_SYSTEM_PROMPT } from "@/lib/moderation/prompt";
+
+import { PolicyPromptEditor } from "./PolicyPromptEditor";
+
+/**
+ * /admin/policy-prompt — staff editor for the AI policy moderator's
+ * system prompt.
+ *
+ * Today the moderator is Ada (per migration 0009 + the system-user
+ * lookup). Saving here creates a new row in moderation_prompts with
+ * active=true and atomically deactivates the prior active row. Old
+ * versions stay in history; "rollback" is just creating a new row
+ * with the old content.
+ *
+ * The fallback (FALLBACK_SYSTEM_PROMPT in lib/moderation/prompt.ts)
+ * is the boot-time default when the DB table is empty. Once a row
+ * exists, the DB version always wins.
+ */
+
+export default async function PolicyPromptAdminPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ as?: string }>;
+}) {
+  const sp = await searchParams;
+  const gate = await staffGate(sp);
+  if (gate) return gate;
+
+  const history = await loadPolicyPromptHistory();
+  const active = history.find((h) => h.active);
+  const initialSystemPrompt = active?.systemPrompt ?? FALLBACK_SYSTEM_PROMPT;
+
+  // Suggest the next integer if the version label has been integers
+  // so far; otherwise echo "fallback+1" / fall back to a date stamp.
+  const suggestedVersion = suggestNextVersion(history.map((h) => h.version));
+
+  return (
+    <div className="proto-page-narrow">
+      <h1>Policy moderator prompt</h1>
+      <p className="proto-dek">
+        The system prompt the AI policy moderator (
+        <Link href="/office/persona/ada">Ada</Link>) uses to score
+        every submission and comment. Edits here take effect within
+        ~60s without a redeploy. Past versions stay in history and
+        can be rolled back by saving their content as a new version.
+      </p>
+
+      <section className="proto-section">
+        <h2>Currently active</h2>
+        {active ? (
+          <p className="proto-dek">
+            <strong>{active.version}</strong>
+            {active.note ? <> — {active.note}</> : null} · saved{" "}
+            {relativeTime(active.createdAt.toISOString())}
+            {active.createdByUsername ? (
+              <> by @{active.createdByUsername}</>
+            ) : null}
+            .
+          </p>
+        ) : (
+          <p className="proto-dek">
+            No DB row active yet — moderator is using the fallback
+            prompt baked into the deploy. Save a version below to
+            switch the moderator to DB-backed prompts.
+          </p>
+        )}
+      </section>
+
+      <PolicyPromptEditor
+        initialSystemPrompt={initialSystemPrompt}
+        suggestedVersion={suggestedVersion}
+      />
+
+      <section className="proto-section">
+        <h2>History</h2>
+        {history.length === 0 ? (
+          <p className="proto-empty">No saved versions yet.</p>
+        ) : (
+          <table className="proto-mod-table">
+            <thead>
+              <tr>
+                <th>Version</th>
+                <th>Saved</th>
+                <th>By</th>
+                <th>Active</th>
+                <th>Note</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.map((h) => (
+                <tr key={h.id}>
+                  <td>
+                    <code>{h.version}</code>
+                  </td>
+                  <td>{relativeTime(h.createdAt.toISOString())}</td>
+                  <td>
+                    {h.createdByUsername ? (
+                      <Link href={`/u/${h.createdByUsername}`}>
+                        @{h.createdByUsername}
+                      </Link>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                  <td>{h.active ? "✓" : ""}</td>
+                  <td className="proto-mod-reason">{h.note ?? ""}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}
+
+/**
+ * Return a sensible default for the version input. If every existing
+ * version is a parseable integer, suggest max+1. Otherwise suggest
+ * an ISO-date stamp so the user never gets a duplicate by accident.
+ */
+function suggestNextVersion(existing: string[]): string {
+  const ints: number[] = [];
+  let allInts = true;
+  for (const v of existing) {
+    const n = Number.parseInt(v, 10);
+    if (Number.isInteger(n) && String(n) === v) {
+      ints.push(n);
+    } else {
+      allInts = false;
+      break;
+    }
+  }
+  if (allInts && ints.length > 0) {
+    return String(Math.max(...ints) + 1);
+  }
+  // Fallback: a date stamp (always unique among recent edits).
+  const now = new Date();
+  const yyyy = now.getUTCFullYear();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(now.getUTCDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}

--- a/web/src/app/(reader)/office/persona/[name]/page.tsx
+++ b/web/src/app/(reader)/office/persona/[name]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import type React from "react";
-import { Cpu, ExternalLink, ArrowLeft } from "lucide-react";
+import { Cpu, ExternalLink, ArrowLeft, Shield } from "lucide-react";
 import { getRecentDecisions, getPersonaStats } from "@/db/office-queries";
 import { OFFICE_PERSONAS } from "@/lib/office-personas";
 import { relativeTime } from "@/lib/format";
@@ -51,6 +51,16 @@ export default async function PersonaPage({
           <span className="office-ai-chip" aria-label="AI editorial agent">
             <Cpu size={11} aria-hidden /> AI editor
           </span>
+          {(persona.roles ?? []).map((role) => (
+            <Link
+              key={role.name}
+              href={role.href}
+              className="office-ai-chip"
+              aria-label={`Also serves as ${role.name}`}
+            >
+              <Shield size={11} aria-hidden /> {role.name}
+            </Link>
+          ))}
         </div>
         <p className="proto-dek">{persona.description}</p>
       </header>

--- a/web/src/app/(reader)/office/policy/page.tsx
+++ b/web/src/app/(reader)/office/policy/page.tsx
@@ -1,0 +1,194 @@
+import Link from "next/link";
+import { ArrowLeft, Cpu, Shield } from "lucide-react";
+import { count, gte, sql } from "drizzle-orm";
+
+import { db } from "@/db/client";
+import { policyDecisions } from "@/db/schema";
+import { POLICY_CATEGORIES } from "@/lib/moderation";
+import { getActiveSystemPrompt } from "@/lib/moderation/prompt-store";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * /office/policy — Ada's other job.
+ *
+ * Public window into the AI policy moderator. Aggregate-only:
+ * counts by category over rolling 30 days, the active prompt
+ * version, the five-category taxonomy with definitions. Does NOT
+ * expose per-decision detail — those stay private to the affected
+ * user (via /appeal/[id]) and to staff (via /admin/log).
+ *
+ * Per dev-docs/policy-moderator-plan.md §13 (privacy + transparency):
+ * the policy prompt is public; per-decision rows are private; the
+ * aggregate is the right granularity for a public audit surface.
+ */
+
+const CATEGORY_NOTES: Record<string, string> = {
+  spam: "Off-topic promotion, link farms, repetitive postings, paid promotion without disclosure.",
+  abuse: "Harassment, slurs, threats, targeted personal attacks against an identified person or group.",
+  illegal:
+    "CSAM; distributing malware or stolen credentials; flagrant copyright violation. Discussion of these is allowed; distribution is not.",
+  doxxing:
+    "Exposing a private individual's home address, phone number, government ID, or non-public personal email tied to a real-name target.",
+  off_topic:
+    "Submissions only — clearly unrelated to AI tools / AI-augmented work / LLM technique. Comments are not rejected for off-topic.",
+};
+
+export default async function OfficePolicyPage() {
+  const startOfWindow = new Date(Date.now() - 30 * 86_400_000);
+
+  // Total decisions in window + rejects in window + by-category breakdown.
+  const [{ total }, { rejected }, byCategoryRaw] = await Promise.all([
+    db
+      .select({ total: count() })
+      .from(policyDecisions)
+      .where(gte(policyDecisions.decidedAt, startOfWindow))
+      .then((r) => r[0] ?? { total: 0 }),
+    db
+      .select({ rejected: count() })
+      .from(policyDecisions)
+      .where(
+        sql`${policyDecisions.decidedAt} >= ${startOfWindow} AND ${policyDecisions.verdict} = 'reject'`,
+      )
+      .then((r) => r[0] ?? { rejected: 0 }),
+    db
+      .select({
+        category: policyDecisions.category,
+        n: count(),
+      })
+      .from(policyDecisions)
+      .where(
+        sql`${policyDecisions.decidedAt} >= ${startOfWindow} AND ${policyDecisions.verdict} = 'reject'`,
+      )
+      .groupBy(policyDecisions.category),
+  ]);
+
+  const byCategory = new Map<string, number>();
+  for (const r of byCategoryRaw) {
+    if (r.category) byCategory.set(r.category, r.n);
+  }
+
+  const { version: activePromptVersion } = await getActiveSystemPrompt();
+
+  return (
+    <div className="proto-page-narrow">
+      <nav className="office-breadcrumb">
+        <Link href="/office">
+          <span className="proto-inline-icon" aria-hidden>
+            <ArrowLeft size={12} />
+          </span>{" "}
+          the office
+        </Link>
+      </nav>
+
+      <header className="proto-section">
+        <div className="office-persona-head">
+          <h1>Policy moderation</h1>
+          <span className="office-ai-chip" aria-label="AI policy moderator">
+            <Shield size={11} aria-hidden /> Ada&rsquo;s other job
+          </span>
+        </div>
+        <p className="proto-dek">
+          Every submission and comment runs through a synchronous AI
+          policy gate before publish. The job belongs to{" "}
+          <Link href="/office/persona/ada">Ada</Link> — same persona who
+          scores editorial picks, here in a different mode. The full
+          system prompt is in this repo (
+          <Link href="/office/rubric">rubric &amp; voice are public</Link>);
+          the moderator&rsquo;s per-decision reasoning stays private to
+          the affected user and to staff so the public log doesn&rsquo;t
+          re-expose the very PII it just classified.
+        </p>
+      </header>
+
+      <section className="proto-section">
+        <h2>The five categories</h2>
+        <p className="office-section-lede">
+          Reject only when content clearly fits one. When in doubt,
+          pass. The rubric is intentionally small — five categories,
+          not fifty — because every additional category trades
+          precision for argued-edges.
+        </p>
+        <dl className="office-policy-categories">
+          {POLICY_CATEGORIES.map((cat) => (
+            <div key={cat} className="office-policy-category">
+              <dt>
+                <code>{cat}</code>{" "}
+                {byCategory.has(cat) ? (
+                  <span className="office-pick-host">
+                    ({byCategory.get(cat)} in last 30d)
+                  </span>
+                ) : null}
+              </dt>
+              <dd>{CATEGORY_NOTES[cat]}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      <section className="proto-section">
+        <h2>Last 30 days</h2>
+        {total === 0 ? (
+          <p className="office-empty">
+            Ada hasn&rsquo;t scored anything yet (or the window is
+            quiet). Aggregate stats land here as decisions accumulate.
+          </p>
+        ) : (
+          <p className="office-stat-summary">
+            <strong>{total}</strong> decision{total === 1 ? "" : "s"};{" "}
+            <strong>{rejected}</strong> reject{rejected === 1 ? "" : "s"}{" "}
+            ({total > 0 ? Math.round((rejected / total) * 100) : 0}%).
+          </p>
+        )}
+      </section>
+
+      <section className="proto-section">
+        <h2>The prompt</h2>
+        <p className="proto-dek">
+          Active version:{" "}
+          <code>
+            <Cpu size={10} aria-hidden /> {activePromptVersion}
+          </code>
+          . Staff edits it at{" "}
+          <code>/admin/policy-prompt</code> when the false-positive
+          rate calls for it. Versioned: every saved version is in the
+          DB under its label, and{" "}
+          <Link href="/admin/log?automated=1">/admin/log</Link>{" "}
+          (visible to any signed-in user) shows when the prompt
+          changed.
+        </p>
+        <p className="office-fineprint">
+          Why no prompt body here: the policy prompt is{" "}
+          <em>public</em> by design (industry-standard categories;
+          not adversarially tunable in the way the editorial taste
+          rubric is) — but rendering the full text on a public
+          aggregate page would make it look like editorial copy.
+          It&rsquo;s in <code>web/src/lib/moderation/prompt.ts</code>{" "}
+          (the fallback) and in the <code>moderation_prompts</code>{" "}
+          table (the active version).
+        </p>
+      </section>
+
+      <section className="proto-section">
+        <h2>What this page does NOT show</h2>
+        <ul className="office-fineprint-list">
+          <li>
+            Per-decision details — the moderator&rsquo;s one-line-why
+            on a doxxing reject can quote the very address that
+            triggered the rule. Drill-down lives in{" "}
+            <code>/admin/log</code> (staff only).
+          </li>
+          <li>
+            Author identities — counts here are per-category, not
+            per-user.
+          </li>
+          <li>
+            Appeals — they go to staff via the existing review queue
+            at <code>/admin/queue</code>; resolutions land in{" "}
+            <code>/admin/log</code>.
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/web/src/db/migrations/0021_moderation_prompts.sql
+++ b/web/src/db/migrations/0021_moderation_prompts.sql
@@ -1,0 +1,42 @@
+-- 0021_moderation_prompts — DB-backed system prompt for the AI
+-- policy moderator, editable via /admin/policy-prompt.
+--
+-- Why a table at all when the prompt was a TypeScript constant
+-- through Slice 1a/1b/2/3: calibrating false-positive rates is
+-- iterative, and bouncing each tweak through a redeploy cycle
+-- breaks flow. The editor lets staff (Ada is the persona; the
+-- human staff member acting via /admin) save a new version and
+-- activate it without a deploy.
+--
+-- Constraints enforced at the DB level:
+--
+--   1. UNIQUE on `version` — each version label is unique.
+--   2. Partial unique index on (active=true) — at most one active
+--      version at a time. Activation flips happen in a single
+--      transaction (UPDATE … SET active=false WHERE active=true;
+--      INSERT new row WITH active=true) so the index never sees
+--      a transient state with two actives.
+--
+-- Fallback: when the table is empty (e.g. fresh deploy where no
+-- staff has yet saved a version), the moderator's prompt-store
+-- returns the hardcoded constants from web/src/lib/moderation/prompt.ts
+-- and stamps policy_decisions.prompt_version = 'fallback'. So the
+-- moderator works correctly the moment migration 0021 runs, even
+-- before /admin/policy-prompt is ever visited.
+
+CREATE TABLE IF NOT EXISTS "moderation_prompts" (
+  "id"            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "version"       text NOT NULL UNIQUE,
+  "system_prompt" text NOT NULL,
+  "active"        boolean NOT NULL DEFAULT false,
+  "created_by"    uuid NOT NULL REFERENCES "users"("id"),
+  "created_at"    timestamptz NOT NULL DEFAULT now(),
+  "note"          text
+);--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_moderation_prompts_active"
+  ON "moderation_prompts" ("active")
+  WHERE "active" = true;--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_moderation_prompts_created"
+  ON "moderation_prompts" ("created_at" DESC);

--- a/web/src/db/migrations/meta/_journal.json
+++ b/web/src/db/migrations/meta/_journal.json
@@ -22,6 +22,7 @@
     { "idx": 17, "version": "7", "when": 1778067777000, "tag": "0017_content_updated_at",         "breakpoints": true },
     { "idx": 18, "version": "7", "when": 1778169999000, "tag": "0018_policy_moderation",          "breakpoints": true },
     { "idx": 19, "version": "7", "when": 1778199999000, "tag": "0019_policy_moderation_followups","breakpoints": true },
-    { "idx": 20, "version": "7", "when": 1778210000000, "tag": "0020_moderation_retro_queue",     "breakpoints": true }
+    { "idx": 20, "version": "7", "when": 1778210000000, "tag": "0020_moderation_retro_queue",     "breakpoints": true },
+    { "idx": 21, "version": "7", "when": 1778220000000, "tag": "0021_moderation_prompts",         "breakpoints": true }
   ]
 }

--- a/web/src/db/schema/index.ts
+++ b/web/src/db/schema/index.ts
@@ -29,6 +29,7 @@ export * from "./enums";
 export * from "./users";
 export * from "./content";
 export * from "./moderation";
+export * from "./moderation-prompts";
 export * from "./moderation-retro";
 export * from "./notifications";
 export * from "./editorial";

--- a/web/src/db/schema/moderation-prompts.ts
+++ b/web/src/db/schema/moderation-prompts.ts
@@ -1,0 +1,50 @@
+/**
+ * DB-backed system prompt for the AI policy moderator (migration 0021).
+ *
+ * One row per saved version. Exactly one row may have active=true at
+ * any time, enforced by a partial unique index. Activation flips
+ * happen in a single transaction so the index never observes two
+ * active rows.
+ *
+ * The hardcoded fallback in web/src/lib/moderation/prompt.ts is the
+ * boot-time default; once a row exists here with active=true,
+ * lib/moderation/prompt-store.ts returns it instead. Empty table
+ * keeps the fallback in effect — fresh deploys work without staff
+ * intervention.
+ */
+
+import {
+  boolean,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+
+import { users } from "./users";
+
+export const moderationPrompts = pgTable(
+  "moderation_prompts",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    version: text("version").notNull().unique(),
+    systemPrompt: text("system_prompt").notNull(),
+    active: boolean("active").notNull().default(false),
+    createdBy: uuid("created_by")
+      .notNull()
+      .references(() => users.id),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    note: text("note"),
+  },
+  (t) => [
+    uniqueIndex("idx_moderation_prompts_active")
+      .on(t.active)
+      .where(sql`${t.active} = true`),
+    index("idx_moderation_prompts_created").on(t.createdAt.desc()),
+  ],
+);

--- a/web/src/lib/actions/policy-prompt.ts
+++ b/web/src/lib/actions/policy-prompt.ts
@@ -1,0 +1,407 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq, sql } from "drizzle-orm";
+
+import { db } from "@/db/client";
+import { moderationLog, moderationPrompts } from "@/db/schema";
+import { requireStaffId } from "@/lib/staff";
+import { clearPromptCache } from "@/lib/moderation/prompt-store";
+import { POLICY_RESPONSE_JSON_SCHEMA, buildUserPrompt } from "@/lib/moderation/prompt";
+import { PolicyResponseSchema, reconcileCategory } from "@/lib/moderation/schema";
+import { POLICY_MODEL, type ModerationKind } from "@/lib/moderation/types";
+
+/**
+ * Server actions for /admin/policy-prompt.
+ *
+ *   publishPolicyPromptAction(input):
+ *     Inserts a new row into moderation_prompts and atomically
+ *     flips it active. Old active row keeps its history (active
+ *     becomes false). Logs to moderation_log so /admin/log shows
+ *     who changed the prompt and when. Clears the prompt-store
+ *     cache so the next moderate() call picks up the new prompt
+ *     immediately.
+ *
+ *   previewPolicyPromptAction(input):
+ *     Takes a DRAFT system prompt (not yet saved) and runs it
+ *     against a small fixture set, returning the verdict for each.
+ *     Lets staff confirm a new prompt scores known cases the way
+ *     they expect before activation. Costs ~$0.0005 per preview
+ *     run (5 calls × ~$0.0001 each).
+ *
+ * Both actions are staff-only via requireStaffId().
+ */
+
+const MIN_PROMPT_CHARS = 200;
+const MAX_PROMPT_CHARS = 16_000;
+const MAX_VERSION_LEN = 40;
+const MAX_NOTE_LEN = 500;
+
+export interface PublishPolicyPromptInput {
+  version: string;
+  systemPrompt: string;
+  note?: string;
+}
+
+export type PublishPolicyPromptResult =
+  | { ok: true; id: string; version: string }
+  | {
+      ok: false;
+      reason:
+        | "forbidden"
+        | "validation"
+        | "duplicate_version"
+        | "internal";
+      detail?: string;
+    };
+
+export async function publishPolicyPromptAction(
+  input: PublishPolicyPromptInput,
+): Promise<PublishPolicyPromptResult> {
+  const staffId = await requireStaffId();
+  if (!staffId) return { ok: false, reason: "forbidden" };
+
+  const version = (input.version ?? "").trim();
+  const systemPrompt = (input.systemPrompt ?? "").trim();
+  const note = input.note?.trim() || undefined;
+
+  if (
+    version.length === 0 ||
+    version.length > MAX_VERSION_LEN ||
+    !/^[\w.\-]+$/.test(version)
+  ) {
+    return {
+      ok: false,
+      reason: "validation",
+      detail:
+        "version must be 1–40 chars of [A-Za-z0-9_.-] (no spaces, no special chars).",
+    };
+  }
+  if (systemPrompt.length < MIN_PROMPT_CHARS) {
+    return {
+      ok: false,
+      reason: "validation",
+      detail: `system prompt must be at least ${MIN_PROMPT_CHARS} chars (suspicious otherwise).`,
+    };
+  }
+  if (systemPrompt.length > MAX_PROMPT_CHARS) {
+    return {
+      ok: false,
+      reason: "validation",
+      detail: `system prompt is too long (>${MAX_PROMPT_CHARS} chars).`,
+    };
+  }
+  if (note && note.length > MAX_NOTE_LEN) {
+    return {
+      ok: false,
+      reason: "validation",
+      detail: `note is too long (>${MAX_NOTE_LEN} chars).`,
+    };
+  }
+
+  let newId: string | null = null;
+  try {
+    await db.transaction(async (tx) => {
+      // Single transaction: deactivate prior active row, insert new
+      // active row, plus the audit log entry. The partial unique
+      // index on (active=true) is checked at COMMIT — both writes
+      // must land before the constraint is evaluated.
+      await tx
+        .update(moderationPrompts)
+        .set({ active: false })
+        .where(eq(moderationPrompts.active, true));
+
+      const [row] = await tx
+        .insert(moderationPrompts)
+        .values({
+          version,
+          systemPrompt,
+          active: true,
+          createdBy: staffId,
+          note: note ?? null,
+        })
+        .returning({ id: moderationPrompts.id });
+      newId = row?.id ?? null;
+
+      await tx.insert(moderationLog).values({
+        staffId,
+        action: "approve",
+        targetType: null,
+        targetId: null,
+        note: `policy_prompt_v=${version}`.slice(0, 500),
+      });
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // Postgres unique-violation on `version` → user-facing duplicate.
+    if (
+      typeof msg === "string" &&
+      (msg.includes("moderation_prompts_version_unique") ||
+        msg.includes("23505"))
+    ) {
+      return { ok: false, reason: "duplicate_version" };
+    }
+    console.warn(`[policy-prompt] publish failed: ${msg}`);
+    return { ok: false, reason: "internal", detail: msg.slice(0, 200) };
+  }
+
+  if (!newId) {
+    return { ok: false, reason: "internal", detail: "insert returned no id" };
+  }
+
+  // Clear the in-process prompt cache so the next moderate() call
+  // sees the new prompt without waiting for the TTL.
+  clearPromptCache();
+
+  // Revalidate paths whose rendering depends on the active prompt.
+  revalidatePath("/admin/policy-prompt");
+  revalidatePath("/admin/log");
+
+  return { ok: true, id: newId, version };
+}
+
+/* ── Preview action ─────────────────────────────────────────── */
+
+export interface PreviewPolicyPromptInput {
+  systemPrompt: string;
+}
+
+export interface PreviewFixtureResult {
+  label: string;
+  kind: ModerationKind;
+  expected: string;
+  actual: {
+    verdict: "pass" | "reject";
+    category: string | null;
+    confidence: "high" | "low";
+    oneLineWhy: string;
+  } | null;
+  matched: boolean;
+  elapsedMs: number;
+  error?: string;
+}
+
+export type PreviewPolicyPromptResult =
+  | { ok: true; results: PreviewFixtureResult[] }
+  | { ok: false; reason: "forbidden" | "validation" | "no_api_key"; detail?: string };
+
+const PREVIEW_FIXTURES: Array<{
+  label: string;
+  kind: ModerationKind;
+  title: string;
+  body: string;
+  expected: string;
+}> = [
+  {
+    label: "good submission",
+    kind: "submission",
+    title: "Tutorial: building an eval harness for legal-doc summarization",
+    body: "Step 1: gather 50 documents with hand-written summaries. Step 2: define your judge prompt. Step 3: run pairwise comparison. We hit 87% agreement with the expert reviewer over 4 weeks.",
+    expected: "pass",
+  },
+  {
+    label: "spam submission",
+    kind: "submission",
+    title: "AMAZING DEAL — buy followers cheap",
+    body: "Get 10K followers for $5! Visit www.spammy.example/promo. No questions asked.",
+    expected: "reject:spam",
+  },
+  {
+    label: "doxxing comment",
+    kind: "comment",
+    title: "",
+    body: "I know who you are. Your real name is Jane Doe, you live at 1234 Maple St, Apt 4B, Springfield, your phone is 555-0142.",
+    expected: "reject:doxxing",
+  },
+  {
+    label: "security research (FP risk)",
+    kind: "submission",
+    title: "Reverse-engineering the EvilCorp ransomware payload",
+    body: "We disassembled the EvilCorp.bin sample. The payload uses RSA-2048 with a hardcoded public key and AES-256-CBC. Mitigation: snapshot Volume Shadow Copies before the kill switch fires.",
+    expected: "pass",
+  },
+];
+
+export async function previewPolicyPromptAction(
+  input: PreviewPolicyPromptInput,
+): Promise<PreviewPolicyPromptResult> {
+  const staffId = await requireStaffId();
+  if (!staffId) return { ok: false, reason: "forbidden" };
+
+  const systemPrompt = (input.systemPrompt ?? "").trim();
+  if (
+    systemPrompt.length < MIN_PROMPT_CHARS ||
+    systemPrompt.length > MAX_PROMPT_CHARS
+  ) {
+    return {
+      ok: false,
+      reason: "validation",
+      detail: `system prompt must be ${MIN_PROMPT_CHARS}–${MAX_PROMPT_CHARS} chars.`,
+    };
+  }
+
+  if (!process.env.OPENAI_API_KEY) {
+    return { ok: false, reason: "no_api_key" };
+  }
+
+  // Lazy-import the SDK; the action is staff-only and called from
+  // server-side rendering, so the cost of the import on every
+  // preview request is fine — and keeping it out of the module
+  // top-level avoids the SDK paying init cost on every page load.
+  const OpenAI = (await import("openai")).default;
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+  const results: PreviewFixtureResult[] = [];
+  for (const fx of PREVIEW_FIXTURES) {
+    const t0 = Date.now();
+    try {
+      const completion = await client.chat.completions.create({
+        model: POLICY_MODEL,
+        messages: [
+          { role: "system", content: systemPrompt },
+          {
+            role: "user",
+            content: buildUserPrompt({ kind: fx.kind, title: fx.title, body: fx.body }),
+          },
+        ],
+        response_format: {
+          type: "json_schema",
+          json_schema: POLICY_RESPONSE_JSON_SCHEMA,
+        },
+        temperature: 0,
+      });
+
+      const choice = completion.choices[0];
+      if (choice?.message?.refusal) {
+        throw new Error(
+          `model refused: ${String(choice.message.refusal).slice(0, 120)}`,
+        );
+      }
+      const raw = choice?.message?.content ?? "";
+      if (!raw) throw new Error("empty model response");
+      const parsed = reconcileCategory(PolicyResponseSchema.parse(JSON.parse(raw)));
+      const actualLabel =
+        parsed.verdict === "reject"
+          ? `reject:${parsed.category ?? "unknown"}`
+          : "pass";
+
+      results.push({
+        label: fx.label,
+        kind: fx.kind,
+        expected: fx.expected,
+        actual: {
+          verdict: parsed.verdict,
+          category: parsed.category,
+          confidence: parsed.confidence,
+          oneLineWhy: parsed.one_line_why,
+        },
+        matched: actualLabel === fx.expected,
+        elapsedMs: Date.now() - t0,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      results.push({
+        label: fx.label,
+        kind: fx.kind,
+        expected: fx.expected,
+        actual: null,
+        matched: false,
+        elapsedMs: Date.now() - t0,
+        error: msg.slice(0, 200),
+      });
+    }
+  }
+
+  return { ok: true, results };
+}
+
+/* ── Form-data shim for the editor's <form action={...}> ───── */
+
+export type PolicyPromptActionState = {
+  ok: boolean;
+  message: string;
+  newVersion?: string;
+};
+
+export async function publishPolicyPromptFormAction(
+  _prev: PolicyPromptActionState,
+  formData: FormData,
+): Promise<PolicyPromptActionState> {
+  const result = await publishPolicyPromptAction({
+    version: String(formData.get("version") ?? ""),
+    systemPrompt: String(formData.get("systemPrompt") ?? ""),
+    note: formData.get("note") ? String(formData.get("note")) : undefined,
+  });
+  if (result.ok) {
+    return {
+      ok: true,
+      message: `Activated version ${result.version}.`,
+      newVersion: result.version,
+    };
+  }
+  switch (result.reason) {
+    case "forbidden":
+      return { ok: false, message: "Not authorized." };
+    case "duplicate_version":
+      return { ok: false, message: "That version label already exists." };
+    case "validation":
+      return { ok: false, message: result.detail ?? "Invalid input." };
+    case "internal":
+      return {
+        ok: false,
+        message: `Internal error: ${result.detail ?? "unknown"}`,
+      };
+  }
+}
+
+/* ── Re-export for the page server-component to read ──────── */
+
+export async function loadPolicyPromptHistory(): Promise<
+  Array<{
+    id: string;
+    version: string;
+    active: boolean;
+    note: string | null;
+    systemPrompt: string;
+    createdAt: Date;
+    createdByUsername: string | null;
+  }>
+> {
+  const rows = await db.execute<{
+    id: string;
+    version: string;
+    active: boolean;
+    note: string | null;
+    system_prompt: string;
+    created_at: Date;
+    created_by_username: string | null;
+  }>(sql`
+    SELECT mp.id, mp.version, mp.active, mp.note,
+           mp.system_prompt, mp.created_at,
+           u.username AS created_by_username
+      FROM moderation_prompts mp
+      LEFT JOIN users u ON u.id = mp.created_by
+     ORDER BY mp.created_at DESC
+     LIMIT 50
+  `);
+  type RawRow = {
+    id: string;
+    version: string;
+    active: boolean;
+    note: string | null;
+    system_prompt: string;
+    created_at: Date;
+    created_by_username: string | null;
+  };
+  const list =
+    (rows as unknown as { rows?: RawRow[] }).rows ?? (rows as unknown as RawRow[]);
+  return list.map((r) => ({
+    id: r.id,
+    version: r.version,
+    active: r.active,
+    note: r.note,
+    systemPrompt: r.system_prompt,
+    createdAt: r.created_at,
+    createdByUsername: r.created_by_username,
+  }));
+}

--- a/web/src/lib/moderation/index.ts
+++ b/web/src/lib/moderation/index.ts
@@ -26,6 +26,7 @@ import { db } from "@/db/client";
 import { policyDecisions } from "@/db/schema";
 import { callPolicyModel } from "./openai";
 import { isExemptFromModeration } from "./exempt";
+import { getActiveSystemPrompt } from "./prompt-store";
 import {
   POLICY_MODEL,
   POLICY_PROMPT_V,
@@ -203,7 +204,14 @@ export async function moderate(
   }
 
   try {
-    const { response, costUsd } = await callPolicyModel(content);
+    // Resolve the active system prompt (DB-backed via migration 0021;
+    // falls back to the FALLBACK_SYSTEM_PROMPT constant when no row
+    // is active). The version stamps every policy_decisions row so
+    // /admin/log drill-down can correlate verdict drift with prompt
+    // changes — and so a /office/policy/ aggregate can chart accept
+    // rates per prompt version.
+    const { systemPrompt, version } = await getActiveSystemPrompt();
+    const { response, costUsd } = await callPolicyModel(content, systemPrompt);
     return {
       verdict: response.verdict,
       category: response.category,
@@ -212,7 +220,7 @@ export async function moderate(
       synthetic: false,
       syntheticReason: null,
       modelId: POLICY_MODEL,
-      promptVersion: POLICY_PROMPT_V,
+      promptVersion: version,
       costUsd,
     };
   } catch (err) {

--- a/web/src/lib/moderation/openai.ts
+++ b/web/src/lib/moderation/openai.ts
@@ -22,7 +22,6 @@
 import OpenAI from "openai";
 import {
   POLICY_RESPONSE_JSON_SCHEMA,
-  buildSystemPrompt,
   buildUserPrompt,
 } from "./prompt";
 import { PolicyResponseSchema, reconcileCategory, type PolicyResponse } from "./schema";
@@ -51,6 +50,7 @@ export interface ModelCallResult {
 
 export async function callPolicyModel(
   content: ModerationContent,
+  systemPrompt: string,
 ): Promise<ModelCallResult> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
@@ -60,7 +60,7 @@ export async function callPolicyModel(
       {
         model: POLICY_MODEL,
         messages: [
-          { role: "system", content: buildSystemPrompt() },
+          { role: "system", content: systemPrompt },
           { role: "user", content: buildUserPrompt(content) },
         ],
         response_format: {

--- a/web/src/lib/moderation/prompt-store.ts
+++ b/web/src/lib/moderation/prompt-store.ts
@@ -1,0 +1,79 @@
+/**
+ * DB-backed system-prompt loader for the policy moderator.
+ *
+ * Returns the active row from `moderation_prompts` (migration 0021)
+ * if one exists, or the FALLBACK_SYSTEM_PROMPT constant from
+ * prompt.ts otherwise.
+ *
+ *   - The cache is per-process and TTL-bounded so a recently-saved
+ *     prompt becomes effective within CACHE_TTL_MS without a
+ *     redeploy. Server-action publishNewPrompt clears the cache
+ *     immediately after activation; the TTL is the second-line
+ *     defense against stale process state across cold starts.
+ *
+ *   - Active-prompt resolution failures fall back to the constant
+ *     rather than crashing the moderator. The persistence layer
+ *     stamps `prompt_version='fallback'` so calibration analysis
+ *     can detect the degraded mode.
+ *
+ *   - One DB query per CACHE_TTL_MS window (per warm process). At
+ *     the platform's volume this is negligible.
+ */
+
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db/client";
+import { moderationPrompts } from "@/db/schema";
+import { FALLBACK_SYSTEM_PROMPT } from "./prompt";
+
+const CACHE_TTL_MS = 60_000;
+const FALLBACK_VERSION = "fallback";
+
+export interface ActivePrompt {
+  systemPrompt: string;
+  version: string;
+}
+
+let cached: ActivePrompt | null = null;
+let cachedAt = 0;
+
+export async function getActiveSystemPrompt(): Promise<ActivePrompt> {
+  const now = Date.now();
+  if (cached && now - cachedAt < CACHE_TTL_MS) return cached;
+
+  try {
+    const [row] = await db
+      .select({
+        version: moderationPrompts.version,
+        systemPrompt: moderationPrompts.systemPrompt,
+      })
+      .from(moderationPrompts)
+      .where(eq(moderationPrompts.active, true))
+      .limit(1);
+
+    cached = row
+      ? { systemPrompt: row.systemPrompt, version: row.version }
+      : { systemPrompt: FALLBACK_SYSTEM_PROMPT, version: FALLBACK_VERSION };
+  } catch (err) {
+    // DB error → degrade to fallback rather than blocking moderation.
+    // The moderator's failure-mode matrix already handles synthetic-
+    // pass-on-error if the moderate() call subsequently fails; this
+    // path keeps the prompt fetch from poisoning otherwise-healthy
+    // calls.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[moderation/prompt-store] active-prompt lookup failed; using fallback: ${msg}`,
+    );
+    cached = {
+      systemPrompt: FALLBACK_SYSTEM_PROMPT,
+      version: FALLBACK_VERSION,
+    };
+  }
+  cachedAt = now;
+  return cached;
+}
+
+export function clearPromptCache(): void {
+  cached = null;
+  cachedAt = 0;
+}

--- a/web/src/lib/moderation/prompt.ts
+++ b/web/src/lib/moderation/prompt.ts
@@ -7,14 +7,19 @@
  * tunable in the way the editorial taste rubric is — keeping them
  * public buys reviewability and CI-testability.
  *
- * If you change anything in this file beyond a typo fix, bump
- * POLICY_PROMPT_V in types.ts so the policy_decisions audit trail
- * can correlate verdict drift with prompt changes.
+ * Migration 0021 added a DB-backed editor at /admin/policy-prompt.
+ * The constant below is the FALLBACK that ships with the deploy;
+ * once staff saves a row in moderation_prompts via the editor,
+ * lib/moderation/prompt-store.ts returns the active row instead.
+ *
+ * If you change FALLBACK_SYSTEM_PROMPT, bump the version label in
+ * the editor's first save (or in the seed) so policy_decisions.
+ * prompt_version stays meaningful as an audit trail.
  */
 
 import type { ModerationContent, ModerationKind } from "./types";
 
-const SYSTEM_PROMPT = `You are claudepot.com's policy moderator. Decide whether a piece of user-submitted content violates the platform's narrow policy taxonomy.
+export const FALLBACK_SYSTEM_PROMPT = `You are claudepot.com's policy moderator. Decide whether a piece of user-submitted content violates the platform's narrow policy taxonomy.
 
 Five categories. Reject only if the content clearly fits one. When in doubt, pass.
 
@@ -60,8 +65,13 @@ export function buildUserPrompt(content: ModerationContent): string {
 ${titleBlock}${bodyBlock}`;
 }
 
+/**
+ * Returns the fallback system prompt. lib/moderation/prompt-store.ts
+ * is the runtime path — it reads the active DB row (migration 0021)
+ * and falls back to this constant when the table is empty.
+ */
 export function buildSystemPrompt(): string {
-  return SYSTEM_PROMPT;
+  return FALLBACK_SYSTEM_PROMPT;
 }
 
 /**

--- a/web/src/lib/moderation/system-user.ts
+++ b/web/src/lib/moderation/system-user.ts
@@ -1,21 +1,25 @@
 /**
- * Resolves the policy-moderator system user id once per process.
+ * Resolves the policy-moderator persona's user id once per process.
  *
- * The username 'policy-moderator' is the stable lookup key — its
- * row is upserted in migration 0018, mirroring the
- * 0009_persona_bots pattern. We avoid hardcoding a UUID so dev /
- * preview / prod don't need to coordinate identifier values.
+ * Ada is the moderator. Migration 0009_persona_bots already created
+ * 'ada' as a system bot user (role='system', is_agent=true). We
+ * reuse that row instead of a separate 'policy-moderator' account
+ * so the audit trail attributes AI-driven moderation_log rows to
+ * a real persona that readers can find via /office/persona/ada/.
  *
- * The id is the actor on AI-driven moderation_log rows (action=
- * 'reject' with this id as staff_id). Staff actions still go
- * through the existing moderationAction code path.
+ * Migration 0018 still creates a 'policy-moderator' fallback user
+ * for any environment that hasn't run 0009. It's kept around as a
+ * defensive seed; this lookup prefers 'ada' and only falls back
+ * to 'policy-moderator' if 'ada' isn't found (e.g. a fresh DB that
+ * skipped the persona migration).
  */
 
-import { eq } from "drizzle-orm";
+import { inArray } from "drizzle-orm";
 import { db } from "@/db/client";
 import { users } from "@/db/schema";
 
-const POLICY_MODERATOR_USERNAME = "policy-moderator";
+const PRIMARY_USERNAME = "ada";
+const FALLBACK_USERNAME = "policy-moderator";
 
 let cached: string | null = null;
 let pending: Promise<string> | null = null;
@@ -24,14 +28,22 @@ export async function getSystemUserId(): Promise<string> {
   if (cached) return cached;
   if (pending) return pending;
   pending = (async () => {
-    const [u] = await db
-      .select({ id: users.id })
+    // Prefer 'ada' (created by migration 0009_persona_bots). Fall
+    // back to 'policy-moderator' (created by migration 0018) so a
+    // freshly-bootstrapped DB that skipped the persona migration
+    // still has a system actor for moderation_log rows.
+    const candidates = await db
+      .select({ id: users.id, username: users.username })
       .from(users)
-      .where(eq(users.username, POLICY_MODERATOR_USERNAME))
-      .limit(1);
+      .where(inArray(users.username, [PRIMARY_USERNAME, FALLBACK_USERNAME]));
+    const ada = candidates.find((u) => u.username === PRIMARY_USERNAME);
+    const fallback = candidates.find(
+      (u) => u.username === FALLBACK_USERNAME,
+    );
+    const u = ada ?? fallback;
     if (!u) {
       throw new Error(
-        `policy-moderator system user missing — run migration 0018_policy_moderation.sql`,
+        `Moderator persona user missing — run migration 0009_persona_bots.sql + 0018_policy_moderation.sql`,
       );
     }
     cached = u.id;

--- a/web/src/lib/office-personas.ts
+++ b/web/src/lib/office-personas.ts
@@ -13,6 +13,13 @@ export interface OfficePersona {
   display: string;
   description: string;
   multipliers: Record<string, number>;
+  /**
+   * Optional non-editorial roles the persona holds. Each entry
+   * renders as a separate chip on /office/persona/<id>. Editorial
+   * scoring is implicit for every persona — only the additional
+   * jobs are listed here.
+   */
+  roles?: ReadonlyArray<{ name: string; href: string }>;
 }
 
 export const OFFICE_PERSONAS: Record<string, OfficePersona> = {
@@ -20,12 +27,21 @@ export const OFFICE_PERSONAS: Record<string, OfficePersona> = {
     id: "ada",
     display: "ada",
     description:
-      "Evidence-first skeptic. Asks 'where's the eval?'. Strongest on engineer / infra-shipper content.",
+      "Evidence-first skeptic. Asks 'where's the eval?'. Strongest on " +
+      "engineer / infra-shipper content. Also serves as the platform's " +
+      "AI policy moderator — the synchronous gate every submission and " +
+      "comment passes through before publish.",
     multipliers: {
       evidence_quality: 1.5,
       mechanism_specificity: 1.2,
       counter_current: 0.8,
     },
+    roles: [
+      {
+        name: "policy moderator",
+        href: "/office/policy",
+      },
+    ],
   },
   historian: {
     id: "historian",


### PR DESCRIPTION
## Summary

- Editable system prompt for the AI policy moderator at `/admin/policy-prompt`. DB-backed (migration 0021), versioned, with an in-app preview that runs a draft prompt against four fixture cases before activation.
- Reassign moderator persona from a separate `policy-moderator` user to `Ada` (the existing editorial persona). AI moderation_log rows now attribute to her; `/office/persona/ada` becomes the public face of moderation.
- New public surface at `/office/policy` — the aggregate window into Ada's other job. No per-decision details (those leak PII the model just classified); just category counts, reject-rate, the active prompt version, and an explicit "what this page does NOT show" section.

## Pre-merge prerequisite

**Apply migration 0021** to prod Neon before merge:
```bash
NEON_DATABASE_URL=<prod-url> pnpm drizzle-kit migrate
```

(0021 only — 0018, 0019, 0020 already applied as part of the prior moderator slice deploy.)

The fallback path means the moderator keeps working through the migration: when `moderation_prompts` is empty, `prompt-store.ts` returns the `FALLBACK_SYSTEM_PROMPT` constant baked into the deploy. So the migration can land before this PR merges, and there's no broken-window state.

## Test plan

- [x] tsc clean
- [x] Existing 27 unit tests still pass
- [ ] Apply migration 0021 (preview branch first)
- [ ] Visit `/admin/policy-prompt` — confirm editor renders the active prompt or fallback if empty
- [ ] Click Preview — confirm 4 fixture verdicts return (~5–10s, ~$0.0005)
- [ ] Save a new version — confirm it activates atomically and the next moderate() call uses it (visible via `policy_decisions.prompt_version` column on the next reject)
- [ ] Visit `/office/persona/ada` — confirm the new "policy moderator" chip
- [ ] Visit `/office/policy` — confirm aggregate counts render and the active prompt version shows

## Files

- `web/src/db/migrations/0021_moderation_prompts.sql` — table + partial unique index on `active=true`
- `web/src/db/schema/moderation-prompts.ts` — Drizzle schema mirror
- `web/src/lib/moderation/prompt-store.ts` — 60s-TTL'd active-prompt loader with fallback
- `web/src/lib/moderation/prompt.ts` — `FALLBACK_SYSTEM_PROMPT` is the boot-time default
- `web/src/lib/moderation/{index,openai}.ts` — `callPolicyModel(content, systemPrompt)`; verdict's `promptVersion` comes from the store
- `web/src/lib/moderation/system-user.ts` — looks up `ada` first, `policy-moderator` fallback
- `web/src/lib/actions/policy-prompt.ts` — `publishPolicyPromptAction`, `previewPolicyPromptAction`, plus form-data shim
- `web/src/app/(reader)/admin/policy-prompt/{page,PolicyPromptEditor}.tsx` — staff editor
- `web/src/app/(reader)/office/policy/page.tsx` — public aggregate
- `web/src/app/(reader)/office/persona/[name]/page.tsx` — renders `roles[]` chips
- `web/src/lib/office-personas.ts` — `roles?: { name; href }[]` field; ada gets `[{name: "policy moderator", href: "/office/policy"}]`
- `web/editorial/rubric.yml` — ada description extended