### PR TITLE
tooling: single-source CI invariants + local preflight gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,88 +64,16 @@ jobs:
         run: cargo xtask verify-cc-parity
 
       # ─── Architectural invariants ─────────────────────────────
-      # Three grep-based tripwires. Each protects an invariant
-      # called out in dev-docs/codex-plans/20260515-1130-shared-memory.md
-      # that the type system can't enforce on its own.
-
-      - name: Invariant — codex_session parser is a single leaf
-        # The Codex rollout parser is a neutral leaf in the
-        # workspace. The decoder pattern is `"session_meta" =>`
-        # in a match arm — flag that anywhere outside the
-        # codex_session/ module. We deliberately ignore plain
-        # string occurrences (test fixtures, comments) because
-        # those aren't parsers.
-        run: |
-          set -euo pipefail
-          violators=$(grep -rnE '"session_meta"[[:space:]]*=>' crates/ --include='*.rs' || true)
-          unexpected=$(echo "$violators" | grep -v 'crates/claudepot-core/src/codex_session/' || true)
-          if [ -n "$unexpected" ]; then
-            echo "::error::Codex rollout decoder found outside codex_session/:"
-            echo "$unexpected"
-            echo
-            echo "Codex rollout parsing (matching on 'session_meta' record type)"
-            echo "must live in claudepot-core/src/codex_session/. Duplicating it"
-            echo "elsewhere leads to two parsers drifting in parallel — exactly"
-            echo "what the plan's leaf-module discipline prevents."
-            exit 1
-          fi
-
-      - name: Invariant — raw text SELECTs are confined to redaction-aware paths
-        # R9 of the plan: every read of transcript-content columns
-        # must go through redaction::apply before crossing an
-        # emission boundary. This grep catches new SELECTs that
-        # skip the redaction step.
-        run: |
-          set -euo pipefail
-          patterns='SELECT.*user_text|SELECT.*assistant_text|SELECT.*tool_result_text'
-          # session/search/mod.rs (search_index / _infix / _tool_calls)
-          # reads these columns only to locate the match and build the
-          # snippet; every emitted snippet goes through redact_secrets —
-          # the same redactor the file's search_rows JSONL path already
-          # uses — and the snippet_text fallback is pre-redacted at rest.
-          violators=$(grep -rlE "$patterns" crates/ --include='*.rs' || true)
-          unexpected=$(echo "$violators" \
-            | grep -v 'crates/claudepot-core/src/shared_memory/search.rs' \
-            | grep -v 'crates/claudepot-core/src/shared_memory/read.rs' \
-            | grep -v 'crates/claudepot-core/src/shared_memory/indexer.rs' \
-            | grep -v 'crates/claudepot-core/src/shared_memory/schema.rs' \
-            | grep -v 'crates/claudepot-core/src/shared_memory/claude_exchanges.rs' \
-            | grep -v 'crates/claudepot-core/src/session/search/mod.rs' \
-            || true)
-          if [ -n "$unexpected" ]; then
-            echo "::error::Raw text SELECTs found outside redaction-aware paths:"
-            echo "$unexpected"
-            echo
-            echo "Every emission of exchanges.user_text / assistant_text /"
-            echo "tool_calls.tool_result_text must go through redaction::apply"
-            echo "before crossing a UI / export / log / MCP boundary."
-            echo "Extend the allowlist in .github/workflows/ci.yml if adding"
-            echo "a legitimate reader, and document why redaction is handled"
-            echo "at the call site."
-            exit 1
-          fi
-
-      - name: Invariant — no bare matches!() statements
-        # H2 of the grill report: a bare matches!(err, Variant);
-        # returns bool and discards it. Tests pass against any
-        # error variant. The grill round caught six such sites;
-        # this gate prevents regression.
-        #
-        # The signal is a `matches!()` call used as a *statement*
-        # (followed by `;`), not as an expression value. Match
-        # arms, return values, and let bindings have no trailing
-        # semicolon and are correctly excluded.
-        run: |
-          set -euo pipefail
-          violators=$(grep -rnE '^[[:space:]]+matches!\(.*\);' crates/ --include='*.rs' || true)
-          if [ -n "$violators" ]; then
-            echo "::error::Bare matches!() statements found:"
-            echo "$violators"
-            echo
-            echo "A bare matches!() returns bool and discards it — the test"
-            echo "passes against any variant. Wrap in assert!(matches!(...))."
-            exit 1
-          fi
+      # Grep-based tripwires for rules the type system can't enforce
+      # (Codex parser leaf, raw-text-SELECT redaction confinement, no
+      # bare matches!() statements). Each is documented in the script.
+      #
+      # Extracted to scripts/repo-invariants.sh so the local pre-push
+      # gate (scripts/preflight.sh) runs the EXACT same checks and can't
+      # drift from CI — the drift that let a guard failure slip a
+      # macOS-local run and surface only in CI (v0.1.53).
+      - name: Architectural invariants
+        run: bash scripts/repo-invariants.sh
 
   test:
     name: Tests (${{ matrix.os }})

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,10 @@ typescript
 !/scripts/regen-icons.sh
 !/scripts/pre-push
 !/scripts/install-hooks.sh
