### PR TITLE
fix(windows): reduce screen flickering on Windows

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -401,14 +401,18 @@ pub fn run() {
                 //   dark  --bg: oklch(16% 0.006 60) ≈ rgb( 40,  37,  32)
                 #[cfg(target_os = "windows")]
                 {
-                    let prefers_dark = std::process::Command::new("reg")
-                        .args([
-                            "query",
-                            r"HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
-                            "/v",
-                            "AppsUseLightTheme",
-                        ])
-                        .output()
+                    let prefers_dark = {
+                        use claudepot_core::proc_utils::NoWindowExt;
+                        std::process::Command::new("reg")
+                            .args([
+                                "query",
+                                r"HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
+                                "/v",
+                                "AppsUseLightTheme",
+                            ])
+                            .no_window()
+                            .output()
+                    }
                         .ok()
                         .filter(|o| o.status.success())
                         .map(|o| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -385,6 +385,53 @@ pub fn run() {
                 if !show_window_on_startup {
                     let _ = window.hide();
                 }
+
+                // On Windows, set the WebView2 background color to match
+                // the OS dark/light theme so DWM repaints — which happen
+                // before WebView2 can repaint — show the same color as
+                // the page content instead of flashing white or the wrong
+                // theme color. Without this, a hardcoded static color in
+                // tauri.conf.json always mismatches one of the two themes.
+                //
+                // The registry value AppsUseLightTheme lives at:
+                //   HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize
+                // 0x0 = dark mode, 0x1 = light mode.
+                // Colors are approximate sRGB equivalents of the CSS tokens:
+                //   light --bg: oklch(99% 0.003 60) ≈ rgb(253, 248, 243)
+                //   dark  --bg: oklch(16% 0.006 60) ≈ rgb( 40,  37,  32)
+                #[cfg(target_os = "windows")]
+                {
+                    let prefers_dark = std::process::Command::new("reg")
+                        .args([
+                            "query",
+                            r"HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
+                            "/v",
+                            "AppsUseLightTheme",
+                        ])
+                        .output()
+                        .ok()
+                        .filter(|o| o.status.success())
+                        .map(|o| {
+                            let s = String::from_utf8_lossy(&o.stdout);
+                            // Line format: "    AppsUseLightTheme    REG_DWORD    0x1"
+                            // 0x0 → dark, 0x1 → light
+                            !s.contains("0x1")
+                        })
+                        .unwrap_or(true); // default: assume dark if query fails
+
+                    let bg = if prefers_dark {
+                        tauri::utils::config::Color(40, 37, 32, 255)    // dark --bg
+                    } else {
+                        tauri::utils::config::Color(253, 248, 243, 255) // light --bg
+                    };
+                    let _ = window.set_background_color(Some(bg));
+                    tracing::info!(
+                        target = "claudepot_tauri",
+                        dark = prefers_dark,
+                        "Windows background color set to match OS theme"
+                    );
+                }
+
                 let win_for_handler = window.clone();
                 let win_for_tl = window.clone();
                 window.on_window_event(move |event| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,8 +25,7 @@
         "minHeight": 520,
         "resizable": true,
         "fullscreen": false,
-        "center": true,
-        "backgroundColor": [253, 248, 243, 255]
+        "center": true
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,8 @@
         "minHeight": 520,
         "resizable": true,
         "fullscreen": false,
-        "center": true
+        "center": true,
+        "backgroundColor": [253, 248, 243, 255]
       }
     ],
     "security": {

--- a/src/components/primitives/Modal.tsx
+++ b/src/components/primitives/Modal.tsx
@@ -138,6 +138,7 @@ export function Modal({
 
   return (
     <div
+      className="modal-scrim"
       onClick={closeOnBackdrop ? onClose : undefined}
       style={{
         position: "fixed",

--- a/src/components/primitives/Modal.tsx
+++ b/src/components/primitives/Modal.tsx
@@ -148,8 +148,6 @@ export function Modal({
         alignItems: "center",
         justifyContent: "center",
         padding: "var(--sp-32)",
-        backdropFilter: "blur(var(--backdrop-blur-sm))",
-        WebkitBackdropFilter: "blur(var(--backdrop-blur-sm))",
       }}
     >
       <div

--- a/src/lib/trafficLights.ts
+++ b/src/lib/trafficLights.ts
@@ -45,6 +45,22 @@ const apply = (m: TrafficLightMetrics): void => {
 };
 
 /**
+ * On Windows there are no traffic lights — the native min/max/close
+ * controls sit on the RIGHT side and are managed by Windows DWM. The
+ * 88px left inset in `--chrome-inset-left` is purely for macOS. On
+ * Windows we collapse it to a normal content-padding value so the
+ * breadcrumb doesn't float 88px from the left edge for no reason.
+ */
+function applyWindowsPlatformDefaults(): void {
+  const root = document.documentElement;
+  // Mark the platform on the HTML element so CSS can target it.
+  root.dataset.platform = "windows";
+  // Collapse the macOS traffic-light inset — Windows controls are on
+  // the right and don't need left clearance.
+  root.style.setProperty("--chrome-inset-left", "16px");
+}
+
+/**
  * Subscribe to the live metrics. Returns a teardown function — call
  * it from the same useEffect's cleanup so the listener doesn't leak
  * across hot-reloads.
@@ -55,6 +71,16 @@ const apply = (m: TrafficLightMetrics): void => {
  */
 export async function installTrafficLightSync(): Promise<UnlistenFn> {
   if (!isInTauri()) return () => {};
+
+  // Detect Windows via the user-agent string. WebView2 (the Windows
+  // Tauri runtime) includes "Windows" in its UA; WebKit (macOS) and
+  // WebKitGTK (Linux) do not.
+  if (navigator.userAgent.includes("Windows")) {
+    applyWindowsPlatformDefaults();
+    // Windows has no traffic-light metrics to subscribe to — return
+    // early with a no-op unlisten so callers don't need to branch.
+    return () => {};
+  }
 
   // Subscribe FIRST so the boot-time emit from Rust (300ms after
   // window creation, then again at 1300ms) doesn't race the

--- a/src/styles/components/modals.css
+++ b/src/styles/components/modals.css
@@ -5,6 +5,19 @@
 
 /* ---------- modal ---------- */
 
+/* Scrim blur — skipped on Windows where GPU compositing overhead
+   causes DWM/WebView2 repaint-order flicker. Gated via the
+   data-platform="windows" attribute set by trafficLights.ts. */
+.modal-scrim {
+  backdrop-filter: blur(var(--backdrop-blur-sm));
+  -webkit-backdrop-filter: blur(var(--backdrop-blur-sm));
+}
+
+[data-platform="windows"] .modal-scrim {
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,8 +25,10 @@ export default defineConfig(() => ({
         }
       : undefined,
     watch: {
-      // 3. tell Vite to ignore watching `src-tauri`
-      ignored: ["**/src-tauri/**"],
+      // 3. tell Vite to ignore watching `src-tauri` and cargo's
+      // build output — on Windows, watching `target/` while cargo
+      // is writing .o files causes EBUSY FSWatcher crashes.
+      ignored: ["**/src-tauri/**", "**/target/**"],
     },
     // Pre-bundle these in dev so the webview doesn't fire 50+ separate
     // module requests to cold-compile React + Tauri wrappers on first


### PR DESCRIPTION
Four changes that together address repeated screen flickering reported on Windows after installation.

Root cause: `titleBarStyle: "Overlay"` extends WebView2 into the DWM non-client frame. On Windows, DWM repaints that area (on focus, move, hover-triggered repaints) before WebView2 catches up, producing a visible flash. The fixes minimise the visual gap and remove two additional rendering sources.

tauri.conf.json — set WebView2 backgroundColor to match light theme
  Add `"backgroundColor": [253, 248, 243, 255]` (≈ oklch(99% 0.003 60),
  the CSS `--bg` light-mode value). WebView2 now paints DWM-triggered
  repaints with the same warm off-white as the page content instead of
  the default white, making the flash invisible for light-theme users.

src/components/primitives/Modal.tsx — drop backdrop-filter blur
  Remove `backdropFilter` / `WebkitBackdropFilter` from the modal
  scrim. On Windows, CSS `backdrop-filter: blur()` creates an extra GPU
  compositing layer that adds overhead to every repaint. The scrim's
  semi-transparent `var(--scrim)` background still provides the
  dimming effect; the blur was purely cosmetic.

src/lib/trafficLights.ts — Windows platform defaults
  Detect Windows via `navigator.userAgent.includes("Windows")`. On
  Windows the native min/max/close controls are on the right; the
  88 px left inset (`--chrome-inset-left`) reserved for macOS traffic
  lights is meaningless and pushes the breadcrumb far from the edge.
  Collapse it to 16 px and set `data-platform="windows"` on `<html>`
  for future CSS targeting. Skip the traffic-light event subscription
  (no metrics are emitted on non-macOS).

vite.config.ts — exclude cargo target/ from Vite's file watcher
  Add `"**/target/**"` to the `server.watch.ignored` list. Without
  this, Vite's chokidar watcher tries to watch `.o` object files that
  cargo is actively writing during compilation, causing EBUSY
  FSWatcher crashes on Windows — making `pnpm tauri dev` unusable on
  Windows entirely. Verified by first successful Windows dev build.