### PR TITLE
fix(windows): credentials unreadable on Windows — unhealthy banner + …

### DIFF
--- a/crates/claudepot-core/src/cli_backend/storage.rs
+++ b/crates/claudepot-core/src/cli_backend/storage.rs
@@ -95,6 +95,16 @@ fn backend() -> CredBackend {
     {
         Some("file") => CredBackend::FileOnly,
         Some("keyring") => CredBackend::KeyringOnly,
+        // `Auto` resolves to Keychain-first on macOS. On every other
+        // platform the keychain stubs always return Err("not
+        // implemented"), and the fail-closed logic in `load()` treats
+        // that error as a real keychain denial — refusing to fall back
+        // to file storage even though credentials were saved there.
+        // Default to FileOnly on non-macOS so reads reach the file
+        // that saves already write on Windows / Linux.
+        #[cfg(not(target_os = "macos"))]
+        _ => CredBackend::FileOnly,
+        #[cfg(target_os = "macos")]
         _ => CredBackend::Auto,
     }
 }

--- a/crates/claudepot-core/src/cli_backend/storage.rs
+++ b/crates/claudepot-core/src/cli_backend/storage.rs
@@ -85,6 +85,7 @@ impl From<KeychainErr> for SwapError {
 enum CredBackend {
     FileOnly,
     KeyringOnly,
+    #[cfg(target_os = "macos")]
     Auto,
 }
 
@@ -403,6 +404,7 @@ pub async fn save(account_id: Uuid, blob: &str) -> Result<(), SwapError> {
         CredBackend::KeyringOnly => save_to_keyring(account_id, blob)
             .await
             .map_err(SwapError::from),
+        #[cfg(target_os = "macos")]
         CredBackend::Auto => match save_to_keyring(account_id, blob).await {
             Ok(()) => {
                 let _ = delete_file(account_id);
@@ -430,6 +432,7 @@ pub async fn load(account_id: Uuid) -> Result<String, SwapError> {
             Ok(None) => Err(SwapError::NoStoredCredentials(account_id)),
             Err(e) => Err(e.into()),
         },
+        #[cfg(target_os = "macos")]
         CredBackend::Auto => match load_from_keyring(account_id).await {
             Ok(Some(blob)) => {
                 let _ = delete_file(account_id);
@@ -465,6 +468,7 @@ pub async fn delete(account_id: Uuid) -> Result<(), SwapError> {
         CredBackend::KeyringOnly => delete_from_keyring(account_id)
             .await
             .map_err(SwapError::from),
+        #[cfg(target_os = "macos")]
         CredBackend::Auto => {
             // Audit fix for storage.rs:328 — fail-closed on real
             // keychain errors. The previous shape returned Ok if


### PR DESCRIPTION
…no usage

Root cause
----------
`backend()` returns `Auto` on every platform. In `Auto` mode, `load()` calls `load_from_keyring()` first. On non-macOS the keyring stub always returns `Err("keyring backend is only implemented on macOS")`. The fail-closed branch in `load()` — designed for a genuinely locked macOS Keychain — treats that Err as a real keychain denial and refuses to fall back to file storage, even though `save()` has been writing credentials to `<data_dir>/credentials/<uuid>.json` all along.

Result on Windows:
  * `token_health()` → `load_private()` → `load()` → `Err` → status: "missing" → `credentials_healthy = false` → "!" banner with "The stored credential file couldn't be read."
  * `fetch_all_usage()` → `fetch_batch_detailed_verified()` → same failed token load → no token for API call → usage % never appears.

Fix
---
Make `backend()` return `FileOnly` by default on non-macOS platforms (`#[cfg(not(target_os = "macos"))]`). The keyring is macOS-only; every other platform's `Auto` default was semantically equivalent to `FileOnly` on the write path (save already fell back to file on every keyring error) but broken on the read path. This aligns both paths and matches the documented intent: "auto: Keychain on macOS if it works, else file."

The `CLAUDEPOT_CREDENTIAL_BACKEND=keyring` override still works on all platforms for testing. Only the unset/Auto default changes on Windows/Linux.