### PR TITLE
web: add baseline strict CSP via middleware + static security headers

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -8,6 +8,37 @@ const withMDX = nextMDX({
 const nextConfig = {
   output: "standalone",
   pageExtensions: ["ts", "tsx", "mdx"],
+  async headers() {
+    // Static security headers applied to every response. CSP is NOT set
+    // here — it's emitted per-request by `src/middleware.ts` with a nonce
+    // that Next.js propagates into its inline hydration scripts. Setting
+    // CSP in both places would cause browsers to intersect the two
+    // policies and drop the nonce, breaking hydration.
+    const securityHeaders = [
+      {
+        key: "Strict-Transport-Security",
+        value: "max-age=63072000; includeSubDomains; preload",
+      },
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      { key: "X-Frame-Options", value: "DENY" },
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      {
+        key: "Permissions-Policy",
+        // FLoC opt-out (interest-cohort=()) keeps the page out of
+        // Google's deprecated ad-cohort scheme. The rest mute APIs
+        // we never use, so a compromised script can't reach them.
+        value:
+          "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()",
+      },
+      // Same-origin opener prevents `window.opener` cross-origin reads
+      // from popups. Cheap XS-Leaks protection. We do NOT set COEP
+      // require-corp — that's only useful for SharedArrayBuffer or
+      // multithreaded WASM, neither of which this app uses, and it
+      // would block every cross-origin asset without a CORP header.
+      { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+    ];
+    return [{ source: "/:path*", headers: securityHeaders }];
+  },
   async redirects() {
     return [
       // Admin redesign — power tools moved under /admin/console/*.

--- a/web/src/app/(reader)/layout.tsx
+++ b/web/src/app/(reader)/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Suspense } from "react";
+import { headers } from "next/headers";
 import { JetBrains_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -71,6 +72,13 @@ export default async function PrototypeLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // CSP nonce minted per-request by `src/middleware.ts` and threaded
+  // back here via the `x-nonce` request header. `headers()` returns
+  // null for the value if the middleware didn't run (e.g. when a route
+  // hits the matcher exclusion list and renders this layout anyway —
+  // rare, but `undefined` is safer than asserting).
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+
   // Pull session.user.image once at layout level so the nav can render
   // the real OAuth photo (path A). Falls back to identicon when null.
   // sessionUsername is the DB username (slug), not the OAuth display
@@ -127,6 +135,11 @@ export default async function PrototypeLayout({
          * was CORS-blocked and recorded zero events. Vercel Analytics
          * runs natively on this stack with no CORS surface.
          */}
+        {/* No nonce prop on Vercel components — both inject their
+         * `<script>` via `document.createElement` from within React's
+         * (nonced) bundle, so `strict-dynamic` in our CSP propagates
+         * trust automatically. @vercel/analytics 2.0.1 doesn't accept
+         * a nonce prop anyway. */}
         <Analytics />
         <SpeedInsights />
         {/* FAB popover handlers — close on outside-tap, on Esc, and
@@ -144,6 +157,7 @@ export default async function PrototypeLayout({
          * page but only find an [open] details when the user has
          * actually expanded the FAB. */}
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html:
               "(function(){var SEL='details.proto-toc-details,details.docs-sidebar-disclosure';function close(d){d.open=false}document.addEventListener('click',function(e){document.querySelectorAll(SEL).forEach(function(d){if(d.open&&!d.contains(e.target))close(d)})});document.addEventListener('keydown',function(e){if(e.key==='Escape')document.querySelectorAll(SEL).forEach(function(d){if(d.open)close(d)})});document.addEventListener('click',function(e){var t=e.target;if(!t||!t.closest)return;var d=t.closest(SEL);if(!d||!d.open)return;var a=t.closest('a');if(a&&d.contains(a))close(d)})})();",

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,0 +1,98 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+/**
+ * Build a Content-Security-Policy header for one HTML response.
+ *
+ * Pattern is the same as lixiaolai.com's middleware: per-request random
+ * nonce that Next.js threads into every inline hydration script via the
+ * `x-nonce` request header (any server component that needs the nonce
+ * reads it back from `headers()` and passes it to `<script nonce={...}>`).
+ *
+ * `'strict-dynamic'` means "scripts trusted by nonce can load further
+ * scripts" — that's what lets Next's chunk-loader fetch `/_next/static/*`
+ * without us having to enumerate every chunk path in `script-src`.
+ *
+ * `'unsafe-eval'` is kept only in development because Turbopack's HMR
+ * client uses `new Function`. Production bundles don't need it.
+ *
+ * Styles still allow `'unsafe-inline'`. Next's critical-CSS flush and
+ * any inline `style="…"` attribute would require per-element nonces
+ * that React doesn't mint. Risk ceiling is low — no script execution
+ * from style sinks in modern browsers.
+ *
+ * External origins explicitly allowlisted:
+ *   img-src    Google + GitHub avatars (OAuth user.image), raw.github
+ *              (markdown-rewritten images from GitHub-imported posts)
+ *   frame-src  YouTube-nocookie, Spotify embeds, Apple Podcasts embeds
+ *              (see src/lib/embed-attrs.ts)
+ *
+ * Vercel Analytics + Speed Insights load their scripts from same-origin
+ * (`/_vercel/insights/script.js`), so `'self'` covers them — no third-
+ * party origin needed in script-src or connect-src.
+ */
+function buildCsp(nonce: string): string {
+  const isDev = process.env.NODE_ENV !== "production";
+  const scriptSrc = [
+    "'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
+    ...(isDev ? ["'unsafe-eval'"] : []),
+  ].join(" ");
+
+  return [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    `script-src ${scriptSrc}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https://lh3.googleusercontent.com https://avatars.githubusercontent.com https://raw.githubusercontent.com",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "media-src 'self'",
+    "frame-src 'self' https://www.youtube-nocookie.com https://open.spotify.com https://embed.podcasts.apple.com",
+    "worker-src 'self' blob:",
+    "manifest-src 'self'",
+    "upgrade-insecure-requests",
+  ].join("; ");
+}
+
+export function middleware(request: NextRequest): NextResponse {
+  // 128 random bits, base64-encoded. Uses Web Crypto + btoa (both
+  // available on every Next.js middleware runtime, including Edge —
+  // `Buffer` is not). The CSP only needs the value to be unguessable
+  // per request and to round-trip through HTTP headers; full base64
+  // padding is fine, no need for base64url.
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  let raw = "";
+  for (const byte of bytes) raw += String.fromCharCode(byte);
+  const nonce = btoa(raw);
+  const csp = buildCsp(nonce);
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  response.headers.set("Content-Security-Policy", csp);
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Skip paths that don't need CSP processing:
+     *  - /api          — route handlers set their own cookies, and
+     *                    middleware's NextResponse.next() merges +
+     *                    drops Set-Cookie headers on those responses.
+     *  - /_next/static — static bundle output
+     *  - /_next/image  — image optimizer
+     *  - /favicon.ico  — root favicon
+     *  - *.svg/png/... — static image files
+     */
+    "/((?!api|_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary

The `/web` subdirectory had no Content Security Policy — only browser-default
XSS protections. This PR ports the per-request-nonce + `strict-dynamic`
pattern from `lixiaolai.com`, plus the standard static security headers.

Action item #1 from `claude-plugins/dev-notes/2026-05-18-web-headache-audit.md`.

### Why this matters

- Any XSS sink (markdown rendering, comment HTML, OAuth profile fields,
  embedded media) is currently constrained only by the browser's default
  same-origin policy — no allowlist, no nonce, no `strict-dynamic`.
- The companion CSP pattern is battle-tested in `lixiaolai.com` (a year
  in production, no incidents) so we're not breaking new ground.

### Per-request flow

1. **`src/middleware.ts`** mints a 128-bit base64 nonce per request,
   builds the CSP, sets the `x-nonce` request header (Next.js
   propagates that onto every inline hydration script automatically),
   and attaches the CSP to the response.
2. **`src/app/(reader)/layout.tsx`** reads `x-nonce` back via
   `next/headers` and threads it into the inline FAB-popover-handler
   `<script>` tag.
3. **`next.config.mjs`** adds the static security headers (HSTS,
   X-Frame-Options, Referrer-Policy, Permissions-Policy with FLoC
   opt-out, COOP `same-origin`). CSP is deliberately **not** set in
   `headers()` — the per-request nonce can only come from middleware,
   and setting CSP in both layers makes browsers intersect the two
   policies and drop the nonce, breaking hydration.

### Allowlist rationale

| Directive | Hosts | Why |
|---|---|---|
| `img-src` | `lh3.googleusercontent.com`, `avatars.githubusercontent.com` | OAuth `session.user.image` |
| `img-src` | `raw.githubusercontent.com` | Markdown-rewritten images from GitHub-imported posts (`src/lib/markdown.ts:648`) |
| `frame-src` | `youtube-nocookie.com`, `open.spotify.com`, `embed.podcasts.apple.com` | Media embeds (`src/lib/embed-attrs.ts`) |

Vercel Analytics + Speed Insights inject their scripts via
`document.createElement` from within React's nonced bundle, so
`strict-dynamic` propagates trust automatically — no allowlist or
`nonce` prop is needed. (`@vercel/analytics` 2.0.1 doesn't expose a
`nonce` prop anyway.)

### Explicitly NOT done

- No COEP `require-corp` — that header is only useful for
  SharedArrayBuffer / multithreaded WASM, neither of which this app
  uses. Setting it would block every cross-origin asset without a
  matching CORP header.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `pnpm build` — clean, middleware compiled (33.8 kB)
- [x] `pnpm test` — 29 / 29 pass
- [x] Dev-server smoke test: `curl -I http://localhost:3000/` shows the
      CSP header with the correct nonce, and the same nonce appears on
      `<script>` tags in the rendered HTML
- [ ] Post-merge: verify in production DevTools that no CSP violation
      warnings appear on the home page, a long-form post (markdown
      embeds), and the settings page (OAuth avatar)
- [ ] If any third-party origin is missed, the failure mode is a clear
      browser console message — fix forward by adding the host to the
      relevant directive

## Rollback

`git revert <merge-commit>`. The three changes are self-contained and
share no code with anything else in the repo, so revert is clean.

## Audit reference

[`claude-plugins/dev-notes/2026-05-18-web-headache-audit.md`](../../claude-plugins/dev-notes/2026-05-18-web-headache-audit.md) §3 + Action #1.