### PR TITLE
fix(web): /c/[slug] 500 → 404 on unknown tag

### DIFF
--- a/web/src/app/(reader)/c/[slug]/page.tsx
+++ b/web/src/app/(reader)/c/[slug]/page.tsx
@@ -4,6 +4,22 @@ import { SubmissionRow } from "@/components/prototype/SubmissionRow";
 import { auth } from "@/lib/auth";
 import { getAllTags, getTagBySlug, getSubmissionsByTag } from "@/db/queries";
 
+/**
+ * Force dynamic rendering. The page reads `auth()` (cookies), so it's
+ * implicitly dynamic at request time — but on 2026-05-06 a route audit
+ * found that unknown slugs returned 500 (Pages Router `/_error` shell)
+ * instead of 404 (App Router not-found.tsx). The 500 was triggered by
+ * the combination of `generateStaticParams` returning [] (empty tags
+ * table) plus Next.js's default static-optimization heuristic, which
+ * marked the route as fully-prerendered with no params.
+ *
+ * `force-dynamic` preserves `generateStaticParams` as a build-time hint
+ * once tags exist (the prerender will still seed known slugs), but
+ * guarantees unknown slugs go through dynamic render → notFound() →
+ * 404 every time.
+ */
+export const dynamic = "force-dynamic";
+
 export async function generateStaticParams() {
   return (await getAllTags()).map((t) => ({ slug: t.slug }));
 }


### PR DESCRIPTION
Route audit found one dead-end: `/c/<anything>` returned **500** (Pages Router `/_error` shell) instead of **404** when the slug wasn't in the tags table.

Other dynamic routes (`/post/[id]`, `/u/[username]`, `/projects/[slug]`, `/office/persona/[name]`, `/office/decision/[id]`) all 404 correctly. The difference: `/c/[slug]` is the only one with `generateStaticParams`. With tags empty (fresh deploy, no submissions yet → no auto-tags), it returns `[]` and Next.js 15's static optimizer marked the route as prerendered-with-zero-params. Unknown slugs missed both the static index and the App Router's dynamic→notFound() path.

`export const dynamic = "force-dynamic"` keeps `generateStaticParams` as a build-time hint for when tags exist, but guarantees unknown slugs render dynamically → `notFound()` → 404 every time.

## Coverage from the same audit
- 18 static reader routes: all 200
- 7 dynamic route types tested: all 200 on valid IDs, 404 on unknown
- 6 API endpoints: 200 (public), 401 (auth-required), 404 (unknown ID)
- /admin → 307 → /admin/queue (intentional)
- /mod → 307 → /admin/queue (intentional)
- /appeal/<id> → 307 → /login when unauthenticated (intentional)

No other dead ends found.

## Test plan
- After merge, hit `https://claudepot.com/c/anything` and confirm 404 with App Router not-found.tsx ("That page slipped through the gravity well") rather than the Pages Router 500 shell.
