### PR TITLE
feat(web/moderation): Ada-as-tagger + retire off_topic — POLICY_PROMPT_V=2

### DIFF
--- a/web/editorial/rubric.yml
+++ b/web/editorial/rubric.yml
@@ -273,7 +273,7 @@ extensions:
 # rate than ClauDepot, and routing.feed_threshold acts as a per-persona bar.
 persona_overlays:
   ada:
-    description: "Evidence-first skeptic. Asks 'where's the eval?'. Strongest on engineer / infra-shipper content. Also serves as the platform's AI policy moderator (the synchronous policy gate every submission and comment passes through before publish — see /office/policy)."
+    description: "Evidence-first skeptic. Asks 'where's the eval?'. Strongest on engineer / infra-shipper content. Also serves as the platform's AI policy moderator (the synchronous policy gate every submission and comment passes through before publish — see /office/policy) and tags accepted submissions, picking up to two topical tags from the active vocabulary or proposing new tags for staff review at /admin/flags."
     multipliers:
       evidence_quality:      1.5
       mechanism_specificity: 1.2

--- a/web/src/app/(reader)/admin/flags/page.tsx
+++ b/web/src/app/(reader)/admin/flags/page.tsx
@@ -1,10 +1,13 @@
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { db } from "@/db/client";
-import { submissionTags, tags } from "@/db/schema";
+import { submissions, submissionTags, tags } from "@/db/schema";
 import { CreateTagForm } from "@/components/prototype/admin/CreateTagForm";
+import { PendingTagRow } from "@/components/prototype/admin/PendingTagRow";
 import { TagRow } from "@/components/prototype/admin/TagRow";
 import { staffGate } from "@/lib/staff-gate";