+# Local CI gate + its shared invariant checks. repo-invariants.sh is
+# invoked by .github/workflows/ci.yml, so it MUST be committed.
+!/scripts/preflight.sh
+!/scripts/repo-invariants.sh
 dev-docs/
 
 # Per-clone validator hosts for scripts/pre-push (internal hostnames —

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# preflight.sh — run the CI gate locally before you push.
+#
+# WHY THIS EXISTS
+# `cargo test` / `cargo clippy` on macOS is NOT the CI gate. CI also runs
+# grep-based architectural guards (scripts/repo-invariants.sh) that no
+# cargo/pnpm command covers, and a newer clippy on Linux catches lints a
+# macOS-local clippy misses. In v0.1.53 a guard failure sailed past a
+# clean local run and only turned up red in CI, mid-release. This script
+# runs the SAME checks CI does so that doesn't happen again.
+#
+# It mirrors .github/workflows/ci.yml's `Format / Clippy (Linux)` +
+# frontend jobs. It does NOT reproduce the cross-platform test matrix or
+# the Linux-specific clippy toolchain — only CI (or a PR) can. Treat a
+# green preflight as necessary, not sufficient: it catches the cheap,
+# common failures locally; the PR/CI run is still the source of truth.
+#
+# RELEASE ORDER (what "doing it right" looks like)
+#   1. Feature work on a branch → open a PR. CI validates the full
+#      matrix + guards BEFORE anything reaches main. Fix red on the PR.
+#   2. Merge the green PR → main stays green by construction.
+#   3. On a clean main: run `bump`, fill CHANGELOG.md, commit the bump.
+#   4. Tag vX.Y.Z → push tag. The pre-push hook validates Linux+Windows;
+#      only use --no-verify if a validator host is down AND CI already
+#      proved this exact SHA green.
+#   5. release.yml builds + signs installers → smoke-test a packaged
+#      artifact (codesign/spctl + launch), then announce.
+#   Run THIS script before every push in step 1.
+#
+# Usage:
+#   scripts/preflight.sh           # full gate
+#   scripts/preflight.sh --rust    # skip the frontend (pnpm) checks
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+rust_only=0
+[ "${1:-}" = "--rust" ] && rust_only=1
+
+step() { printf '\n\033[1;36m▶ %s\033[0m\n' "$1"; }
+ok()   { printf '\033[1;32m✓ %s\033[0m\n' "$1"; }
+
+# Mirror ci.yml's package set exactly (note: includes xtask).
+step "rustfmt --check"
+cargo fmt --check -p claudepot-core -p claudepot-cli -p xtask
+ok "formatting"
+
+step "clippy --all-targets -D warnings"
+cargo clippy --all-targets -p claudepot-core -p claudepot-cli -p xtask -- -D warnings
+ok "clippy"
+
+step "CC-parity fixtures"
+cargo xtask verify-cc-parity
+ok "cc-parity"
+
+step "architectural invariants (scripts/repo-invariants.sh)"
+bash scripts/repo-invariants.sh
+ok "invariants"
+
+step "workspace tests"
+cargo test --workspace
+ok "rust tests"
+
+if [ "$rust_only" -eq 0 ]; then
+  step "frontend typecheck + build"
+  pnpm build
+  ok "frontend build"
+
+  step "frontend tests (vitest)"
+  pnpm test
+  ok "frontend tests"
+fi
+
+printf '\n\033[1;32m✓ preflight clean — safe to push\033[0m\n'

