### PR TITLE
fix(windows): desktop swap fails with ERROR_SHARING_VIOLATION after quit

### DIFF
--- a/crates/claudepot-core/src/desktop_backend/swap.rs
+++ b/crates/claudepot-core/src/desktop_backend/swap.rs
@@ -34,7 +34,7 @@ pub fn snapshot(
             if let Some(parent) = dst.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            std::fs::copy(&src, &dst)?;
+            crate::fs_utils::copy_file_retried(&src, &dst)?;
         } else {
             // Missing in current session — purge any prior snapshot of
             // this item so the profile matches live state. Silent on
@@ -120,8 +120,7 @@ pub fn restore(
             let copy_result = if src.is_dir() {
                 copy_dir_recursive(&src, &dst).and_then(|_| std::fs::remove_dir_all(&src))
             } else {
-                std::fs::copy(&src, &dst)
-                    .map(|_| ())
+                crate::fs_utils::copy_file_retried(&src, &dst)
                     .and_then(|_| std::fs::remove_file(&src))
             };
             if let Err(e) = copy_result {

--- a/crates/claudepot-core/src/desktop_backend/windows.rs
+++ b/crates/claudepot-core/src/desktop_backend/windows.rs
@@ -1,5 +1,4 @@
 use crate::error::DesktopSwapError;
-use crate::proc_utils::NoWindowExt;
 use once_cell::sync::Lazy;
 use std::path::PathBuf;
 use std::sync::RwLock;
@@ -74,7 +73,6 @@ fn discover_package_family() -> Option<String> {
             // be selected instead of Claude Desktop itself.
             "(Get-AppxPackage | Where-Object { $_.PackageFamilyName -like 'Claude_*' } | Select-Object -First 1).PackageFamilyName",
         ])
-        .no_window()
         .output();
     if let Ok(out) = ps {
         if out.status.success() {
@@ -320,7 +318,6 @@ impl super::DesktopPlatform for WindowsDesktop {
         // profile on next launch.
         let _ = tokio::process::Command::new("taskkill")
             .args(["/IM", "Claude.exe", "/T"])
-            .no_window()
             .output()
             .await
             .map_err(DesktopSwapError::Io)?;
@@ -367,7 +364,6 @@ impl super::DesktopPlatform for WindowsDesktop {
         // nothing was launched, and the switch reported success.
         let out = tokio::process::Command::new("explorer.exe")
             .arg(format!("shell:AppsFolder\\{aumid}"))
-            .no_window()
             .output()
             .await
             .map_err(DesktopSwapError::Io)?;

--- a/crates/claudepot-core/src/desktop_backend/windows.rs
+++ b/crates/claudepot-core/src/desktop_backend/windows.rs
@@ -1,4 +1,5 @@
 use crate::error::DesktopSwapError;
+use crate::proc_utils::NoWindowExt;
 use once_cell::sync::Lazy;
 use std::path::PathBuf;
 use std::sync::RwLock;
@@ -73,6 +74,7 @@ fn discover_package_family() -> Option<String> {
             // be selected instead of Claude Desktop itself.
             "(Get-AppxPackage | Where-Object { $_.PackageFamilyName -like 'Claude_*' } | Select-Object -First 1).PackageFamilyName",
         ])
+        .no_window()
         .output();
     if let Ok(out) = ps {
         if out.status.success() {
@@ -302,9 +304,7 @@ impl super::DesktopPlatform for WindowsDesktop {
             // can outlive Claude.exe briefly after taskkill /T. Declaring the
             // app "stopped" while helpers still run causes ERROR_SHARING_VIOLATION
             // (os error 32) in the subsequent snapshot/restore.
-            name == "Claude.exe"
-                || name.starts_with("Claude Helper")
-                || name == "claude.exe"
+            name == "Claude.exe" || name.starts_with("Claude Helper")
         })
     }
 
@@ -320,6 +320,7 @@ impl super::DesktopPlatform for WindowsDesktop {
         // profile on next launch.
         let _ = tokio::process::Command::new("taskkill")
             .args(["/IM", "Claude.exe", "/T"])
+            .no_window()
             .output()
             .await
             .map_err(DesktopSwapError::Io)?;
@@ -366,6 +367,7 @@ impl super::DesktopPlatform for WindowsDesktop {
         // nothing was launched, and the switch reported success.
         let out = tokio::process::Command::new("explorer.exe")
             .arg(format!("shell:AppsFolder\\{aumid}"))
+            .no_window()
             .output()
             .await
             .map_err(DesktopSwapError::Io)?;

--- a/crates/claudepot-core/src/desktop_backend/windows.rs
+++ b/crates/claudepot-core/src/desktop_backend/windows.rs
@@ -294,9 +294,18 @@ impl super::DesktopPlatform for WindowsDesktop {
     async fn is_running(&self) -> bool {
         let mut sys = sysinfo::System::new();
         sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
-        sys.processes()
-            .values()
-            .any(|p| p.name().to_string_lossy() == "Claude.exe")
+        sys.processes().values().any(|p| {
+            let name = p.name().to_string_lossy();
+            // Check the main process AND Electron helper variants.
+            // Helper processes (GPU, Renderer, Utility) hold file locks on
+            // the Chromium profile (Cookies, Local Storage, IndexedDB) and
+            // can outlive Claude.exe briefly after taskkill /T. Declaring the
+            // app "stopped" while helpers still run causes ERROR_SHARING_VIOLATION
+            // (os error 32) in the subsequent snapshot/restore.
+            name == "Claude.exe"
+                || name.starts_with("Claude Helper")
+                || name == "claude.exe"
+        })
     }
 
     async fn quit(&self) -> Result<(), DesktopSwapError> {

--- a/crates/claudepot-core/src/fs_utils.rs
+++ b/crates/claudepot-core/src/fs_utils.rs
@@ -31,10 +31,44 @@ pub fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
         } else if ft.is_dir() {
             copy_dir_recursive(&entry.path(), &dst_path)?;
         } else {
-            std::fs::copy(entry.path(), &dst_path)?;
+            copy_file_retried(&entry.path(), &dst_path)?;
         }
     }
     Ok(())
+}
+
+/// Copy a single file, retrying on Windows ERROR_SHARING_VIOLATION (os error 32).
+///
+/// MSIX-virtualized Chromium profile files (Cookies, Local Storage, IndexedDB)
+/// can stay transiently locked for up to ~2 s after the Electron process tree
+/// exits, even after `is_running()` returns false. The 1 s post-quit settle
+/// delay in `desktop_prelude` handles the common case; this retry is the
+/// belt-and-suspenders fallback for slower machines or heavier profiles.
+pub fn copy_file_retried(src: &Path, dst: &Path) -> std::io::Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        const MAX_RETRIES: u32 = 4;
+        for attempt in 0..MAX_RETRIES {
+            match std::fs::copy(src, dst) {
+                Ok(_) => return Ok(()),
+                Err(e) if attempt + 1 < MAX_RETRIES && e.raw_os_error() == Some(32) => {
+                    tracing::debug!(
+                        "copy_file_retried: sharing violation on {}, retry {}/{}",
+                        src.display(),
+                        attempt + 1,
+                        MAX_RETRIES - 1
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        unreachable!()
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        std::fs::copy(src, dst).map(|_| ())
+    }
 }
 
 /// Atomically write `contents` to `path`: write to a sibling temp file,

--- a/crates/claudepot-core/src/services/desktop_service.rs
+++ b/crates/claudepot-core/src/services/desktop_service.rs
@@ -647,6 +647,12 @@ pub(crate) async fn desktop_prelude<'a>(
     if platform.is_running().await {
         tracing::info!("Desktop op prelude — quitting Claude Desktop");
         platform.quit().await?;
+        // Windows: MSIX container virtualization releases file handles
+        // asynchronously after the process tree exits. Without this gap,
+        // snapshot/restore immediately tries to copy Cookies / Local Storage /
+        // IndexedDB and hits ERROR_SHARING_VIOLATION (os error 32).
+        #[cfg(target_os = "windows")]
+        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
     }
 
     Ok(DesktopPrelude {


### PR DESCRIPTION
## Summary

  - Extend `is_running()` to include Electron helper processes (GPU, Renderer,
    Utility) that hold file locks on the Chromium profile after `Claude.exe` exits
  - Add a 1 s post-quit settle delay on Windows so the MSIX container can release
    file handles before snapshot/restore begins
  - Add `copy_file_retried` (4 attempts × 500 ms) as a belt-and-suspenders
    fallback for slower machines or heavier profiles that slip past the settle gap

  ## Root cause

  `taskkill /T` terminates the main process tree but Electron helper processes
  can outlive `Claude.exe` briefly, keeping Cookies, Local Storage, and IndexedDB
  locked. The prior `is_running()` check only looked for `Claude.exe`, so the
  prelude declared the app stopped while helpers still held locks, causing
  `ERROR_SHARING_VIOLATION` (os error 32) on the subsequent file copy.

  ## Test plan

  - [ ] Swap Desktop profile on Windows — confirm no `ERROR_SHARING_VIOLATION` in logs
  - [ ] Swap on macOS — confirm no regression (`copy_file_retried` is no-op on non-Windows)
  - [ ] `cargo test -p claudepot-core` passes on Windows