+
+const PENDING_SAMPLE_LIMIT = 3;
 
 export default async function AdminFlags({
   searchParams,
@@ -15,7 +18,9 @@ export default async function AdminFlags({
   const gate = await staffGate(sp);
   if (gate) return gate;
 
-  // Group counts in one round-trip instead of N+1 queries.
+  // Group counts in one round-trip instead of N+1 queries. Filter
+  // out pending_review=true rows — those render in the dedicated
+  // section above with their own approve/reject actions.
   const rows = await db
     .select({
       slug: tags.slug,
@@ -28,7 +33,75 @@ export default async function AdminFlags({
       )`,
     })
     .from(tags)
+    .where(eq(tags.pendingReview, false))
     .orderBy(tags.sortOrder);
+
+  // Migration 0022 — pending Ada-proposed tags awaiting staff review.
+  // We pull post counts inline so staff sees how many submissions
+  // would lose this tag if they reject it. Sample titles below.
+  const pendingRows = await db
+    .select({
+      slug: tags.slug,
+      name: tags.name,
+      tagline: tags.tagline,
+      postCount: sql<number>`(
+        SELECT COUNT(*)::int FROM ${submissionTags}
+        WHERE ${submissionTags.tagSlug} = ${tags.slug}
+      )`,
+    })
+    .from(tags)
+    .where(eq(tags.pendingReview, true))
+    .orderBy(tags.slug);
+
+  // Fetch sample titles for every pending tag in ONE query using
+  // ROW_NUMBER() OVER (PARTITION BY tag_slug ORDER BY created_at DESC).
+  // The CTE picks the top N per tag, then we group in JS. Avoids
+  // the previous N+1 (one query per pending tag) so the page stays
+  // responsive even if a quiet vocabulary suddenly accumulates a
+  // long pending list (e.g. after a model upgrade that changes
+  // tagging behavior).
+  const samplesByTag: Record<string, string[]> = {};
+  const pendingSlugs = pendingRows.map((t) => t.slug);
+  if (pendingSlugs.length > 0) {
+    // sql.join builds the literal `($1, $2, ...)` IN clause with
+    // proper parameter binding — passing an array directly to sql``
+    // would interpolate as text and break.
+    const slugList = sql.join(
+      pendingSlugs.map((s) => sql`${s}`),
+      sql`, `,
+    );
+    const sampleRows = await db.execute<{
+      tag_slug: string;
+      title: string;
+    }>(sql`
+      SELECT tag_slug, title FROM (
+        SELECT
+          ${submissionTags.tagSlug} AS tag_slug,
+          ${submissions.title} AS title,
+          ROW_NUMBER() OVER (
+            PARTITION BY ${submissionTags.tagSlug}
+            ORDER BY ${submissions.createdAt} DESC
+          ) AS rn
+        FROM ${submissionTags}
+        INNER JOIN ${submissions}
+          ON ${submissions.id} = ${submissionTags.submissionId}
+        WHERE ${submissionTags.tagSlug} IN (${slugList})
+      ) ranked
+      WHERE rn <= ${PENDING_SAMPLE_LIMIT}
+      ORDER BY tag_slug, rn
+    `);
+    // db.execute returns either { rows: [...] } (pg adapter) or
+    // an array directly (neon-http) — handle both shapes.
+    const rows: Array<{ tag_slug: string; title: string }> = Array.isArray(
+      sampleRows,
+    )
+      ? sampleRows
+      : (sampleRows as { rows: Array<{ tag_slug: string; title: string }> })
+          .rows;
+    for (const row of rows) {
+      (samplesByTag[row.tag_slug] ??= []).push(row.title);
+    }
+  }
 
   return (
     <section>
@@ -44,6 +117,43 @@ export default async function AdminFlags({
         <code>moderation_log</code>.
       </p>
 
+      {pendingRows.length > 0 ? (
+        <>
+          <h3 className="proto-h3">Pending review ({pendingRows.length})</h3>
+          <p className="proto-dek">
+            Ada proposed these tags during moderation. Approve to add
+            them to the public vocabulary, or reject to delete the tag
+            and unlink it from any submissions that picked it up. The
+            moderator's tag-vocab cache is cleared on approve so Ada
+            picks up the change on the next submission.
+          </p>
+          <table className="proto-mod-table">
+            <thead>
+              <tr>
+                <th>Slug</th>
+                <th>Name</th>
+                <th>Tagline</th>
+                <th>Posts (samples)</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pendingRows.map((t) => (
+                <PendingTagRow
+                  key={t.slug}
+                  slug={t.slug}
+                  name={t.name}
+                  tagline={t.tagline}
+                  postCount={t.postCount}
+                  sampleTitles={samplesByTag[t.slug] ?? []}
+                />
+              ))}
+            </tbody>
+          </table>
+        </>
+      ) : null}
+
+      <h3 className="proto-h3">Active vocabulary</h3>
       <table className="proto-mod-table">
         <thead>
           <tr>

--- a/web/src/app/(reader)/office/policy/page.tsx
+++ b/web/src/app/(reader)/office/policy/page.tsx
@@ -25,14 +25,17 @@ export const dynamic = "force-dynamic";
  */
 
 const CATEGORY_NOTES: Record<string, string> = {
-  spam: "Off-topic promotion, link farms, repetitive postings, paid promotion without disclosure.",
+  spam: "Promotional content with no surrounding discussion, link farms, repetitive postings, paid promotion without disclosure.",
   abuse: "Harassment, slurs, threats, targeted personal attacks against an identified person or group.",
   illegal:
     "CSAM; distributing malware or stolen credentials; flagrant copyright violation. Discussion of these is allowed; distribution is not.",
   doxxing:
     "Exposing a private individual's home address, phone number, government ID, or non-public personal email tied to a real-name target.",
-  off_topic:
-    "Submissions only — clearly unrelated to AI tools / AI-augmented work / LLM technique. Comments are not rejected for off-topic.",
+  // Legacy category — retired in POLICY_PROMPT_V="2". Kept here so
+  // historical policy_decisions rows with category='off_topic'
+  // render with a recognizable label on this page if they surface
+  // in the aggregate. New rejects never use this category.
+  off_topic: "[legacy] Submissions retired from this category in v2.",
 };
 
 export default async function OfficePolicyPage() {
@@ -96,12 +99,14 @@ export default async function OfficePolicyPage() {
       </header>
 
       <section className="proto-section">
-        <h2>The five categories</h2>
+        <h2>Categories</h2>
         <p className="office-section-lede">
-          Reject only when content clearly fits one. When in doubt,
-          pass. The rubric is intentionally small — five categories,
-          not fifty — because every additional category trades
-          precision for argued-edges.
+          Universal trust-and-safety taxonomy. Reject only when
+          content clearly fits one. When in doubt, pass. Topical
+          fit (does this submission match the platform&rsquo;s
+          audience) is NOT a moderator concern — that&rsquo;s
+          handled by editorial scoring and community voting, not
+          by the gate.
         </p>
         <dl className="office-policy-categories">
           {POLICY_CATEGORIES.map((cat) => (

--- a/web/src/components/prototype/admin/PendingTagRow.tsx
+++ b/web/src/components/prototype/admin/PendingTagRow.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useActionState } from "react";
+import {
+  approvePendingTag,
+  rejectPendingTag,
+  type TagActionState,
+} from "@/lib/actions/admin-tag";
+
+const INIT: TagActionState = { ok: true, message: "" };
+
+/**
+ * One row of the /admin/flags pending-review table. Lists an
+ * Ada-proposed tag with sample submissions linking it.
+ *
+ * Approve flips pending_review=false and (optionally) edits the
+ * placeholder name. Reject deletes the tag (cascading
+ * submission_tags rows) — staff has decided it shouldn't enter the
+ * vocabulary.
+ *
+ * Two independent action states so each form's flash message is
+ * scoped to its own submit button.
+ */
+export function PendingTagRow({
+  slug,
+  name,
+  tagline,
+  postCount,
+  sampleTitles,
+}: {
+  slug: string;
+  name: string;
+  tagline: string | null;
+  postCount: number;
+  sampleTitles: string[];
+}) {
+  const [approveState, approveAction, approvePending] = useActionState(
+    approvePendingTag,
+    INIT,
+  );
+  const [rejectState, rejectAction, rejectPending] = useActionState(
+    rejectPendingTag,
+    INIT,
+  );
+
+  const approveFormId = `approve-${slug}`;
+
+  return (
+    <tr>
+      <td>
+        <code>{slug}</code>
+      </td>
+      <td>
+        <form
+          id={approveFormId}
+          action={approveAction}
+          className="proto-tag-edit"
+        >
+          <input type="hidden" name="slug" value={slug} />
+          <input
+            type="text"
+            name="name"
+            defaultValue={name}
+            className="proto-input proto-input-inline"
+            aria-label={`Display name for ${slug}`}
+            required
+          />
+        </form>
+        {approveState.message ? (
+          <p
+            className={`proto-form-flash ${approveState.ok ? "proto-form-flash-ok" : "proto-form-flash-err"}`}
+          >
+            {approveState.message}
+          </p>
+        ) : null}
+      </td>
+      <td>
+        <input
+          type="text"
+          name="tagline"
+          form={approveFormId}
+          defaultValue={tagline ?? ""}
+          className="proto-input proto-input-inline proto-input-wide"
+          aria-label={`Tagline for ${slug}`}
+          placeholder="Optional one-line description"
+        />
+      </td>
+      <td>
+        {postCount}
+        {sampleTitles.length > 0 ? (
+          <ul className="proto-pending-samples">
+            {sampleTitles.map((title) => (
+              <li key={title} title={title}>
+                {title}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </td>
+      <td className="proto-mod-actions">
+        <button
+          type="submit"
+          form={approveFormId}
+          className="proto-mod-btn proto-mod-btn-keep"
+          disabled={approvePending}
+        >
+          {approvePending ? "Approving…" : "Approve"}
+        </button>
+        <form action={rejectAction}>
+          <input type="hidden" name="slug" value={slug} />
+          <button
+            type="submit"
+            className="proto-mod-btn proto-mod-btn-remove"
+            disabled={rejectPending}
+          >
+            {rejectPending ? "Rejecting…" : "Reject"}
+          </button>
+        </form>
+        {rejectState.message ? (
+          <p
+            className={`proto-form-flash ${rejectState.ok ? "proto-form-flash-ok" : "proto-form-flash-err"}`}
+          >
+            {rejectState.message}
+          </p>
+        ) : null}
+      </td>
+    </tr>
+  );
+}

--- a/web/src/db/migrations/0022_ai_tagging.sql
+++ b/web/src/db/migrations/0022_ai_tagging.sql
@@ -1,0 +1,56 @@
+-- 0022_ai_tagging — Ada gains a second job: tag every accepted
+-- submission with two tags during the same moderate() call.
+--
+-- Two columns added, both additive + idempotent:
+--
+-- 1. tags.pending_review — boolean, default false. When Ada
+--    proposes a tag that doesn't exist in the vocabulary yet, the
+--    new row goes in with pending_review=true and stays hidden
+--    from the public /c catalog until staff approves it at
+--    /admin/tags. Staff approval flips the flag to false; the tag
+--    enters the live vocabulary.
+--
+-- 2. submission_tags.source — text, default 'user', constrained
+--    to {'ai','user'}. Distinguishes Ada-applied tags from
+--    user-applied tags (the latter come from the submit form's
+--    tags field). Used for analytics ("did AI tags drive search
+--    engagement?"), audit, and override logic (user-supplied
+--    tags win on duplicates).
+--
+-- The existing 5-tag-per-submission cap (enforced in the input
+-- schema) still holds: user can supply up to 5; Ada adds up to 2;
+-- duplicates dedupe; the union is capped at 5 by the create path.
+
+ALTER TABLE "tags"
+  ADD COLUMN IF NOT EXISTS "pending_review" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+
+ALTER TABLE "submission_tags"
+  ADD COLUMN IF NOT EXISTS "source" text NOT NULL DEFAULT 'user';
+--> statement-breakpoint
+
+-- Postgres lacks `ADD CONSTRAINT IF NOT EXISTS`, so guard the add
+-- via pg_catalog so a re-run (e.g. running this file by hand on a
+-- DB where it already applied) doesn't error. The catalog query
+-- looks for the constraint by exact name on the target table.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'submission_tags_source_check'
+      AND conrelid = 'submission_tags'::regclass
+  ) THEN
+    ALTER TABLE "submission_tags"
+      ADD CONSTRAINT "submission_tags_source_check"
+      CHECK ("source" IN ('ai', 'user'));
+  END IF;
+END$$;
+--> statement-breakpoint
+
+-- Index supports the /admin/tags review page (pending tags first,
+-- then ordered by when Ada proposed them so newest goes to top).
+-- No created_at column on tags today — adding one is a separate
+-- slice; use slug as a tie-breaker for now.
+CREATE INDEX IF NOT EXISTS "idx_tags_pending_review"
+  ON "tags" ("pending_review", "slug")
+  WHERE "pending_review" = true;

--- a/web/src/db/migrations/meta/_journal.json
+++ b/web/src/db/migrations/meta/_journal.json
@@ -23,6 +23,7 @@
     { "idx": 18, "version": "7", "when": 1778169999000, "tag": "0018_policy_moderation",          "breakpoints": true },
     { "idx": 19, "version": "7", "when": 1778199999000, "tag": "0019_policy_moderation_followups","breakpoints": true },
     { "idx": 20, "version": "7", "when": 1778210000000, "tag": "0020_moderation_retro_queue",     "breakpoints": true },
-    { "idx": 21, "version": "7", "when": 1778220000000, "tag": "0021_moderation_prompts",         "breakpoints": true }
+    { "idx": 21, "version": "7", "when": 1778220000000, "tag": "0021_moderation_prompts",         "breakpoints": true },
+    { "idx": 22, "version": "7", "when": 1778316000000, "tag": "0022_ai_tagging",                  "breakpoints": true }
   ]
 }

--- a/web/src/db/queries.ts
+++ b/web/src/db/queries.ts
@@ -182,7 +182,19 @@ const SUBMISSION_BASE_SELECT = {
   authorImageUrl: users.image,
   authorIsAgent: users.isAgent,
   commentsCount: sql<number>`(SELECT COUNT(*)::int FROM ${comments} WHERE ${comments.submissionId} = ${submissions.id} AND ${comments.deletedAt} IS NULL)`,
-  tagSlugs: sql<string[]>`ARRAY(SELECT ${submissionTags.tagSlug} FROM ${submissionTags} WHERE ${submissionTags.submissionId} = ${submissions.id})`,
+  // Migration 0022 — exclude pending_review=true tags from public
+  // submission rows. Without this filter, an Ada-proposed tag still
+  // awaiting staff review would appear as a chip on /c rows linking
+  // to a /c/<slug> page that 404s (getTagBySlug filters pending too).
+  // Joining tags via the slug FK and gating on pending_review keeps
+  // the chip and the landing page in sync.
+  tagSlugs: sql<string[]>`ARRAY(
+    SELECT ${submissionTags.tagSlug}
+    FROM ${submissionTags}
+    INNER JOIN ${tags} ON ${tags.slug} = ${submissionTags.tagSlug}
+    WHERE ${submissionTags.submissionId} = ${submissions.id}
+      AND ${tags.pendingReview} = false
+  )`,
 };
 
 // GREATEST(..., 0) clamps the age so future-dated fixture rows don't
@@ -491,9 +503,14 @@ export async function getUpvotedByUser(username: string): Promise<Submission[]> 
 /* ── Tags ───────────────────────────────────────────────────────── */
 
 export async function getAllTags(): Promise<Tag[]> {
+  // Migration 0022 — pending_review=true tags are Ada-proposed and
+  // awaiting staff approval. Hide them from the public catalog so
+  // the /c index only shows curated tags. Staff sees and approves
+  // them at /admin/tags.
   const rows = await db
     .select()
     .from(tags)
+    .where(eq(tags.pendingReview, false))
     .orderBy(tags.sortOrder);
   return rows.map((t) => ({
     slug: t.slug,
@@ -503,7 +520,15 @@ export async function getAllTags(): Promise<Tag[]> {
 }
 
 export async function getTagBySlug(slug: string): Promise<Tag | undefined> {
-  const [t] = await db.select().from(tags).where(eq(tags.slug, slug)).limit(1);
+  // Per migration 0022, a pending_review tag has no public landing
+  // page — return undefined so /c/<slug> 404s until staff approves
+  // it. Submissions that already link to a pending tag remain in
+  // the DB; they're just not surfaced by tag.
+  const [t] = await db
+    .select()
+    .from(tags)
+    .where(and(eq(tags.slug, slug), eq(tags.pendingReview, false)))
+    .limit(1);
   return t ? { slug: t.slug, name: t.name, tagline: t.tagline ?? "" } : undefined;
 }
 
@@ -527,6 +552,9 @@ export async function getTopTags(): Promise<Array<Tag & { count: number }>> {
         gte(submissions.createdAt, cutoff),
       ),
     )
+    // Migration 0022 — drop pending_review=true rows so the home
+    // page top-tags rail only shows staff-approved tags.
+    .where(eq(tags.pendingReview, false))
     .groupBy(tags.slug, tags.name, tags.tagline, tags.sortOrder)
     .orderBy(desc(sql`COUNT(${submissionTags.submissionId})`));
   return rows.map((r) => ({

--- a/web/src/db/schema/content.ts
+++ b/web/src/db/schema/content.ts
@@ -11,6 +11,7 @@
  */
 
 import {
+  boolean,
   customType,
   index,
   integer,
@@ -106,7 +107,19 @@ export const tags = pgTable("tags", {
   name: text("name").notNull(),
   tagline: text("tagline"),
   sortOrder: integer("sort_order").notNull().default(0),
+  // Migration 0022 — Ada-proposed tags land with pending_review=true
+  // and stay hidden from the public /c catalog until staff approves
+  // them at /admin/tags. Staff approval flips this to false.
+  pendingReview: boolean("pending_review").notNull().default(false),
 });
+
+/**
+ * Provenance values accepted by submission_tags.source. The
+ * matching CHECK constraint lives in migration 0022 — keep these
+ * two in sync if you add a third source (e.g. 'import').
+ */
+export const SUBMISSION_TAG_SOURCES = ["ai", "user"] as const;
+export type SubmissionTagSource = (typeof SUBMISSION_TAG_SOURCES)[number];
 
 export const submissionTags = pgTable(
   "submission_tags",
@@ -117,6 +130,17 @@ export const submissionTags = pgTable(
     tagSlug: text("tag_slug")
       .notNull()
       .references(() => tags.slug, { onDelete: "cascade" }),
+    // Migration 0022 — provenance. 'user' for tags from the submit
+    // form's tags[]; 'ai' for tags Ada applied during moderation.
+    // CHECK constraint in the migration enforces the value space at
+    // the DB layer; .$type() narrows TS so writes that pass an
+    // unknown string fail at compile time before the constraint
+    // ever fires. The set of valid values is exported as
+    // `SUBMISSION_TAG_SOURCES` so call sites can assert on the union.
+    source: text("source")
+      .notNull()
+      .default("user")
+      .$type<SubmissionTagSource>(),
   },
   (t) => [
     primaryKey({ columns: [t.submissionId, t.tagSlug] }),

--- a/web/src/lib/actions/admin-tag.ts
+++ b/web/src/lib/actions/admin-tag.ts
@@ -1,12 +1,14 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import { db } from "@/db/client";
 import { moderationLog, submissionTags, tags } from "@/db/schema";
+import { clearTagVocabCache } from "@/lib/moderation";
 import { requireStaffId } from "@/lib/staff";
+import { tagSlugSchema as slugSchema } from "@/lib/tags/slug";
 
 /** Discriminated state shape returned from every admin-tag action.
  *  Pairs with React 19's useActionState in the client form components.
@@ -17,10 +19,6 @@ export type TagActionState = { ok: boolean; message: string };
 
 const ok = (message: string): TagActionState => ({ ok: true, message });
 const err = (message: string): TagActionState => ({ ok: false, message });
-
-// kebab-case, alphanumeric + hyphens, 2..40 chars
-const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-const slugSchema = z.string().trim().min(2).max(40).regex(SLUG);
 
 const createInput = z.object({
   slug: slugSchema,
@@ -56,6 +54,13 @@ function revalidateTagSurfaces(slugs: string[]) {
  *  rolling back the whole action. */
 async function logTagAction(
   staffId: string,
+  // tag_create  — new tag entered the active vocabulary (manual or
+  //               via approving a pending Ada-proposed tag).
+  // tag_rename  — display name/tagline changed.
+  // tag_merge   — associations moved, source slug deleted.
+  // tag_retire  — tag deleted entirely (manual retire OR rejection
+  //               of a pending Ada-proposed tag — they share the
+  //               same DB effect, the note string discriminates).
   action: "tag_create" | "tag_rename" | "tag_merge" | "tag_retire",
   note: string,
 ) {
@@ -110,6 +115,12 @@ export async function createTag(
   }
 
   await logTagAction(staffId, "tag_create", `slug=${parsed.data.slug}`);
+  // Drop the moderator's cached vocab so Ada sees the new active
+  // slug on the next call. Without this, up to 60 s of submissions
+  // would still treat the slug as new and produce duplicate
+  // pending-tag noise (the brand-new row gets ON CONFLICT DO
+  // NOTHING'd, but pending_review state could thrash).
+  clearTagVocabCache();
   revalidateTagSurfaces([parsed.data.slug]);
   return ok(`Created tag "${parsed.data.slug}".`);
 }
@@ -224,6 +235,10 @@ export async function mergeTag(
     "tag_merge",
     `from=${parsed.data.fromSlug} to=${parsed.data.toSlug} moved=${movedCount}`,
   );
+  // The fromSlug just disappeared from the active vocabulary; if
+  // we don't drop the cache, Ada might keep proposing it for up
+  // to 60 s and applyAiTags would resurrect it as a pending row.
+  clearTagVocabCache();
   revalidateTagSurfaces([parsed.data.fromSlug, parsed.data.toSlug]);
   return ok(
     `Merged "${parsed.data.fromSlug}" into "${parsed.data.toSlug}" — ${movedCount} association${movedCount === 1 ? "" : "s"} moved.`,
@@ -256,6 +271,118 @@ export async function retireTag(
     "tag_retire",
     `slug=${parsed.data.slug}`,
   );
+  // Same reason as the merge path: the slug just left the active
+  // vocabulary; force the cache so Ada doesn't keep re-proposing
+  // it and recreating it as a pending row.
+  clearTagVocabCache();
   revalidateTagSurfaces([parsed.data.slug]);
   return ok(`Retired tag "${parsed.data.slug}".`);
+}
+
+/**
+ * Approve a pending Ada-proposed tag (migration 0022). Flip
+ * pending_review=false and optionally rename / set tagline. The
+ * tag-vocab cache used by the moderator is cleared so Ada can
+ * pick up the newly-public tag on the very next moderate() call
+ * without a 60s wait.
+ *
+ * Form fields:
+ *   - slug (required, must reference an existing pending tag)
+ *   - name (optional override; if empty, keep the placeholder)
+ *   - tagline (optional)
+ */
+const approvePendingInput = z.object({
+  slug: slugSchema,
+  name: z.string().trim().min(1).max(60).optional(),
+  tagline: z.string().trim().max(200).optional(),
+});
+
+export async function approvePendingTag(
+  _prev: TagActionState,
+  formData: FormData,
+): Promise<TagActionState> {
+  const staffId = await requireStaffId();
+  if (!staffId) return err("Not authorized.");
+
+  const parsed = approvePendingInput.safeParse({
+    slug: formData.get("slug"),
+    name: formData.get("name") || undefined,
+    tagline: formData.get("tagline") || undefined,
+  });
+  if (!parsed.success) return err("Invalid input.");
+
+  // .returning() reports zero rows when the WHERE doesn't match —
+  // either the tag doesn't exist or it's already approved. Both
+  // mean "nothing to approve" from the staff's POV.
+  const updateValues: {
+    pendingReview: boolean;
+    name?: string;
+    tagline?: string | null;
+  } = { pendingReview: false };
+  if (parsed.data.name !== undefined) updateValues.name = parsed.data.name;
+  if (parsed.data.tagline !== undefined) {
+    updateValues.tagline = parsed.data.tagline;
+  }
+
+  const updated = await db
+    .update(tags)
+    .set(updateValues)
+    .where(and(eq(tags.slug, parsed.data.slug), eq(tags.pendingReview, true)))
+    .returning({ slug: tags.slug });
+
+  if (updated.length === 0) {
+    return err(`Pending tag "${parsed.data.slug}" not found.`);
+  }
+
+  await logTagAction(
+    staffId,
+    "tag_create",
+    `approved-pending slug=${parsed.data.slug}`,
+  );
+  // Drop the moderator's cached vocab so Ada sees the newly-public
+  // tag immediately. Without this, up to 60s of submissions would
+  // still be tagged with is_new=true on this same slug, creating
+  // duplicate pending-tag noise for staff to re-approve.
+  clearTagVocabCache();
+  revalidateTagSurfaces([parsed.data.slug]);
+  return ok(`Approved tag "${parsed.data.slug}".`);
+}
+
+/**
+ * Reject a pending Ada-proposed tag (migration 0022). Deletes the
+ * tag row, which cascades through submission_tags via the existing
+ * FK (ON DELETE CASCADE). The submissions remain — they just lose
+ * this single tag association.
+ */
+const rejectPendingInput = z.object({ slug: slugSchema });
+
+export async function rejectPendingTag(
+  _prev: TagActionState,
+  formData: FormData,
+): Promise<TagActionState> {
+  const staffId = await requireStaffId();
+  if (!staffId) return err("Not authorized.");
+
+  const parsed = rejectPendingInput.safeParse({ slug: formData.get("slug") });
+  if (!parsed.success) return err("Invalid slug.");
+
+  // Only delete pending rows — guard against accidentally retiring
+  // an approved tag through this path. The retireTag action handles
+  // approved tags explicitly.
+  const removed = await db
+    .delete(tags)
+    .where(and(eq(tags.slug, parsed.data.slug), eq(tags.pendingReview, true)))
+    .returning({ slug: tags.slug });
+
+  if (removed.length === 0) {
+    return err(`Pending tag "${parsed.data.slug}" not found.`);
+  }
+
+  await logTagAction(
+    staffId,
+    "tag_retire",
+    `rejected-pending slug=${parsed.data.slug}`,
+  );
+  revalidateTagSurfaces([parsed.data.slug]);
+  return ok(`Rejected tag "${parsed.data.slug}".`);
 }

--- a/web/src/lib/api/inputs.ts
+++ b/web/src/lib/api/inputs.ts
@@ -9,12 +9,12 @@
 
 import { decodeCursor, type Cursor } from "./cursor";
 import { SUBMISSION_TYPES } from "@/lib/submissions";
+import { isValidTagSlug } from "@/lib/tags/slug";
 import type { SubmissionType } from "./dto";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const USERNAME_RE = /^[a-z0-9_-]{1,32}$/i;
-const TAG_SLUG_RE = /^[a-z0-9-]{1,40}$/;
 
 /** Path-param UUID guard. */
 export function isUuid(s: string): boolean {
@@ -139,7 +139,7 @@ export function parseSubmissionListParams(
 
   const tagSlugs: string[] = [];
   for (const t of url.searchParams.getAll("tag")) {
-    if (!TAG_SLUG_RE.test(t)) {
+    if (!isValidTagSlug(t)) {
       errors.push({ field: "tag", message: `Invalid tag slug: ${t}.` });
     } else {
       tagSlugs.push(t);

--- a/web/src/lib/moderation/apply-ai-tags.ts
+++ b/web/src/lib/moderation/apply-ai-tags.ts
@@ -1,0 +1,180 @@
+/**
+ * Reconciliation for Ada-proposed tags on accepted submissions.
+ *
+ * Three phases:
+ *
+ *   1. Filter: drop AI tags whose slug duplicates a user-supplied tag
+ *      (user wins — they already chose, and Ada agreeing is
+ *      redundant) and drop slugs already linked to this submission.
+ *   2. Vocab probe: for each surviving slug, decide if the row exists
+ *      in the `tags` table. A slug Ada flagged is_new=false but
+ *      that doesn't exist gets treated as new (reconcile, not trust).
+ *      An existing slug with pending_review=true is also acceptable —
+ *      it means staff is reviewing it; another submission using it
+ *      is fine.
+ *   3. Insert: missing `tags` rows get inserted with
+ *      pending_review=true (and a name derived from the slug).
+ *      Then `submission_tags` rows are inserted with source='ai'.
+ *
+ * Cap: total tags per submission stay ≤ 5 (the existing input cap).
+ * If user already supplied 5, AI tags are dropped silently — the
+ * user's intent wins.
+ *
+ * Errors here MUST NOT throw out of createSubmission. The submission
+ * itself is already inserted; tag application failure is logged and
+ * swallowed so a vocab race doesn't undo a valid post.
+ */
+
+import { inArray } from "drizzle-orm";
+
+import { db } from "@/db/client";
+import { submissionTags, tags as tagsTable } from "@/db/schema";
+
+import type { ModerationTag } from "./types";
+
+const MAX_TAGS_PER_SUBMISSION = 5;
+
+interface ApplyAiTagsParams {
+  submissionId: string;
+  userTagSlugs: readonly string[];
+  aiTags: readonly ModerationTag[];
+}
+
+interface ApplyAiTagsResult {
+  /** Slugs actually linked to the submission with source='ai'. */
+  appliedSlugs: string[];
+  /** Slugs newly inserted into `tags` with pending_review=true. */
+  newlyCreatedSlugs: string[];
+  /** Slugs Ada proposed but were skipped (cap, dup, etc.). */
+  skippedSlugs: string[];
+}
+
+/**
+ * Convert a slug to a human-friendly default name. The result is a
+ * placeholder — staff can rename when approving at /admin/tags. We
+ * keep the heuristic simple (replace hyphens, capitalize) rather
+ * than trying to be clever. "rag" → "Rag", "ai-agents" → "Ai
+ * Agents". Staff fixes it on approval.
+ */
+function defaultNameForSlug(slug: string): string {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export async function applyAiTags(
+  params: ApplyAiTagsParams,
+): Promise<ApplyAiTagsResult> {
+  const { submissionId, userTagSlugs, aiTags } = params;
+
+  const result: ApplyAiTagsResult = {
+    appliedSlugs: [],
+    newlyCreatedSlugs: [],
+    skippedSlugs: [],
+  };
+
+  // Budget check first — if the user already saturated the cap we
+  // skip entirely. Empty AI tag list is the common path; bail fast.
+  const remaining = MAX_TAGS_PER_SUBMISSION - userTagSlugs.length;
+  if (aiTags.length === 0 || remaining <= 0) {
+    for (const t of aiTags) result.skippedSlugs.push(t.slug);
+    return result;
+  }
+
+  // Phase 1 — dedup against the user's choices and against each
+  // other (in case Ada returned the same slug twice). Order matters:
+  // earlier in the array wins so the first occurrence of a slug is
+  // the one we keep.
+  const userSet = new Set(userTagSlugs);
+  const seen = new Set<string>();
+  const candidates: ModerationTag[] = [];
+  for (const t of aiTags) {
+    if (userSet.has(t.slug) || seen.has(t.slug)) {
+      result.skippedSlugs.push(t.slug);
+      continue;
+    }
+    seen.add(t.slug);
+    candidates.push(t);
+  }
+  if (candidates.length === 0) return result;
+
+  // Trim candidates down to the remaining budget. AI proposals
+  // beyond the cap are dropped, not queued.
+  const accepted = candidates.slice(0, remaining);
+  for (const t of candidates.slice(remaining)) {
+    result.skippedSlugs.push(t.slug);
+  }
+
+  // Phases 2 and 3 run in a single transaction. Splitting the new-
+  // tag INSERT and the submission_tags INSERT across autocommit
+  // boundaries would let a failed link insert leave orphan pending
+  // tags behind (a tag row with no submission attached), which is
+  // user-invisible but creates noise in /admin/flags. The whole
+  // function still doesn't throw out of createSubmission — the
+  // caller swallows tx failures so a vocab race never undoes a
+  // valid post.
+  const candidateSlugs = accepted.map((t) => t.slug);
+  await db.transaction(async (tx) => {
+    // Find which candidate slugs already exist in `tags`. The set
+    // decides which need an INSERT first. We deliberately do NOT
+    // trust the model's is_new flag here — a hallucinated
+    // is_new=false on a missing slug would FK-violate the
+    // submission_tags insert below.
+    const existing = await tx
+      .select({ slug: tagsTable.slug })
+      .from(tagsTable)
+      .where(inArray(tagsTable.slug, candidateSlugs));
+    const existingSet = new Set(existing.map((r) => r.slug));
+
+    const toCreate = accepted.filter((t) => !existingSet.has(t.slug));
+    if (toCreate.length > 0) {
+      // Brand-new tags land with pending_review=true. The slug is
+      // also the placeholder name — staff renames when approving.
+      await tx
+        .insert(tagsTable)
+        .values(
+          toCreate.map((t) => ({
+            slug: t.slug,
+            name: defaultNameForSlug(t.slug),
+            tagline: null,
+            sortOrder: 0,
+            pendingReview: true,
+          })),
+        )
+        // A concurrent moderation pass on a different submission
+        // may have inserted the same slug between our SELECT and
+        // INSERT. onConflictDoNothing keeps us idempotent — the
+        // existing row wins (pending_review state stays whatever
+        // staff left it).
+        .onConflictDoNothing({ target: tagsTable.slug });
+      for (const t of toCreate) result.newlyCreatedSlugs.push(t.slug);
+    }
+
+    // Link the submission to every accepted slug. source='ai'
+    // marks provenance so /admin/log and future analytics can
+    // split AI vs user tagging. onConflictDoNothing covers a
+    // parallel call that already created the same (submission,
+    // tag) pair.
+    await tx
+      .insert(submissionTags)
+      .values(
+        accepted.map((t) => ({
+          submissionId,
+          tagSlug: t.slug,
+          source: "ai" as const,
+        })),
+      )
+      .onConflictDoNothing({
+        target: [submissionTags.submissionId, submissionTags.tagSlug],
+      });
+    for (const t of accepted) result.appliedSlugs.push(t.slug);
+  });
+
+  return result;
+}
+
+/** Exported for tests: the per-submission tag cap is shared with
+ *  the input schema (lib/submissions/schema.ts max(5)). */
+export const TAG_CAP_PER_SUBMISSION = MAX_TAGS_PER_SUBMISSION;

--- a/web/src/lib/moderation/index.ts
+++ b/web/src/lib/moderation/index.ts
@@ -20,10 +20,10 @@
  * No retries — see openai.ts for rationale.
  */
 
-import { and, count, eq, gte } from "drizzle-orm";
+import { and, asc, count, eq, gte } from "drizzle-orm";
 
 import { db } from "@/db/client";
-import { policyDecisions } from "@/db/schema";
+import { policyDecisions, tags } from "@/db/schema";
 import { callPolicyModel } from "./openai";
 import { isExemptFromModeration } from "./exempt";
 import { getActiveSystemPrompt } from "./prompt-store";
@@ -90,6 +90,10 @@ function syntheticPass(
     category: null,
     confidence: "high",
     oneLineWhy,
+    // Synthetic verdicts never produce tags — Ada didn't actually
+    // score the content. The submission's user-supplied tags (if
+    // any) still apply via the existing input.tags path.
+    tags: [],
     synthetic: true,
     syntheticReason,
     modelId: POLICY_MODEL,
@@ -133,6 +137,53 @@ const DEFAULT_DAILY_MODERATE_CAP = 50;
 function getDailyCap(): number {
   const v = Number(process.env.MODERATION_DAILY_CAP_PER_AUTHOR);
   return Number.isFinite(v) && v > 0 ? Math.floor(v) : DEFAULT_DAILY_MODERATE_CAP;
+}
+
+/**
+ * Active tag vocabulary for the moderator prompt — pending tags
+ * are excluded so Ada can't accidentally re-propose a tag staff is
+ * still reviewing. Cached per process for TAG_VOCAB_TTL_MS.
+ *
+ * The list is injected into the moderator's USER prompt (not
+ * system) so /admin/policy-prompt edits don't accidentally drop
+ * tagging behavior. The system prompt only describes the rules;
+ * the user prompt carries the data.
+ */
+const TAG_VOCAB_TTL_MS = 60_000;
+let cachedTagSlugs: string[] | null = null;
+let cachedTagSlugsAt = 0;
+
+async function getActiveTagSlugs(): Promise<string[]> {
+  const now = Date.now();
+  if (cachedTagSlugs && now - cachedTagSlugsAt < TAG_VOCAB_TTL_MS) {
+    return cachedTagSlugs;
+  }
+  try {
+    const rows = await db
+      .select({ slug: tags.slug })
+      .from(tags)
+      .where(eq(tags.pendingReview, false))
+      .orderBy(asc(tags.slug));
+    cachedTagSlugs = rows.map((r) => r.slug);
+  } catch (err) {
+    // DB error → return what's cached (even if stale) or [] so the
+    // moderator falls back to "all tags are new" behavior. Better
+    // than blocking moderation on a tag-vocab fetch failure.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[moderation] tag vocab fetch failed; using ${cachedTagSlugs ? "stale cache" : "empty"}: ${msg}`,
+    );
+    if (!cachedTagSlugs) cachedTagSlugs = [];
+  }
+  cachedTagSlugsAt = now;
+  return cachedTagSlugs;
+}
+
+/** Test-only / admin-server-action: clear the tag-vocab cache so a
+ *  newly-approved tag becomes visible immediately. */
+export function clearTagVocabCache(): void {
+  cachedTagSlugs = null;
+  cachedTagSlugsAt = 0;
 }
 
 async function isAtDailyCap(authorId: string): Promise<boolean> {
@@ -211,12 +262,28 @@ export async function moderate(
     // changes — and so a /office/policy/ aggregate can chart accept
     // rates per prompt version.
     const { systemPrompt, version } = await getActiveSystemPrompt();
-    const { response, costUsd } = await callPolicyModel(content, systemPrompt);
+    // Submissions get the active tag vocabulary injected into the
+    // user prompt; comments never tag, so callers skip this fetch.
+    const availableTags =
+      content.kind === "submission" ? await getActiveTagSlugs() : [];
+    const { response, costUsd } = await callPolicyModel(
+      content,
+      systemPrompt,
+      availableTags,
+    );
     return {
       verdict: response.verdict,
       category: response.category,
       confidence: response.confidence,
       oneLineWhy: response.one_line_why,
+      // Tags only apply to accepted submissions. Reject + comments
+      // strip them defensively — the model is instructed to leave
+      // them empty in those cases, but we don't trust output without
+      // verification.
+      tags:
+        response.verdict === "pass" && content.kind === "submission"
+          ? response.tags.map((t) => ({ slug: t.slug, isNew: t.is_new }))
+          : [],
       synthetic: false,
       syntheticReason: null,
       modelId: POLICY_MODEL,

--- a/web/src/lib/moderation/openai.ts
+++ b/web/src/lib/moderation/openai.ts
@@ -51,6 +51,10 @@ export interface ModelCallResult {
 export async function callPolicyModel(
   content: ModerationContent,
   systemPrompt: string,
+  /** Active tag vocabulary for submissions; ignored for comments.
+   *  Empty array means Ada always has to mark new tags with
+   *  is_new=true (the bootstrap state when no tags exist yet). */
+  availableTags: string[] = [],
 ): Promise<ModelCallResult> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
@@ -61,7 +65,7 @@ export async function callPolicyModel(
         model: POLICY_MODEL,
         messages: [
           { role: "system", content: systemPrompt },
-          { role: "user", content: buildUserPrompt(content) },
+          { role: "user", content: buildUserPrompt(content, availableTags) },
         ],
         response_format: {
           type: "json_schema",

--- a/web/src/lib/moderation/prompt.ts
+++ b/web/src/lib/moderation/prompt.ts
@@ -19,15 +19,16 @@
 
 import type { ModerationContent, ModerationKind } from "./types";
 
-export const FALLBACK_SYSTEM_PROMPT = `You are claudepot.com's policy moderator. Decide whether a piece of user-submitted content violates the platform's narrow policy taxonomy.
+export const FALLBACK_SYSTEM_PROMPT = `You are claudepot.com's policy moderator. Decide whether a piece of user-submitted content violates the platform's universal trust-and-safety taxonomy.
 
-Five categories. Reject only if the content clearly fits one. When in doubt, pass.
+Four categories. Reject only if the content clearly fits one. When in doubt, pass.
 
-1. spam     — off-topic promotion, link farms, repetitive postings, paid promotion without disclosure.
+1. spam     — promotional content with no surrounding discussion, link farms, repetitive postings, paid promotion without disclosure.
 2. abuse    — harassment, slurs, threats, targeted personal attacks against an identified person or group.
 3. illegal  — CSAM; distributing malware or stolen credentials; flagrant copyright violation (full pirated works, not quotation or fair-use criticism).
 4. doxxing  — exposing a private individual's home address, phone number, government ID, or non-public personal email tied to a real-name target.
-5. off_topic — for SUBMISSIONS only: clearly unrelated to the platform's audience (AI tools, AI-augmented work, LLM technique). For COMMENTS, off_topic is advisory and does NOT count as a violation — return verdict='pass'.
+
+Topical fit is NOT your concern. A submission that's a poor fit for the audience is handled by the editorial scoring layer and by community voting — your gate is universal trust-and-safety only. If a submission is legal, non-abusive, non-spam, and non-doxxing, pass it.
 
 Hard rules:
 
@@ -35,7 +36,7 @@ Hard rules:
 - Public figures (CEOs, politicians, public-facing creators) discussed in their public capacity do not trigger doxxing.
 - Profanity alone is not abuse; targeting + intent + identifiability are required.
 - A short, terse, or low-effort comment is not spam unless it carries promotional intent.
-- "off_topic" on a submission requires high confidence. Default to pass when the topical fit is plausible.
+- A submission about an unfamiliar topic, or one that seems out of place for the audience, is NOT a violation. Pass it.
 
 Output exactly one JSON object matching the response_format schema. No prose, no markdown fences, no commentary outside the JSON.
 
@@ -43,13 +44,33 @@ Fields:
 - verdict: "pass" or "reject".
 - category: null on pass; one of the five strings on reject.
 - confidence: "high" when the violation is unambiguous; "low" when borderline.
-- one_line_why: ONE sentence, ≤ 200 chars, non-generic, in user-facing voice. On pass, write a brief positive ("looks fine") or skip-reason. On reject, name the specific element that triggered the category — not "spam" but "promotional link with no surrounding discussion".`;
+- one_line_why: ONE sentence, ≤ 200 chars, non-generic, in user-facing voice. On pass, write a brief positive ("looks fine") or skip-reason. On reject, name the specific element that triggered the category — not "spam" but "promotional link with no surrounding discussion".
+- tags: an array of 0–2 topic tags. REQUIRED FIELD. See the tagging section below.
+
+Tagging (submissions on PASS only):
+
+- For ACCEPTED SUBMISSIONS, propose up to 2 topical tags in the "tags" array (0–2 entries). For REJECTS or COMMENTS, return "tags": [].
+- Tags describe what the submission is ABOUT (e.g. "rag", "evals", "agents", "prompting"), not its sentiment or quality. One concept per tag.
+- Slug shape: lowercase ASCII, kebab-case, matching ^[a-z][a-z0-9-]{1,40}$. No spaces, no punctuation, no leading digit, no trailing hyphen.
+- Prefer existing tags from the vocabulary list provided in the user message. Set is_new=false when picking from the list.
+- If no existing tag fits, you MAY propose a new tag — set is_new=true. New tags are held for staff review before becoming public.
+- Do NOT propose near-duplicates of existing tags. If an existing tag is close enough, use it.
+- 0 tags is a valid answer when nothing fits well. Quality over coverage.`;
 
 /**
  * Builds the message body the model will be asked to evaluate.
  * Comments have no title — pass an empty string.
+ *
+ * For submissions, the active tag vocabulary is injected verbatim
+ * so Ada can match against existing tags. Comments and an empty
+ * vocabulary skip the block entirely. The list is intentionally
+ * inert text (not JSON) so a thousand-tag dictionary doesn't blow
+ * the prompt budget.
  */
-export function buildUserPrompt(content: ModerationContent): string {
+export function buildUserPrompt(
+  content: ModerationContent,
+  availableTags: readonly string[] = [],
+): string {
   const kindLabel: Record<ModerationKind, string> = {
     submission: "Submission",
     comment: "Comment",
@@ -60,9 +81,16 @@ export function buildUserPrompt(content: ModerationContent): string {
     : "";
   const bodyBlock = `Body:\n${content.body.trim()}`;
 
+  const tagBlock =
+    content.kind === "submission" && availableTags.length > 0
+      ? `\n\nExisting tag vocabulary (prefer these; set is_new=false when reused):\n${availableTags.join(", ")}`
+      : content.kind === "submission"
+        ? "\n\nExisting tag vocabulary: (empty — every tag you choose is new; set is_new=true)"
+        : "";
+
   return `Type: ${kindLabel[content.kind]}
 
-${titleBlock}${bodyBlock}`;
+${titleBlock}${bodyBlock}${tagBlock}`;
 }
 
 /**
@@ -85,15 +113,38 @@ export const POLICY_RESPONSE_JSON_SCHEMA = {
   schema: {
     type: "object",
     additionalProperties: false,
-    required: ["verdict", "category", "confidence", "one_line_why"],
+    required: ["verdict", "category", "confidence", "one_line_why", "tags"],
     properties: {
       verdict: { type: "string", enum: ["pass", "reject"] },
       category: {
         type: ["string", "null"],
-        enum: ["spam", "abuse", "illegal", "doxxing", "off_topic", null],
+        enum: ["spam", "abuse", "illegal", "doxxing", null],
       },
       confidence: { type: "string", enum: ["high", "low"] },
       one_line_why: { type: "string", minLength: 1, maxLength: 280 },
+      // Migration 0022 — Ada-proposed tags. Up to 2 per accepted
+      // submission; empty array for rejects, comments, and synthetic
+      // verdicts. Slug shape is enforced server-side by Zod
+      // (TAG_SLUG_RE in schema.ts) — JSON schema can't carry a regex
+      // under strict structured-output mode, so the format-level
+      // check happens at parse time.
+      tags: {
+        type: "array",
+        maxItems: 2,
+        items: {
+          type: "object",
+          additionalProperties: false,
+          required: ["slug", "is_new"],
+          // Length bounds match `tagSlugSchema` in lib/tags/slug.ts
+          // so JSON-schema rejection lines up with Zod parse + the
+          // admin write path. Regex shape lives in Zod (JSON-schema
+          // strict mode forbids `pattern`).
+          properties: {
+            slug: { type: "string", minLength: 2, maxLength: 40 },
+            is_new: { type: "boolean" },
+          },
+        },
+      },
     },
   },
 } as const;

--- a/web/src/lib/moderation/schema.ts
+++ b/web/src/lib/moderation/schema.ts
@@ -13,6 +13,7 @@
  */
 
 import { z } from "zod";
+import { tagSlugSchema } from "@/lib/tags/slug";
 import { POLICY_CATEGORIES, POLICY_CONFIDENCE, POLICY_VERDICTS } from "./types";
 
 export const PolicyResponseSchema = z.object({
@@ -25,6 +26,25 @@ export const PolicyResponseSchema = z.object({
   // the model overruns, we'd rather fail-validate than truncate
   // silently and lose context.
   one_line_why: z.string().min(1).max(280),
+  // Migration 0022 — Ada tags accepted submissions during the same
+  // moderation call. Up to 2 tags. Empty on rejects, comments, and
+  // synthetic verdicts. The model is instructed in the user prompt
+  // to either pick from the active vocabulary (is_new=false) or
+  // propose new slugs (is_new=true). Server-side reconcile handles
+  // both paths.
+  tags: z
+    .array(
+      z.object({
+        // Reuse the canonical tagSlugSchema (regex + length 2..40 +
+        // .trim()) so a slug that passes here can definitely round-
+        // trip through the admin actions and the public API. Without
+        // the length cap, a 41-char slug (allowed by the JSON schema's
+        // maxLength: 41) would parse here but fail downstream.
+        slug: tagSlugSchema,
+        is_new: z.boolean(),
+      }),
+    )
+    .max(2),
 });
 
 export type PolicyResponse = z.infer<typeof PolicyResponseSchema>;

--- a/web/src/lib/moderation/types.ts
+++ b/web/src/lib/moderation/types.ts
@@ -1,9 +1,26 @@
 /**
  * Public types for the AI policy moderator.
  *
- * The five categories are defined in dev-docs/policy-moderator-plan.md
- * §2 — narrow on purpose, calibration-ready. Adding a category requires
- * a prompt update + an audit; do not extend casually.
+ * Four universal trust-and-safety categories. Platform-identity
+ * judgments (was the submission "on topic for AI builders") are
+ * NOT a moderator concern — those belong to editorial scoring
+ * (rubric.yml's domain_legibility, vote signal, persona overlays).
+ * The moderator gate enforces what every public discussion
+ * platform must enforce, and nothing more.
+ *
+ * History: an `off_topic` category existed in POLICY_PROMPT_V="1"
+ * (taxonomy of five). It was removed in v="2" because (a) it
+ * coupled the gate to a never-formalized definition of "the
+ * platform's audience" that gpt-4o-mini misread, and (b) the
+ * editorial scoring layer already handles topical fit better — a
+ * misplaced submission gets downscored and falls out of feeds
+ * without anyone deciding it should never have been posted.
+ *
+ * Existing rows in policy_decisions with category='off_topic'
+ * persist by design — `category` is a plain text column, not an
+ * enum, so legacy values stay queryable. Display surfaces
+ * (/office/policy, /appeal/[id]) keep their off_topic labels for
+ * historical rendering.
  */
 
 export const POLICY_CATEGORIES = [
@@ -11,7 +28,6 @@ export const POLICY_CATEGORIES = [
   "abuse",
   "illegal",
   "doxxing",
-  "off_topic",
 ] as const;
 
 export type PolicyCategory = (typeof POLICY_CATEGORIES)[number];
@@ -62,12 +78,34 @@ export interface ModerationAuthor {
  */
 export type SyntheticReason = "exempt" | "disabled" | "error" | "capped";
 
+/**
+ * Tag Ada proposes alongside an accepted submission (migration
+ * 0022). Up to 2 per pass; empty otherwise (rejects, comments,
+ * synthetic verdicts).
+ *
+ *   - slug: lowercase-kebab, ^[a-z][a-z0-9-]+$ (server validates).
+ *   - isNew: model's hint that the slug isn't in the active
+ *     vocabulary. Reconciled server-side: if isNew=false but the
+ *     slug doesn't exist, the row is treated as new (and inserted
+ *     with pending_review=true). Hint, not contract.
+ */
+export interface ModerationTag {
+  slug: string;
+  isNew: boolean;
+}
+
 export interface ModerationVerdict {
   verdict: PolicyVerdict;
   /** null on pass; the rejected category otherwise. */
   category: PolicyCategory | null;
   confidence: PolicyConfidence;
   oneLineWhy: string;
+  /**
+   * Up to 2 tags Ada chose for the accepted submission. Empty for
+   * rejects, comments, and synthetic verdicts. Server-side reconcile
+   * handles dedup against user-supplied tags + slug validation.
+   */
+  tags: ModerationTag[];
   /**
    * True when the verdict was synthesized (exempt author, moderator
    * disabled in dev, or a model error). Persistence layer skips the
@@ -86,8 +124,12 @@ export interface ModerationVerdict {
 /**
  * Bumped whenever the prompt changes in a way that would invalidate
  * historical comparisons. Stored on every policy_decisions row.
+ *
+ * v=1 — initial five-category taxonomy (spam/abuse/illegal/doxxing/off_topic).
+ * v=2 — off_topic removed; minimal universal trust-and-safety floor only.
+ *       Tagging instructions added (Ada-as-tagger).
  */
-export const POLICY_PROMPT_V = "1";
+export const POLICY_PROMPT_V = "2";
 
 /**
  * Pinned model id. Versioned model ids let us correlate verdict

--- a/web/src/lib/office-personas.ts
+++ b/web/src/lib/office-personas.ts
@@ -30,7 +30,9 @@ export const OFFICE_PERSONAS: Record<string, OfficePersona> = {
       "Evidence-first skeptic. Asks 'where's the eval?'. Strongest on " +
       "engineer / infra-shipper content. Also serves as the platform's " +
       "AI policy moderator — the synchronous gate every submission and " +
-      "comment passes through before publish.",
+      "comment passes through before publish — and proposes up to two " +
+      "topical tags per accepted submission, picking from the active " +
+      "vocabulary or proposing new tags for staff review.",
     multipliers: {
       evidence_quality: 1.5,
       mechanism_specificity: 1.2,
@@ -40,6 +42,10 @@ export const OFFICE_PERSONAS: Record<string, OfficePersona> = {
       {
         name: "policy moderator",
         href: "/office/policy",
+      },
+      {
+        name: "tagger",
+        href: "/c",
       },
     ],
   },

--- a/web/src/lib/submissions/create.ts
+++ b/web/src/lib/submissions/create.ts
@@ -26,6 +26,7 @@ import {
   writePolicyDecision,
   type ModerationAuthor,
 } from "@/lib/moderation";
+import { applyAiTags } from "@/lib/moderation/apply-ai-tags";
 
 import {
   determineInitialState,
@@ -133,8 +134,42 @@ export async function createSubmission(
 
   if (tags.length > 0) {
     await db.insert(submissionTags).values(
-      tags.map((tagSlug) => ({ submissionId: row.id, tagSlug })),
+      // Migration 0022 — explicit source='user' for user-supplied
+      // tags so /admin/log + analytics can split user vs ai tagging.
+      // The column has a DEFAULT 'user', so omitting it would also
+      // work, but being explicit here makes the provenance audit-
+      // grep-able from a single point.
+      tags.map((tagSlug) => ({
+        submissionId: row.id,
+        tagSlug,
+        source: "user" as const,
+      })),
     );
+  }
+
+  // Apply Ada-proposed tags only on accepted submissions. Skip when
+  // moderator rejected or errored — a rejected row never displays
+  // tags publicly, and the synthetic-error path doesn't carry real
+  // tag proposals (verdict.tags is forced to [] in those cases).
+  // Errors here MUST NOT roll back the submission insert, so the
+  // try/catch keeps applyAiTags isolated from the main pipeline.
+  if (
+    !moderatorRejected &&
+    !moderatorErrored &&
+    verdict.tags.length > 0
+  ) {
+    try {
+      await applyAiTags({
+        submissionId: row.id,
+        userTagSlugs: tags,
+        aiTags: verdict.tags,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[moderation] AI-tag apply failed for submission ${row.id}: ${msg}`,
+      );
+    }
   }
 
   // Record the verdict + (on reject) the audit log + the user

--- a/web/src/lib/tags/slug.ts
+++ b/web/src/lib/tags/slug.ts
@@ -1,0 +1,65 @@
+/**
+ * Single source of truth for the tag-slug shape.
+ *
+ * Three call sites depend on this:
+ *
+ *   - `lib/moderation/schema.ts` — Zod parse on Ada's structured
+ *     output. A slug that fails this drops to is_new=false skip
+ *     in apply-ai-tags (the regex check is enforced inside Zod).
+ *   - `lib/actions/admin-tag.ts` — staff create/rename/merge/retire
+ *     and approve/reject pending. Staff can never produce a slug
+ *     Ada couldn't legally emit, and vice versa.
+ *   - `lib/api/inputs.ts` — REST/MCP submission tags array. Same
+ *     shape so external callers can't slip in a slug that admin
+ *     can't render.
+ *
+ * The shape:
+ *
+ *   - lowercase ASCII letters, digits, hyphens
+ *   - leading letter required (forbids "-foo", "9-foo")
+ *   - no consecutive hyphens (forbids "foo--bar")
+ *   - no trailing hyphen (forbids "foo-")
+ *   - 2..40 characters total
+ *
+ * Why a leading letter? It keeps slugs distinct from numeric ids
+ * in the routing layer ("/c/9" should never collide with a tag).
+ * Why max 40? Display budget on a chip — anything longer wraps
+ * awkwardly. Why no double hyphen? The slug is meant to be one
+ * concept, not a smashed-together n-gram.
+ */
+
+import { z } from "zod";
+
+/**
+ * Canonical regex. Read it as: a letter, then any mix of alpha-
+ * numeric + single hyphens, ending in alphanumeric. The
+ * `(?:[a-z0-9]+-)*[a-z0-9]+` tail prevents both consecutive and
+ * trailing hyphens without a lookahead.
+ */
+export const TAG_SLUG_RE = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+
+/**
+ * Zod schema for inputs that arrive as raw strings (form data,
+ * external API payloads). `.trim()` runs first so trailing
+ * whitespace from copy/paste doesn't trip the regex; then the
+ * length and pattern checks fire.
+ */
+export const tagSlugSchema = z
+  .string()
+  .trim()
+  .min(2)
+  .max(40)
+  .regex(TAG_SLUG_RE, {
+    message:
+      "Slug must be lowercase, start with a letter, use only letters/digits/hyphens, no consecutive or trailing hyphens.",
+  });
+
+/**
+ * Pure regex test for hot paths that already have a string and
+ * don't need Zod's overhead. Keeps the regex literal in one
+ * place. Returns true on a valid slug, false otherwise.
+ */
+export function isValidTagSlug(s: string): boolean {
+  if (s.length < 2 || s.length > 40) return false;
+  return TAG_SLUG_RE.test(s);
+}

--- a/web/tests/integration/createComment-moderation.test.ts
+++ b/web/tests/integration/createComment-moderation.test.ts
@@ -82,6 +82,7 @@ function passVerdict(): ModerationVerdict {
     modelId: POLICY_MODEL,
     promptVersion: POLICY_PROMPT_V,
     costUsd: 0.0001,
+    tags: [],
   };
 }
 
@@ -96,6 +97,7 @@ function rejectSpamVerdict(): ModerationVerdict {
     modelId: POLICY_MODEL,
     promptVersion: POLICY_PROMPT_V,
     costUsd: 0.0001,
+    tags: [],
   };
 }
 
@@ -110,6 +112,7 @@ function illegalVerdict(): ModerationVerdict {
     modelId: POLICY_MODEL,
     promptVersion: POLICY_PROMPT_V,
     costUsd: 0.0001,
+    tags: [],
   };
 }
 
@@ -124,6 +127,7 @@ function syntheticErrorVerdict(): ModerationVerdict {
     modelId: POLICY_MODEL,
     promptVersion: POLICY_PROMPT_V,
     costUsd: null,
+    tags: [],
   };
 }
 

--- a/web/tests/integration/createSubmission-moderation.test.ts
+++ b/web/tests/integration/createSubmission-moderation.test.ts
@@ -82,6 +82,7 @@ function passVerdict(): ModerationVerdict {
     modelId: POLICY_MODEL,
     promptVersion: POLICY_PROMPT_V,
     costUsd: 0.0001,
+    tags: [],
   };
 }
 
@@ -96,6 +97,7 @@ function rejectSpamVerdict(): ModerationVerdict {
     modelId: POLICY_MODEL,
     promptVersion: POLICY_PROMPT_V,
     costUsd: 0.0001,
+    tags: [],
   };
 }
 
@@ -110,6 +112,7 @@ function syntheticErrorVerdict(): ModerationVerdict {
     modelId: POLICY_MODEL,
     promptVersion: POLICY_PROMPT_V,
     costUsd: null,
+    tags: [],
   };
 }
 
@@ -124,6 +127,7 @@ function syntheticCappedVerdict(): ModerationVerdict {
     modelId: POLICY_MODEL,
     promptVersion: POLICY_PROMPT_V,
     costUsd: null,
+    tags: [],
   };
 }
 

--- a/web/tests/moderation-prompt.test.ts
+++ b/web/tests/moderation-prompt.test.ts
@@ -7,8 +7,8 @@
  * versioned via POLICY_PROMPT_V. These tests lock invariants we
  * never want a casual edit to break:
  *
- *   1. The system prompt names the five categories exactly once
- *      each — drift in the taxonomy must be deliberate.
+ *   1. The system prompt names every category in POLICY_CATEGORIES
+ *      exactly once each — drift in the taxonomy must be deliberate.
  *   2. The user prompt includes both kind and body, and includes
  *      the title only when present.
  *   3. The JSON schema we send to OpenAI matches the categories
@@ -92,16 +92,21 @@ test("user prompt trims surrounding whitespace on title and body", () => {
   assert.match(prompt, /Body:\nspaced body/);
 });
 
-test("JSON schema lists exactly the five categories plus null", () => {
+test("JSON schema lists exactly POLICY_CATEGORIES plus null", () => {
   const props = POLICY_RESPONSE_JSON_SCHEMA.schema
     .properties as Record<string, unknown>;
   const cat = props.category as { enum: ReadonlyArray<string | null> };
-  // null + the five categories.
+  // null + every category in POLICY_CATEGORIES.
   assert.equal(cat.enum.length, POLICY_CATEGORIES.length + 1);
   for (const c of POLICY_CATEGORIES) {
     assert.ok(cat.enum.includes(c), `JSON schema missing category ${c}`);
   }
   assert.ok(cat.enum.includes(null), "JSON schema missing null category");
+  // Negative: the legacy off_topic value must not be in the v=2 enum.
+  assert.ok(
+    !cat.enum.includes("off_topic"),
+    "off_topic should be retired from v=2 schema",
+  );
 });
 
 test("JSON schema flags strict + additionalProperties=false", () => {

--- a/web/tests/moderation-schema.test.ts
+++ b/web/tests/moderation-schema.test.ts
@@ -36,10 +36,12 @@ test("parses a happy-path pass response", () => {
     category: null,
     confidence: "high",
     one_line_why: "Looks like a normal tutorial submission.",
+    tags: [],
   };
   const parsed = PolicyResponseSchema.parse(raw);
   assert.equal(parsed.verdict, "pass");
   assert.equal(parsed.category, null);
+  assert.deepEqual(parsed.tags, []);
 });
 
 test("parses a happy-path reject response", () => {
@@ -48,10 +50,55 @@ test("parses a happy-path reject response", () => {
     category: "spam",
     confidence: "high",
     one_line_why: "Promotional link with no surrounding discussion.",
+    tags: [],
   };
   const parsed = PolicyResponseSchema.parse(raw);
   assert.equal(parsed.verdict, "reject");
   assert.equal(parsed.category, "spam");
+});
+
+test("parses Ada-proposed tags on a pass response", () => {
+  const raw = {
+    verdict: "pass",
+    category: null,
+    confidence: "high",
+    one_line_why: "Tutorial on retrieval-augmented agents.",
+    tags: [
+      { slug: "rag", is_new: false },
+      { slug: "ai-agents", is_new: true },
+    ],
+  };
+  const parsed = PolicyResponseSchema.parse(raw);
+  assert.equal(parsed.tags.length, 2);
+  assert.equal(parsed.tags[0].slug, "rag");
+  assert.equal(parsed.tags[0].is_new, false);
+  assert.equal(parsed.tags[1].is_new, true);
+});
+
+test("rejects more than 2 tags", () => {
+  const raw = {
+    verdict: "pass",
+    category: null,
+    confidence: "high",
+    one_line_why: "x",
+    tags: [
+      { slug: "a", is_new: false },
+      { slug: "b", is_new: false },
+      { slug: "c", is_new: false },
+    ],
+  };
+  assert.throws(() => PolicyResponseSchema.parse(raw));
+});
+
+test("rejects malformed tag slug", () => {
+  const raw = {
+    verdict: "pass",
+    category: null,
+    confidence: "high",
+    one_line_why: "x",
+    tags: [{ slug: "Invalid Slug!", is_new: true }],
+  };
+  assert.throws(() => PolicyResponseSchema.parse(raw));
 });
 
 test("rejects an unknown category", () => {
@@ -60,6 +107,7 @@ test("rejects an unknown category", () => {
     category: "self_harm",
     confidence: "high",
     one_line_why: "x",
+    tags: [],
   };
   assert.throws(() => PolicyResponseSchema.parse(raw));
 });
@@ -70,6 +118,7 @@ test("rejects an unknown verdict", () => {
     category: null,
     confidence: "high",
     one_line_why: "x",
+    tags: [],
   };
   assert.throws(() => PolicyResponseSchema.parse(raw));
 });
@@ -80,6 +129,7 @@ test("rejects a one_line_why over the length limit", () => {
     category: null,
     confidence: "high",
     one_line_why: "x".repeat(500),
+    tags: [],
   };
   assert.throws(() => PolicyResponseSchema.parse(raw));
 });
@@ -90,18 +140,18 @@ test("rejects an empty one_line_why", () => {
     category: null,
     confidence: "high",
     one_line_why: "",
+    tags: [],
   };
   assert.throws(() => PolicyResponseSchema.parse(raw));
 });
 
 test("reconcileCategory clears category when verdict is pass", () => {
-  // Some model outputs ship a leftover category on pass; we strip
-  // it server-side rather than persist a contradictory row.
   const parsed = PolicyResponseSchema.parse({
     verdict: "pass",
     category: "spam",
     confidence: "low",
     one_line_why: "borderline pass",
+    tags: [],
   });
   const out = reconcileCategory(parsed);
   assert.equal(out.category, null);
@@ -114,6 +164,7 @@ test("reconcileCategory throws when reject ships category=null", () => {
     category: null,
     confidence: "high",
     one_line_why: "x",
+    tags: [],
   });
   assert.throws(() => reconcileCategory(parsed));
 });


### PR DESCRIPTION
## Summary

Two structural changes that ride together because both bump the
prompt version stamp on `policy_decisions`.

1. **Ada gains a tagging job.** The moderator emits up to 2 topical tags for accepted submissions in the same call. Hybrid vocab: pick from existing tags (`is_new=false`) or propose new tags with `pending_review=true` for staff approval at `/admin/flags`. Migration 0022 adds `tags.pending_review` and `submission_tags.source` (`'ai'|'user'`) with a CHECK constraint. Pending tags hide from `/c` and from public submission rows; staff approve/reject in the new pending-review section. `tagSlugSchema` in `lib/tags/slug.ts` is the one canonical slug shape — moderator parsing, admin actions, and the public API now share it.
2. **`POLICY_CATEGORIES` drops `off_topic`.** The gate now handles universal trust-and-safety only (`spam`/`abuse`/`illegal`/`doxxing`). Topical fit is the editorial layer's concern (rubric scoring + voting), not the moderator's. Removes a perpetual drift point for autonomous operation and fixes the misread where gpt-4o-mini was rejecting AI-on-topic content as off-topic-for-AI-audience due to an ambiguous parenthetical in the fallback prompt.

`POLICY_PROMPT_V` bumped 1→2 so `policy_decisions.prompt_version` splits analytics cleanly across the change. The `category` column is plain text not enum, so legacy rows with `category='off_topic'` stay queryable; display surfaces (`/office/policy`, `/appeal/[id]`) keep their off_topic labels for historical rendering.

## Migration

Migration `0022_ai_tagging.sql` adds two columns, a CHECK constraint, and one partial index. **Apply manually via psql** per `.claude/rules/db-migrations.md` — `drizzle-kit push` against prod would drop the `search_vec` generated column.

```
ALTER TABLE tags ADD COLUMN IF NOT EXISTS pending_review boolean NOT NULL DEFAULT false;
ALTER TABLE submission_tags ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'user';
-- + guarded ADD CONSTRAINT (DO $$ ... pg_constraint check)
-- + CREATE INDEX IF NOT EXISTS idx_tags_pending_review (pending_review, slug) WHERE pending_review = true
```

## Audit + verify

- Codex mini audit (5-dim: correctness, security, error-handling, types, perf) returned 7 findings (2 HIGH, 2 MED, 3 LOW). All 7 fixed in this branch and re-verified by Codex (independent fresh-thread call).
- `tsc --noEmit` → 0 errors
- 11/11 unit-test suites pass

## Test plan

- [ ] Apply migration 0022 to prod via psql
- [ ] Submit a new post in prod, confirm Ada attaches up to 2 tags
- [ ] Hit `/admin/flags`, confirm pending-review section renders any new Ada-proposed tags with sample submission titles
- [ ] Approve a pending tag, confirm it appears at `/c/<slug>` and the moderator vocab cache is cleared (Ada picks it up on next submission)
- [ ] Confirm `/office/policy` shows 4 categories, lede explicitly disclaims topical-fit gating
- [ ] Confirm `policy_decisions.prompt_version` rows with new submissions are stamped `"2"`