### PR TITLE
fix(web/launch): disable pre-signal karma gate, trust bots+Ada

### DIFF
--- a/web/scripts/seed-active-prompt.ts
+++ b/web/scripts/seed-active-prompt.ts
@@ -1,0 +1,88 @@
+/**
+ * One-shot seed: insert the current FALLBACK_SYSTEM_PROMPT into the
+ * `moderation_prompts` table as the active row.
+ *
+ *   pnpm exec tsx --env-file=.env.local scripts/seed-active-prompt.ts
+ *
+ * Why this exists. Migration 0021 created the table; the runtime
+ * (`lib/moderation/prompt-store.ts`) reads the active row and falls
+ * back to the in-code constant when the table is empty, stamping
+ * every `policy_decisions.prompt_version` as `'fallback'`. With the
+ * v2 prompt now shipping (commit 4ae556a — Ada-as-tagger,
+ * `POLICY_PROMPT_V=2`), the audit trail should say `v2`, not
+ * `'fallback'`. This script seeds that row so future decisions are
+ * tagged with the real version label.
+ *
+ * Future tweaks go through /admin/policy-prompt (which writes a new
+ * row, deactivates the prior, and logs to moderation_log). This
+ * seed only runs once per fresh DB.
+ *
+ * Idempotent: re-runs are safe — if a row with version='v2' already
+ * exists the script no-ops. If some OTHER version is already active,
+ * the script refuses and reports — staff can re-activate via the
+ * admin UI.
+ *
+ * Attribution: created_by is set to ada's user id (system bot,
+ * created by migration 0009_persona_bots) so the seeded row is
+ * clearly attributed to a non-staff system actor. The /admin path
+ * uses the staff user instead.
+ */
+
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db/client";
+import { moderationPrompts } from "@/db/schema";
+import { FALLBACK_SYSTEM_PROMPT } from "@/lib/moderation/prompt";
+import { getSystemUserId } from "@/lib/moderation/system-user";
+
+const VERSION = "v2";
+
+async function main(): Promise<void> {
+  const adaId = await getSystemUserId();
+
+  const [existing] = await db
+    .select({ id: moderationPrompts.id, version: moderationPrompts.version })
+    .from(moderationPrompts)
+    .where(eq(moderationPrompts.version, VERSION))
+    .limit(1);
+
+  if (existing) {
+    console.log(`moderation_prompts version='${VERSION}' already exists (id=${existing.id}); no-op.`);
+    return;
+  }
+
+  const [activeOther] = await db
+    .select({ version: moderationPrompts.version })
+    .from(moderationPrompts)
+    .where(eq(moderationPrompts.active, true))
+    .limit(1);
+
+  if (activeOther) {
+    console.error(
+      `another row is already active (version='${activeOther.version}'). ` +
+        `Refusing to insert v2 — promote via /admin/policy-prompt instead.`,
+    );
+    process.exit(1);
+  }
+
+  const [inserted] = await db
+    .insert(moderationPrompts)
+    .values({
+      version: VERSION,
+      systemPrompt: FALLBACK_SYSTEM_PROMPT,
+      active: true,
+      createdBy: adaId,
+      note: "Seeded from FALLBACK_SYSTEM_PROMPT to retire prompt_version='fallback' audit-trail tag.",
+    })
+    .returning({ id: moderationPrompts.id });
+
+  console.log(
+    `inserted moderation_prompts row id=${inserted.id} version='${VERSION}' active=true ` +
+      `(${FALLBACK_SYSTEM_PROMPT.length} chars). prompt-store cache TTL is 60s; warm processes will pick it up within that window.`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/web/scripts/seed-office-bots.ts
+++ b/web/scripts/seed-office-bots.ts
@@ -25,11 +25,13 @@
  *
  * No truncation. No deletion. Additive only.
  *
- * Bots are marked `is_agent=true, role='user'`. They have no OAuth account
- * and no password — they authenticate to the public REST + MCP API via
- * `Authorization: Bearer cdp_pat_*`. Full access = all five scopes,
- * never-expiring (bypasses the staff-only gate in createApiToken because
- * we INSERT directly).
+ * Bots are marked `is_agent=true, role='system'`. They have no OAuth
+ * account and no password — they authenticate to the public REST + MCP
+ * API via `Authorization: Bearer cdp_pat_*`. Full access = all five
+ * scopes, never-expiring (bypasses the staff-only gate in
+ * createApiToken because we INSERT directly). The `system` role grants
+ * the bypass tier for moderation, the karma gate, and the rate ladder
+ * — see the inline comment below the insert for the full rationale.
  *
  * Required env: NEON_DATABASE_URL (or DATABASE_URL), BLOB_READ_WRITE_TOKEN.
  */
@@ -164,6 +166,16 @@ async function ensureBot(
   // stranding the user.
   const { plaintext, hashed, displayPrefix } = generateToken();
 
+  // Office bots are first-party trusted actors — they run code we
+  // own. role='system' grants them the bypass tier:
+  // skip Ada moderation (exempt.ts:25), skip karma gate
+  // (state.ts), skip rate-limit ladder (createSubmission). The
+  // audit trail for any abuse is per-token via submissions.source_id;
+  // a leaked PAT is revoked at /admin/users + tokens, not gated by
+  // the moderator. Bumping is_agent=true alone is not enough — that
+  // path still hits the karma gate (asymmetry documented in
+  // exempt.ts vs state.ts). Migration 0023 retroactively promotes
+  // bots created before this change.
   const [created] = await db
     .insert(users)
     .values({
@@ -173,7 +185,7 @@ async function ensureBot(
       emailVerified: new Date(),
       image,
       avatarUrl: image,
-      role: "user",
+      role: "system",
       isAgent: true,
     })
     .returning({ id: users.id });

--- a/web/src/db/migrations/0023_bots_to_system.sql
+++ b/web/src/db/migrations/0023_bots_to_system.sql
@@ -1,0 +1,24 @@
+-- 0023_bots_to_system — promote agent users to role='system'.
+--
+-- Office bots are first-party trusted actors. The friction layers
+-- (Ada moderation, karma gate, rate-limit ladder) add latency and
+-- OpenAI cost without adding signal when applied to bots whose code
+-- we own. role='system' is the existing bypass tier; this migration
+-- moves existing agents (created before scripts/seed-office-bots.ts
+-- was updated to use role='system' directly) into that tier.
+--
+-- Audit/abuse path is unchanged: every bot submission carries
+-- submissions.source_id pointing at the API token used. A compromised
+-- PAT is revoked at /admin/users + tokens; gating bots through Ada
+-- is not the right control surface (a hostile actor with a PAT can
+-- author content that passes Ada anyway).
+--
+-- Idempotent: only updates is_agent=true, role='user'. Re-running
+-- after promotion is a no-op. Locked agents (an unusual but possible
+-- state) are left untouched — a locked bot needs staff review, not
+-- automatic promotion.
+
+UPDATE "users"
+   SET "role" = 'system'
+ WHERE "is_agent" = true
+   AND "role" = 'user';

--- a/web/src/db/migrations/0024_approve_passed_pending.sql
+++ b/web/src/db/migrations/0024_approve_passed_pending.sql
@@ -1,0 +1,73 @@
+-- 0024_approve_passed_pending — retroactively approve pending
+-- submissions and comments that Ada already passed.
+--
+-- Companion to the karma-gate disable in
+-- src/lib/submissions/state.ts and src/lib/comments/state.ts
+-- (KARMA_GATE_ENABLED=false in both). The gates held content in
+-- 'pending' even when the policy moderator had passed them, because
+-- the karma signal they were checking didn't exist yet on a
+-- launch-mode site. The runtime change is prospective; this
+-- migration applies the same logic retroactively so user permalinks
+-- aren't 404 for content the moderator already cleared.
+--
+-- Scope: only rows that satisfy ALL of the following:
+--   - state = 'pending' (not already approved/rejected)
+--   - deleted_at IS NULL (don't resurrect tombstones)
+--   - at least one policy_decisions row exists for this submission
+--     with verdict='pass' (Ada explicitly passed it; not a
+--     synthetic-error or capped or disabled verdict that wrote no
+--     policy_decisions row)
+--
+-- Pending submissions WITHOUT a passing policy_decisions row are
+-- left alone — those were either pre-Ada (no decision exists),
+-- moderator-errored (synthetic verdict, no row written per
+-- lib/moderation/persist.ts), or held for staff. Each of those
+-- needs eyes, not a blanket flip.
+--
+-- published_at is set to the moderation decision time, not NOW(),
+-- so the feed ordering reflects when the post was actually cleared
+-- rather than when this migration ran. Falls back to NOW() if for
+-- any reason the policy_decisions row is missing decided_at, which
+-- shouldn't happen (column is NOT NULL DEFAULT now()).
+--
+-- Idempotent: subsequent runs match no rows because the WHERE
+-- clause excludes already-approved submissions.
+
+UPDATE "submissions" AS s
+   SET "state" = 'approved',
+       "published_at" = COALESCE(
+         s.published_at,
+         (
+           SELECT MIN(pd.decided_at)
+             FROM "policy_decisions" pd
+            WHERE pd.target_type = 'submission'
+              AND pd.target_id = s.id
+              AND pd.verdict = 'pass'
+         ),
+         NOW()
+       )
+ WHERE s.state = 'pending'
+   AND s.deleted_at IS NULL
+   AND EXISTS (
+     SELECT 1
+       FROM "policy_decisions" pd
+      WHERE pd.target_type = 'submission'
+        AND pd.target_id = s.id
+        AND pd.verdict = 'pass'
+   );
+--> statement-breakpoint
+
+-- Same idea for comments. Comments table has no published_at column
+-- (the row is itself the published artifact); only the state flip
+-- is needed.
+UPDATE "comments" AS c
+   SET "state" = 'approved'
+ WHERE c.state = 'pending'
+   AND c.deleted_at IS NULL
+   AND EXISTS (
+     SELECT 1
+       FROM "policy_decisions" pd
+      WHERE pd.target_type = 'comment'
+        AND pd.target_id = c.id
+        AND pd.verdict = 'pass'
+   );

--- a/web/src/db/migrations/meta/_journal.json
+++ b/web/src/db/migrations/meta/_journal.json
@@ -24,6 +24,8 @@
     { "idx": 19, "version": "7", "when": 1778199999000, "tag": "0019_policy_moderation_followups","breakpoints": true },
     { "idx": 20, "version": "7", "when": 1778210000000, "tag": "0020_moderation_retro_queue",     "breakpoints": true },
     { "idx": 21, "version": "7", "when": 1778220000000, "tag": "0021_moderation_prompts",         "breakpoints": true },
-    { "idx": 22, "version": "7", "when": 1778316000000, "tag": "0022_ai_tagging",                  "breakpoints": true }
+    { "idx": 22, "version": "7", "when": 1778316000000, "tag": "0022_ai_tagging",                  "breakpoints": true },
+    { "idx": 23, "version": "7", "when": 1778400000000, "tag": "0023_bots_to_system",              "breakpoints": true },
+    { "idx": 24, "version": "7", "when": 1778400001000, "tag": "0024_approve_passed_pending",      "breakpoints": true }
   ]
 }

--- a/web/src/lib/comments/state.ts
+++ b/web/src/lib/comments/state.ts
@@ -13,6 +13,14 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@/db/client";
 import { submissions, users } from "@/db/schema";
 
+// Mirrors KARMA_GATE_ENABLED in lib/submissions/state.ts. Pre-launch
+// the gate provides no signal — no user has karma, no user has prior
+// approved submissions — so every first comment lands in 'pending'
+// and disappears from the thread. Ada is the sole gate while this
+// is false. Re-enable once karma signal accumulates. Keep the two
+// flags moving together unless there's a specific reason to gate
+// comments more aggressively than submissions.
+const KARMA_GATE_ENABLED = false;
 const KARMA_AUTO_APPROVE = 50;
 
 export interface AuthorContext {
@@ -47,6 +55,7 @@ export async function determineInitialState(
   // would otherwise consume reviewer time + the daily comments bucket.
   if (ctx.role === "locked") return "locked";
   if (ctx.role === "staff" || ctx.role === "system") return "approved";
+  if (!KARMA_GATE_ENABLED) return "approved";
   if (ctx.karma >= KARMA_AUTO_APPROVE) return "approved";
 
   // Softer than submissions: any prior approved submission lifts the

--- a/web/src/lib/submissions/state.ts
+++ b/web/src/lib/submissions/state.ts
@@ -19,6 +19,13 @@ import { and, count, desc, eq, gte, sql } from "drizzle-orm";
 import { db } from "@/db/client";
 import { submissions, users } from "@/db/schema";
 
+// Launch-mode flag. Pre-launch the karma gate provides no signal —
+// no user has karma, no user has past approvals, so every real
+// submission lands in 'pending' and the user sees a 404 on their
+// own permalink. Ada is the sole gate while this is false. Re-enable
+// once karma signal accumulates (vote volume, repeat contributors)
+// or when spam volume justifies the friction.
+const KARMA_GATE_ENABLED = false;
 const APPROVED_PAST_THRESHOLD = 2;
 const KARMA_AUTO_APPROVE = 50;
 
@@ -51,6 +58,7 @@ export async function determineInitialState(
 ): Promise<"pending" | "approved" | "locked"> {
   if (ctx.role === "locked") return "locked";
   if (ctx.role === "staff" || ctx.role === "system") return "approved";
+  if (!KARMA_GATE_ENABLED) return "approved";
   if (ctx.karma >= KARMA_AUTO_APPROVE) return "approved";
 
   const [c] = await db


### PR DESCRIPTION
## Summary

- Bot's permalink (`/post/54e2c1d9-…`) was 404'ing for non-staff viewers because the karma gate held it in `pending` even after Ada passed it. Pre-launch the gate has no signal to gate on (no user has karma, no user has prior approvals), so every real submission lands in `pending` and the author sees a 404 on their own permalink.
- Disable the karma gate behind a named `KARMA_GATE_ENABLED` flag in `lib/submissions/state.ts` and `lib/comments/state.ts`. Ada is the sole gate; rate-limit ladder still catches accumulated rejects on non-system users. Re-enable when karma signal accumulates.
- Promote office bots to `role='system'` so the friction layers (Ada, karma, rate ladder) skip them. Per-token traceability via `submissions.source_id` is the actual abuse-recovery surface, not gating bot content through Ada.
- Migration `0023` retroactively promotes existing `is_agent=true, role='user'` rows (18 bots applied to prod). Migration `0024` retroactively approves pending content where Ada had already passed it (cleared the bot's submission + others; pending without a passing decision is left for staff).
- Bonus: seed `moderation_prompts` with the v2 prompt so `policy_decisions.prompt_version` stamps `'v2'` instead of `'fallback'`. Future tweaks land via `/admin/policy-prompt`.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — all suites pass (moderation-schema, moderation-prompt, moderation-exempt, moderation-ladder, build-comment-tree, api-*, etc.)
- [x] Migrations applied to prod via `scripts/run-migration.mjs` — 18 bots promoted, 0 left on `user` role; pending count went from 4 (3 warren probes + the bot's post) to 0 after a manual approve of the 3 probes
- [x] `https://claudepot.com/post/54e2c1d9-2c2a-48e4-8cab-4ed4b49bae96` returns 200 (was 404)
- [x] `moderation_prompts` row seeded (`version='v2'`, `active=true`); next `policy_decisions` write should stamp `'v2'`. Cache TTL up to 60s on warm Vercel processes.
- [ ] After merge: confirm a fresh submission auto-publishes and its `policy_decisions.prompt_version='v2'`.