--- a/scripts/repo-invariants.sh
+++ b/scripts/repo-invariants.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Architectural invariants — grep-based tripwires for rules the type
+# system can't enforce. Each mirrors a decision in
+# dev-docs/codex-plans/20260515-1130-shared-memory.md.
+#
+# SINGLE SOURCE OF TRUTH. Both callers run this exact file:
+#   - .github/workflows/ci.yml  (Format / Clippy (Linux) job)
+#   - scripts/preflight.sh      (the local pre-push gate)
+# so "green locally" and "green in CI" can't diverge on these checks —
+# which is exactly how a guard failure once slipped past a macOS-local
+# run and only surfaced in CI (v0.1.53).
+#
+# Reports EVERY violation (not just the first) and exits non-zero if any
+# fired. No side effects; safe to run anytime from the repo root.
+set -euo pipefail
+
+fail=0
+
+# ── 1. Codex rollout parser is a single leaf ─────────────────────────
+# The decoder pattern is `"session_meta" =>` in a match arm; it must
+# live only in codex_session/. Two parsers drifting in parallel is the
+# failure the leaf-module discipline prevents. Plain string occurrences
+# (fixtures, comments) are intentionally ignored — they aren't parsers.
+violators=$(grep -rnE '"session_meta"[[:space:]]*=>' crates/ --include='*.rs' || true)
+unexpected=$(echo "$violators" | grep -v 'crates/claudepot-core/src/codex_session/' || true)
+if [ -n "$unexpected" ]; then
+  echo "::error::Codex rollout decoder found outside codex_session/:"
+  echo "$unexpected"
+  echo "  Codex rollout parsing must live in claudepot-core/src/codex_session/."
+  echo
+  fail=1
+fi
+
+# ── 2. Raw text SELECTs confined to redaction-aware paths ────────────
+# R9: every read of transcript-content columns must be redacted before
+# it crosses an emission boundary. New SELECTs of these columns land in
+# a file that redacts at the call site — extend the allowlist below and
+# say why, exactly as this message directs.
+patterns='SELECT.*user_text|SELECT.*assistant_text|SELECT.*tool_result_text'
+violators=$(grep -rlE "$patterns" crates/ --include='*.rs' || true)
+# session/search/mod.rs (search_index / _infix / _tool_calls) reads these
+# columns only to locate the match and build the snippet; every emitted
+# snippet goes through redact_secrets — the same redactor the file's
+# search_rows JSONL path already uses — and the snippet_text fallback is
+# pre-redacted at rest.
+unexpected=$(echo "$violators" \
+  | grep -v 'crates/claudepot-core/src/shared_memory/search.rs' \
+  | grep -v 'crates/claudepot-core/src/shared_memory/read.rs' \
+  | grep -v 'crates/claudepot-core/src/shared_memory/indexer.rs' \
+  | grep -v 'crates/claudepot-core/src/shared_memory/schema.rs' \
+  | grep -v 'crates/claudepot-core/src/shared_memory/claude_exchanges.rs' \
+  | grep -v 'crates/claudepot-core/src/session/search/mod.rs' \
+  || true)
+if [ -n "$unexpected" ]; then
+  echo "::error::Raw text SELECTs found outside redaction-aware paths:"
+  echo "$unexpected"
+  echo "  Every emission of exchanges.user_text / assistant_text /"
+  echo "  tool_calls.tool_result_text must go through redaction before a"
+  echo "  UI / export / log / MCP boundary. Extend the allowlist in this"
+  echo "  script if adding a legitimate reader, and say why redaction is"
+  echo "  handled at the call site."
+  echo
+  fail=1
+fi
+
+# ── 3. No bare matches!() statements ─────────────────────────────────
+# A bare `matches!(err, Variant);` returns bool and discards it — the
+# test then passes against any variant. Wrap in assert!(matches!(...)).
+# The signal is matches!() as a *statement* (trailing `;`); match arms,
+# returns, and let-bindings have no trailing semicolon and are excluded.
+violators=$(grep -rnE '^[[:space:]]+matches!\(.*\);' crates/ --include='*.rs' || true)
+if [ -n "$violators" ]; then
+  echo "::error::Bare matches!() statements found:"
+  echo "$violators"
+  echo "  A bare matches!() discards its bool — wrap in assert!(matches!(...))."
+  echo
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi
+echo "repo invariants: clean"


### PR DESCRIPTION
## Why

During the **v0.1.53** release, CI's `Format / Clippy (Linux)` job went red *after* a clean macOS-local run. The failure wasn't clippy or a platform bug — every test matrix passed — it was a repo security guard (raw-text-SELECT redaction confinement) that lives only in `ci.yml` as an inline grep. No `cargo`/`pnpm` command covers those guards, so the failure only surfaced after a push, mid-release.

This closes that gap: a local gate that runs the **exact** checks CI does, sharing one source so it can't drift.

## What

- **`scripts/repo-invariants.sh`** — the three grep tripwires (Codex parser leaf · raw-text-SELECT redaction confinement · no bare `matches!()`) lifted verbatim out of `ci.yml` into one runnable file.
- **`scripts/preflight.sh`** — the full local CI-equivalent gate: `fmt --check`, `clippy --all-targets` (incl. `xtask`), cc-parity, the invariants, `cargo test --workspace`, `pnpm build`, `vitest`. Its header also documents the correct PR-gated release order.
- **`ci.yml`** — the `Format / Clippy` job now calls `scripts/repo-invariants.sh` instead of inlining the three guards, so local and CI can't diverge.
- **`.gitignore`** — re-include the two scripts (the repo ignores `scripts/*` by default; `repo-invariants.sh` is invoked by CI so it must be committed).

## Verified

- Extraction is faithful: a planted violation of **all three** guards (including the redaction guard) is still caught, exit 1.
- `scripts/preflight.sh` runs **green** on this branch (744 frontend tests + all Rust gates).
- `ci.yml` is valid YAML; guards pass on the clean tree.

Follow-up to the v0.1.53 release — no product code changes.