### PR TITLE
fix(build): make fresh-clone build work (pnpm esbuild approval + Tauri sidecar staging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ cd claudepot-app
 cargo build -p claudepot-cli --release
 # Built binary: ./target/release/claudepot
 
+# Stage the CLI as the GUI's bundled sidecar (Tauri `externalBin`).
+# Required before any GUI build or `tauri dev` run — Tauri validates
+# this slot at compile time.
+mkdir -p src-tauri/binaries
+cp target/release/claudepot \
+   "src-tauri/binaries/claudepot-cli-$(rustc -Vv | sed -n 's/host: //p')"
+
 # Desktop app
 pnpm install
 pnpm tauri build --no-bundle      # builds a binary, no installer

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+# pnpm 10+ blocks dependency build scripts by default. The frontend's
+# vite toolchain pulls in esbuild, whose postinstall must run for the
+# bundle build (`pnpm build`, `pnpm tauri build`) to succeed. Without
+# this, a fresh `pnpm install` aborts with ERR_PNPM_IGNORED_BUILDS.
+# This file also makes the repo root a pnpm workspace root; web/ carries
+# its own pnpm-workspace.yaml so it stays an independent install.
+allowBuilds:
+  esbuild: true

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+# Anchors web/ as its own pnpm workspace root. The repo-root
+# pnpm-workspace.yaml (which approves esbuild's build script for the
+# Tauri app's frontend) would otherwise capture web/ as a non-member of
+# that workspace — pnpm run from here would install the ROOT package
+# instead of this app, breaking the Vercel deploy (Root Directory =
+# web/, full repo checked out). Keeping a pnpm-workspace.yaml here stops
+# pnpm's upward search so web/ resolves to itself. web/ keeps its own
+# pnpm-lock.yaml and pinned packageManager (pnpm 10.30.3); it is NOT a
+# member of the root Tauri workspace. See AGENTS.md "## Web".


### PR DESCRIPTION
## Problem

Following the README build steps on a clean clone fails in two places — both outside Rust (`cargo build -p claudepot-cli --release` is fine):

1. **`pnpm install` aborts** with `ERR_PNPM_IGNORED_BUILDS: esbuild`. pnpm 10+/11 blocks dependency build scripts by default; vite's esbuild needs its postinstall, and pnpm 11 treats the ignored build as a fatal error (exit 1), so `pnpm install` / `pnpm build` / `pnpm tauri build` all abort before compiling. This only worked locally because of an **uncommitted** `pnpm-workspace.yaml`.
2. **`pnpm tauri build` aborts** with `resource path 'binaries/claudepot-cli-aarch64-apple-darwin' doesn't exist`. `tauri.conf.json` declares the CLI as an `externalBin` sidecar, but nothing in the README tells you to stage it. `release.yml` already does this in CI.

## Changes

- **`pnpm-workspace.yaml`** (new) — `allowBuilds: { esbuild: true }`. pnpm 11 only honors build approval from `pnpm-workspace.yaml` (verified it ignores the same key in `package.json` and `.npmrc`).
- **`web/pnpm-workspace.yaml`** (new) — anchors `web/` as its own pnpm root. Without it, the new root workspace file **captures `web/`** as a non-member: `pnpm install` from `web/` installs the root package and leaves `web/node_modules` empty, which would break the Vercel deploy (Root Directory = `web/`, full repo checked out). Verified. `web/` keeps its own lockfile and pinned `pnpm@10.30.3`.
- **`README.md`** — documents staging the CLI into `src-tauri/binaries/claudepot-cli-<triple>` before any GUI build/dev run, mirroring `release.yml`'s externalBin step. The binary is a gitignored build artifact, not committed.

## Verification (clean tree, in order)

`cargo build -p claudepot-cli --release` ✓ → `pnpm install` ✓ (no error) → `pnpm build` ✓ → stage sidecar → `pnpm tauri build --no-bundle` ✓ (`claudepot-tauri`, 26 MB). CLI runs: `claudepot 0.1.51`.

https://claude.ai/code/session_01YWBP8rh3r23nzxqqjZDQSC