### PR TITLE
project move: migrate + detect plugin bindings (P10)

### DIFF
--- a/.claude/rules/cc-state-move-blast-radius.md
+++ b/.claude/rules/cc-state-move-blast-radius.md
@@ -1,0 +1,70 @@
+# CC state that a project move must migrate — the blast radius
+
+Claude Code stores per-project state in **two shapes**:
+
+1. **Inside the project directory** (`.claude/settings.json`,
+   `.mcp.json`, …) — travels automatically when the directory moves.
+2. **In global files keyed by the project's absolute path** — does
+   **not** travel. Every one of these is a move landmine: rename the
+   project and the binding is left pointing at a path that no longer
+   exists.
+
+Shape 2 is the whole problem. The authoritative list below was
+established empirically (grep the old path across all of `~/.claude`
+after a real move; see the v0.1.53 plugin-binding incident). It is the
+target set for `claudepot_core::project::move_project`'s phases **and**
+for the staleness detectors.
+
+## The path-keyed global state (and its owning phase)
+
+| Global file | Keyed by | Migrated by |
+|---|---|---|
+| `projects/<slug>/*.jsonl` (transcripts) | sanitized abs path (dir name) | P4 (dir rename) + P6 (`cwd` fields) |
+| `history.jsonl` | abs path | P5 |
+| `~/.claude.json` `projects[<abs path>]` | abs path (map key) | P7 |
+| auto-memory dir | sanitized git-root path | P8 |
+| `<proj>/.claude/settings.json` `autoMemoryDirectory` | abs path (value) | P9 |
+| `plugins/installed_plugins.json` `projectPath` | abs path (field) | **P10** |
+
+Verified **not** path-keyed (safe across a move): `state.db` (keyed by
+session UUID). Re-verify if CC's schema changes.
+
+## The invariant
+
+**Every global, path-keyed piece of CC state MUST have (a) a
+`move_project` phase that migrates it, and (b) a staleness detector
+that finds it after an *external* move.** One without the other is a
+half-fix:
+
+- Phase without detector → only helps when the move goes through
+  `claudepot project move`. Users move with Finder / `mv` / `git`,
+  which bypasses every phase. (This is how the plugin bug reached a
+  user: the move was manual, so P4–P9 never ran, and there was no P10
+  at all.)
+- Detector without phase → surfaces the breakage but can't repair it.
+
+Current detectors:
+
+- Transcripts → `session::move_::detect_orphaned_projects` (slug whose
+  `cwd` is gone) → repair via `project move <old> <new>`.
+- Plugins → `project::detect_stale_plugin_bindings` (`projectPath`
+  gone) → CLI `project plugin-bindings` → repair via `project move`.
+
+`history.jsonl` and the `~/.claude.json` key are repaired by the same
+`project move <old> <new>` reconcile (AlreadyMoved + `--merge`), so
+they need no separate detector — but any NEW path-keyed file does.
+
+## When you add a new path-keyed global CC file
+
+1. Add a `move_project` phase (`Pn`) that rewrites it. Reuse
+   `project_rewrite::rewrite_strings_in_value_pub` (boundary rule) for
+   JSON, and snapshot before mutating (see P7/P10).
+2. Add it to the table above.
+3. Add a staleness detector (or fold it into the `project move`
+   AlreadyMoved reconcile and note that here).
+4. Cover all four path shapes in tests
+   (`/Users/…`, `C:\…`, `\\server\share\…`, `\\?\C:\…`) per
+   `rules/paths.md`.
+5. Wire the phase into the dry-run plan, the CLI result, and the GUI
+   progress map (`projectMoveProgress.tsx`) — a phase that isn't
+   surfaced everywhere the others are is a review finding.

--- a/crates/claudepot-cli/src/commands/project.rs
+++ b/crates/claudepot-cli/src/commands/project.rs
@@ -108,6 +108,7 @@ fn format_relative_time(time: SystemTime) -> String {
 // private items in Rust).
 mod clean;
 mod list;
+mod plugin_bindings;
 mod remove;
 mod rename;
 mod repair;
@@ -117,6 +118,7 @@ mod trash;
 // these names.
 pub use clean::clean;
 pub use list::{list, show};
+pub use plugin_bindings::plugin_bindings;
 pub use remove::remove;
 pub use rename::{move_project, MoveArgs};
 pub use repair::{repair, RepairArgs};

--- a/crates/claudepot-cli/src/commands/project/plugin_bindings.rs
+++ b/crates/claudepot-cli/src/commands/project/plugin_bindings.rs
@@ -1,0 +1,63 @@
+//! `plugin-bindings` verb — read-only health check over the global
+//! plugin registry (`~/.claude/plugins/installed_plugins.json`).
+//!
+//! Reports project-scoped plugin bindings whose `projectPath` no longer
+//! exists on disk — the plugin-side symptom of a project moved outside
+//! `claudepot project move` (Finder / `mv` / `git`). It is the plugin
+//! dimension that `session list-orphans` (transcripts only) doesn't
+//! cover. The fix it points at — `claudepot project move <old> <new>` —
+//! runs P10 and repoints the bindings.
+//!
+//! Sub-module of `commands/project.rs`; see that file's header.
+
+use super::*;
+
+pub fn plugin_bindings(ctx: &AppContext) -> Result<()> {
+    let config_dir = paths::claude_config_dir();
+    let registry = config_dir.join("plugins").join("installed_plugins.json");
+    let stale = project::detect_stale_plugin_bindings(&registry)
+        .context("failed to scan installed_plugins.json")?;
+
+    if ctx.json {
+        // Emit a stable, scriptable shape.
+        let rows: Vec<_> = stale
+            .iter()
+            .map(|b| {
+                serde_json::json!({
+                    "plugin": b.plugin,
+                    "project_path": b.project_path,
+                    "scope": b.scope,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+
+    if stale.is_empty() {
+        println!("All project-scoped plugin bindings resolve to existing directories.");
+        return Ok(());
+    }
+
+    println!(
+        "{} stale plugin binding{} \u{2014} projectPath no longer exists on disk:",
+        stale.len(),
+        if stale.len() == 1 { "" } else { "s" }
+    );
+    println!();
+    for b in &stale {
+        println!("  {} [{}]", b.plugin, b.scope);
+        println!("    \u{21b3} {}", b.project_path);
+    }
+    println!();
+    println!(
+        "These plugins were installed for a project directory that is gone \
+         (moved or deleted)."
+    );
+    println!(
+        "If the project MOVED, repoint every binding by running:\n  \
+         claudepot project move <old-path> <new-path>"
+    );
+
+    Ok(())
+}

--- a/crates/claudepot-cli/src/commands/project/rename.rs
+++ b/crates/claudepot-cli/src/commands/project/rename.rs
@@ -159,6 +159,17 @@ pub fn move_project(ctx: &AppContext, args: MoveArgs) -> Result<()> {
             "  \u{2713} Project-local .claude/settings.json autoMemoryDirectory rewritten (P9)"
         );
     }
+    if result.plugin_bindings_rewritten > 0 {
+        println!(
+            "  \u{2713} Repointed {} plugin binding{} in installed_plugins.json (P10)",
+            result.plugin_bindings_rewritten,
+            if result.plugin_bindings_rewritten == 1 {
+                ""
+            } else {
+                "s"
+            },
+        );
+    }
 
     for warning in &result.warnings {
         println!("  \u{26a0} {}", warning);

--- a/crates/claudepot-cli/src/main.rs
+++ b/crates/claudepot-cli/src/main.rs
@@ -699,6 +699,10 @@ enum ProjectAction {
         #[command(flatten)]
         args: commands::project::RepairArgs,
     },
+    /// List project-scoped plugin bindings whose project directory no
+    /// longer exists (e.g. after an external move). Fix with
+    /// `project move <old> <new>`.
+    PluginBindings,
 }
 
 #[derive(Subcommand)]
@@ -1035,6 +1039,7 @@ async fn main() -> Result<()> {
                 }
             },
             ProjectAction::Repair { args } => commands::project::repair(&ctx, args)?,
+            ProjectAction::PluginBindings => commands::project::plugin_bindings(&ctx)?,
         },
         Commands::Agent { action } => match *action {
             AgentAction::Draft {

--- a/crates/claudepot-core/src/project/config_rewrite.rs
+++ b/crates/claudepot-core/src/project/config_rewrite.rs
@@ -302,6 +302,230 @@ fn write_config_atomic(path: &Path, value: &Value) -> Result<(), ProjectError> {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 10: global plugin registry (plugins/installed_plugins.json)
+// ---------------------------------------------------------------------------
+
+/// Outcome of a Phase 10 rewrite.
+#[derive(Debug, Default)]
+pub struct PluginRegistryRewriteResult {
+    /// Number of `projectPath` bindings rewritten from `old_path` (or a
+    /// descendant) to `new_path`.
+    pub bindings_rewritten: usize,
+    /// Snapshot of the pre-rewrite registry file, written only when at
+    /// least one binding changed. `None` on a no-op.
+    pub snapshot_path: Option<PathBuf>,
+}
+
+/// Rewrite project-scoped plugin bindings in
+/// `<config_dir>/plugins/installed_plugins.json` on a project move.
+///
+/// Claude Code records every installed plugin as
+/// `plugins[<name>][] = { scope, projectPath, installPath, … }`. For a
+/// `scope:"project"` (or `"local"`) install, `projectPath` is the
+/// ABSOLUTE path of the project that installed it — the key Claude Code
+/// uses to decide which plugins a project has. That binding lives in
+/// this GLOBAL registry, not inside the project directory, so a project
+/// move never carries it: the moved project's plugins silently appear
+/// uninstalled because Claude Code finds no install record at the new
+/// path. This phase repoints those bindings.
+///
+/// Semantics (same boundary rule as P6/P7, via `rewrite_path_string`):
+///   - `projectPath == old_path` (the project root) → `new_path`.
+///   - `projectPath` under `old_path` (a nested install root) →
+///     rewritten prefix.
+///   - `installPath` points into the global plugin cache
+///     (`<config_dir>/plugins/cache/…`), never under a project path, so
+///     it is left untouched by the boundary rule.
+///
+/// Before mutating, the original file is snapshotted to
+/// `<snapshots_dir>/<ts>-<new_san>-P10.json` (the registry holds many
+/// projects' bindings; a bad rewrite must be recoverable). No-op —
+/// `Ok` with zero bindings and no snapshot — when the registry is
+/// absent or holds no binding to `old_path`.
+pub fn rewrite_installed_plugins(
+    registry_path: &Path,
+    snapshots_dir: &Path,
+    old_path: &str,
+    new_path: &str,
+    new_san: &str,
+) -> Result<PluginRegistryRewriteResult, ProjectError> {
+    let mut result = PluginRegistryRewriteResult::default();
+
+    if !registry_path.exists() {
+        tracing::debug!("installed_plugins.json absent; P10 no-op");
+        return Ok(result);
+    }
+
+    let contents = fs::read_to_string(registry_path).map_err(ProjectError::Io)?;
+
+    // Fast path: skip the parse when `old_path` can't appear. Mirror the
+    // JSON-escaped needle rule from `rewrite_meta_json` (Audit M11) so a
+    // Windows path (backslashes escaped as `\\` in JSON) still matches.
+    let old_escaped = serde_json::to_string(old_path).unwrap_or_else(|_| format!("\"{old_path}\""));
+    let needle = old_escaped.trim_matches('"');
+    if !contents.contains(needle) && !contents.contains(old_path) {
+        return Ok(result);
+    }
+
+    let mut root: Value = match serde_json::from_str(&contents) {
+        Ok(v) => v,
+        Err(e) => {
+            return Err(ProjectError::Ambiguous(format!(
+                "installed_plugins.json is not valid JSON: {e}"
+            )));
+        }
+    };
+
+    // Walk every string in the document under the boundary rule. Only
+    // `projectPath` fields can match `old_path` (installPath lives in the
+    // global cache), so a whole-document walk touches exactly the
+    // bindings we mean to move and naturally handles nested install
+    // roots — the same approach P7 uses for nested values.
+    let rewrites =
+        crate::project_rewrite::rewrite_strings_in_value_pub(&mut root, old_path, new_path);
+    if rewrites == 0 {
+        // Needle matched but the boundary rule didn't (e.g. `old_path`
+        // only appeared as a non-path substring). Nothing to persist.
+        return Ok(result);
+    }
+
+    // Snapshot the ORIGINAL bytes before the atomic replace.
+    result.snapshot_path = Some(write_registry_snapshot(snapshots_dir, new_san, &contents)?);
+    write_config_atomic(registry_path, &root)?;
+    result.bindings_rewritten = rewrites;
+
+    tracing::info!(
+        bindings = rewrites,
+        "P10 installed_plugins.json plugin bindings rewritten"
+    );
+    Ok(result)
+}
+
+/// A project-scoped plugin binding whose `projectPath` no longer exists
+/// on disk — the plugin registry still claims the plugin is installed for
+/// a project directory that is gone (deleted or moved externally). This
+/// is the plugin-side analogue of an orphaned transcript slug
+/// (`session::move_::detect_orphaned_projects`): the same "a project
+/// moved and CC's global, path-keyed state didn't follow" failure, on the
+/// dimension that transcript-orphan detection does not cover.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StalePluginBinding {
+    /// Registry key, e.g. `"sample@acme"`.
+    pub plugin: String,
+    /// The `projectPath` that no longer exists on disk.
+    pub project_path: String,
+    /// The install scope (`"project"` or `"local"`).
+    pub scope: String,
+}
+
+/// Scan the plugin registry for project-scoped bindings whose
+/// `projectPath` directory no longer exists on disk.
+///
+/// This is the detection half of the manual-move repair story. A project
+/// moved with `claudepot project move` has its bindings repointed by P10;
+/// a project moved **externally** (Finder / `mv` / `git`) leaves the
+/// bindings pointing at a vanished path, and the moved project's plugins
+/// silently stop resolving. This surfaces exactly those bindings so the
+/// user can run `project move <old> <new>` (which repoints them) — the
+/// plugin dimension that `detect_orphaned_projects` (transcripts only)
+/// never reports.
+///
+/// Only `scope: "project"` and `"local"` bindings are considered — a
+/// `"user"`-scoped install is global and not tied to any single project
+/// directory's existence. Returns `[]` when the registry is absent, is
+/// not the expected shape, or every project binding still resolves.
+pub fn detect_stale_plugin_bindings(
+    registry_path: &Path,
+) -> Result<Vec<StalePluginBinding>, ProjectError> {
+    if !registry_path.exists() {
+        return Ok(Vec::new());
+    }
+    let contents = fs::read_to_string(registry_path).map_err(ProjectError::Io)?;
+    let root: Value = match serde_json::from_str(&contents) {
+        Ok(v) => v,
+        // A malformed registry is a real problem, but detection is a
+        // read-only health check — surface it rather than aborting a
+        // caller that may be listing many things.
+        Err(e) => {
+            return Err(ProjectError::Ambiguous(format!(
+                "installed_plugins.json is not valid JSON: {e}"
+            )));
+        }
+    };
+
+    let Some(plugins) = root.get("plugins").and_then(Value::as_object) else {
+        return Ok(Vec::new());
+    };
+
+    let mut out = Vec::new();
+    for (plugin, records) in plugins {
+        let Some(arr) = records.as_array() else {
+            continue;
+        };
+        for rec in arr {
+            let Some(obj) = rec.as_object() else {
+                continue;
+            };
+            let scope = obj.get("scope").and_then(Value::as_str).unwrap_or("");
+            if scope != "project" && scope != "local" {
+                continue;
+            }
+            let Some(project_path) = obj.get("projectPath").and_then(Value::as_str) else {
+                continue;
+            };
+            if project_path.is_empty() {
+                continue;
+            }
+            // Stale iff the bound directory is gone. `exists()` (not
+            // `is_dir()`) is deliberately lenient — a path that resolves
+            // to anything is not treated as orphaned.
+            if !Path::new(project_path).exists() {
+                out.push(StalePluginBinding {
+                    plugin: plugin.clone(),
+                    project_path: project_path.to_string(),
+                    scope: scope.to_string(),
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Snapshot the pre-rewrite plugin registry to
+/// `<snapshots_dir>/<ts>-<safe_san>-P10.json`, verbatim (original bytes),
+/// 0600 on Unix. Mirrors [`write_snapshot`] but preserves the exact
+/// source text rather than re-serializing a parsed value.
+fn write_registry_snapshot(
+    snapshots_dir: &Path,
+    new_san: &str,
+    original: &str,
+) -> Result<PathBuf, ProjectError> {
+    fs::create_dir_all(snapshots_dir).map_err(ProjectError::Io)?;
+    let safe_san: String = new_san
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let path = snapshots_dir.join(format!("{ts}-{safe_san}-P10.json"));
+    fs::write(&path, original).map_err(ProjectError::Io)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+    }
+    Ok(path)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -686,5 +910,298 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, ProjectError::Ambiguous(_)));
+    }
+
+    // ── Phase 10: installed_plugins.json plugin-binding rewrite ──────────
+
+    /// One install record shaped like Claude Code's real schema.
+    fn plugin_record(scope: &str, project_path: &str, install_path: &str) -> Value {
+        json!({
+            "scope": scope,
+            "projectPath": project_path,
+            "installPath": install_path,
+            "version": "0.5.1",
+            "installedAt": "2026-07-14T00:36:29.392Z",
+            "lastUpdated": "2026-07-14T00:36:29.392Z",
+            "gitCommitSha": "2607c7afac185dfefe6148b214e9e186c2859ad0"
+        })
+    }
+
+    fn snap_count(dir: &Path) -> usize {
+        fs::read_dir(dir).map(|d| d.count()).unwrap_or(0)
+    }
+
+    #[test]
+    fn installed_plugins_missing_file_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let snap = tmp.path().join("snaps");
+        let reg = tmp.path().join("installed_plugins.json");
+        let r = rewrite_installed_plugins(&reg, &snap, "/a/b", "/c/d", "-c-d").unwrap();
+        assert_eq!(r.bindings_rewritten, 0);
+        assert!(r.snapshot_path.is_none());
+    }
+
+    #[test]
+    fn installed_plugins_no_binding_to_old_path_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let snap = tmp.path().join("snaps");
+        let reg = tmp.path().join("installed_plugins.json");
+        write_json(
+            &reg,
+            &json!({"version": 2, "plugins": {
+                "foo@owner": [plugin_record("project", "/some/other/project", "/cache/foo")]
+            }}),
+        );
+        let r = rewrite_installed_plugins(&reg, &snap, "/a/b", "/c/d", "-c-d").unwrap();
+        assert_eq!(r.bindings_rewritten, 0);
+        assert!(r.snapshot_path.is_none(), "no-op must not snapshot");
+        // File untouched.
+        assert_eq!(
+            read_json(&reg)["plugins"]["foo@owner"][0]["projectPath"],
+            json!("/some/other/project")
+        );
+    }
+
+    #[test]
+    fn exact_root_project_path_is_rewritten() {
+        // The reported bug: projectPath equals the project ROOT exactly
+        // (no trailing separator), which the boundary-prefix rule alone
+        // would miss — rewrite_path_string's exact-match arm covers it.
+        let tmp = tempfile::tempdir().unwrap();
+        let snap = tmp.path().join("snaps");
+        let reg = tmp.path().join("installed_plugins.json");
+        write_json(
+            &reg,
+            &json!({"version": 2, "plugins": {
+                "sample@acme": [plugin_record(
+                    "project",
+                    "/Users/dev/work/old-project",
+                    "/Users/dev/.claude/plugins/cache/acme/sample/1.0.0",
+                )]
+            }}),
+        );
+        let r = rewrite_installed_plugins(
+            &reg,
+            &snap,
+            "/Users/dev/work/old-project",
+            "/Users/dev/work/renamed-project",
+            "-Users-dev-work-renamed-project",
+        )
+        .unwrap();
+        assert_eq!(r.bindings_rewritten, 1);
+        let after = read_json(&reg);
+        assert_eq!(
+            after["plugins"]["sample@acme"][0]["projectPath"],
+            json!("/Users/dev/work/renamed-project")
+        );
+        // installPath (global cache) is NOT under the project path → untouched.
+        assert_eq!(
+            after["plugins"]["sample@acme"][0]["installPath"],
+            json!("/Users/dev/.claude/plugins/cache/acme/sample/1.0.0")
+        );
+    }
+
+    #[test]
+    fn descendant_project_path_is_rewritten() {
+        let tmp = tempfile::tempdir().unwrap();
+        let snap = tmp.path().join("snaps");
+        let reg = tmp.path().join("installed_plugins.json");
+        write_json(
+            &reg,
+            &json!({"version": 2, "plugins": {
+                "foo@owner": [plugin_record("local", "/a/b/nested", "/cache/foo")]
+            }}),
+        );
+        let r = rewrite_installed_plugins(&reg, &snap, "/a/b", "/c/d", "-c-d").unwrap();
+        assert_eq!(r.bindings_rewritten, 1);
+        assert_eq!(
+            read_json(&reg)["plugins"]["foo@owner"][0]["projectPath"],
+            json!("/c/d/nested")
+        );
+    }
+
+    #[test]
+    fn multiple_bindings_across_plugins_all_rewritten() {
+        let tmp = tempfile::tempdir().unwrap();
+        let snap = tmp.path().join("snaps");
+        let reg = tmp.path().join("installed_plugins.json");
+        write_json(
+            &reg,
+            &json!({"version": 2, "plugins": {
+                "a@o": [plugin_record("project", "/a/b", "/cache/a")],
+                "b@o": [plugin_record("project", "/a/b", "/cache/b")],
+                // A user-scoped record for a DIFFERENT project — must not move.
+                "c@o": [plugin_record("user", "/other", "/cache/c")],
+            }}),
+        );
+        let r = rewrite_installed_plugins(&reg, &snap, "/a/b", "/c/d", "-c-d").unwrap();
+        assert_eq!(r.bindings_rewritten, 2);
+        let after = read_json(&reg);
+        assert_eq!(after["plugins"]["a@o"][0]["projectPath"], json!("/c/d"));
+        assert_eq!(after["plugins"]["b@o"][0]["projectPath"], json!("/c/d"));
+        assert_eq!(after["plugins"]["c@o"][0]["projectPath"], json!("/other"));
+    }
+
+    #[test]
+    fn rewrite_snapshots_the_original_then_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let snap = tmp.path().join("snaps");
+        let reg = tmp.path().join("installed_plugins.json");
+        let original = json!({"version": 2, "plugins": {
+            "a@o": [plugin_record("project", "/a/b", "/cache/a")]
+        }});
+        write_json(&reg, &original);
+        let original_text = fs::read_to_string(&reg).unwrap();
+
+        let r1 = rewrite_installed_plugins(&reg, &snap, "/a/b", "/c/d", "-c-d").unwrap();
+        assert_eq!(r1.bindings_rewritten, 1);
+        let snap_path = r1.snapshot_path.expect("a rewrite must snapshot");
+        assert!(snap_path.to_string_lossy().ends_with("-P10.json"));
+        // Snapshot holds the verbatim pre-rewrite bytes.
+        assert_eq!(fs::read_to_string(&snap_path).unwrap(), original_text);
+        assert_eq!(snap_count(&snap), 1);
+
+        // Second run: old_path no longer present → no-op, no new snapshot.
+        let r2 = rewrite_installed_plugins(&reg, &snap, "/a/b", "/c/d", "-c-d").unwrap();
+        assert_eq!(r2.bindings_rewritten, 0);
+        assert!(r2.snapshot_path.is_none());
+        assert_eq!(snap_count(&snap), 1, "idempotent re-run must not snapshot");
+    }
+
+    #[test]
+    fn windows_drive_path_binding_is_rewritten() {
+        // Golden pure-string test on a Windows shape (runs on every host
+        // per rules/paths.md). Exact-root match, backslash separators.
+        let tmp = tempfile::tempdir().unwrap();
+        let snap = tmp.path().join("snaps");
+        let reg = tmp.path().join("installed_plugins.json");
+        write_json(
+            &reg,
+            &json!({"version": 2, "plugins": {
+                "a@o": [plugin_record(
+                    "project",
+                    r"C:\Users\dev\old-project",
+                    r"C:\Users\dev\.claude\plugins\cache\a",
+                )]
+            }}),
+        );
+        let r = rewrite_installed_plugins(
+            &reg,
+            &snap,
+            r"C:\Users\dev\old-project",
+            r"C:\Users\dev\renamed-project",
+            "-c-d",
+        )
+        .unwrap();
+        assert_eq!(r.bindings_rewritten, 1);
+        let after = read_json(&reg);
+        assert_eq!(
+            after["plugins"]["a@o"][0]["projectPath"],
+            json!(r"C:\Users\dev\renamed-project")
+        );
+        // Cache installPath untouched.
+        assert_eq!(
+            after["plugins"]["a@o"][0]["installPath"],
+            json!(r"C:\Users\dev\.claude\plugins\cache\a")
+        );
+    }
+
+    #[test]
+    fn windows_unc_descendant_binding_is_rewritten() {
+        let tmp = tempfile::tempdir().unwrap();
+        let snap = tmp.path().join("snaps");
+        let reg = tmp.path().join("installed_plugins.json");
+        write_json(
+            &reg,
+            &json!({"version": 2, "plugins": {
+                "a@o": [plugin_record("project", r"\\server\share\proj\sub", "/cache/a")]
+            }}),
+        );
+        let r = rewrite_installed_plugins(
+            &reg,
+            &snap,
+            r"\\server\share\proj",
+            r"\\server\share\renamed",
+            "-c-d",
+        )
+        .unwrap();
+        assert_eq!(r.bindings_rewritten, 1);
+        assert_eq!(
+            read_json(&reg)["plugins"]["a@o"][0]["projectPath"],
+            json!(r"\\server\share\renamed\sub")
+        );
+    }
+
+    #[test]
+    fn unparseable_registry_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let snap = tmp.path().join("snaps");
+        let reg = tmp.path().join("installed_plugins.json");
+        // Contains the needle so the fast path doesn't skip it, but is
+        // not valid JSON → hard error, not a silent no-op.
+        fs::write(&reg, "{ not json /a/b").unwrap();
+        let err = rewrite_installed_plugins(&reg, &snap, "/a/b", "/c/d", "-c-d").unwrap_err();
+        assert!(matches!(err, ProjectError::Ambiguous(_)));
+    }
+
+    // ── detect_stale_plugin_bindings ─────────────────────────────────────
+
+    #[test]
+    fn detect_stale_missing_registry_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = tmp.path().join("installed_plugins.json");
+        assert!(detect_stale_plugin_bindings(&reg).unwrap().is_empty());
+    }
+
+    #[test]
+    fn detect_stale_flags_gone_project_paths_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = tmp.path().join("installed_plugins.json");
+        // A live project dir that exists, and a gone one.
+        let live = tmp.path().join("live-proj");
+        fs::create_dir(&live).unwrap();
+        let gone = tmp.path().join("gone-proj"); // never created
+
+        write_json(
+            &reg,
+            &json!({"version": 2, "plugins": {
+                "live@o":  [plugin_record("project", live.to_str().unwrap(), "/cache/live")],
+                "gone@o":  [plugin_record("project", gone.to_str().unwrap(), "/cache/gone")],
+                "local@o": [plugin_record("local",   gone.to_str().unwrap(), "/cache/local")],
+                // user-scope binding to a gone path is global → NOT flagged.
+                "user@o":  [plugin_record("user",    gone.to_str().unwrap(), "/cache/user")],
+            }}),
+        );
+
+        let mut stale = detect_stale_plugin_bindings(&reg).unwrap();
+        stale.sort_by(|a, b| a.plugin.cmp(&b.plugin));
+        assert_eq!(
+            stale.len(),
+            2,
+            "only project+local bindings to the gone path"
+        );
+        assert_eq!(stale[0].plugin, "gone@o");
+        assert_eq!(stale[0].scope, "project");
+        assert_eq!(stale[0].project_path, gone.to_string_lossy());
+        assert_eq!(stale[1].plugin, "local@o");
+        assert_eq!(stale[1].scope, "local");
+        // The live and user-scope bindings are not reported.
+        assert!(!stale.iter().any(|s| s.plugin == "live@o"));
+        assert!(!stale.iter().any(|s| s.plugin == "user@o"));
+    }
+
+    #[test]
+    fn detect_stale_all_live_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = tmp.path().join("installed_plugins.json");
+        let live = tmp.path().join("p");
+        fs::create_dir(&live).unwrap();
+        write_json(
+            &reg,
+            &json!({"version": 2, "plugins": {
+                "a@o": [plugin_record("project", live.to_str().unwrap(), "/cache/a")]
+            }}),
+        );
+        assert!(detect_stale_plugin_bindings(&reg).unwrap().is_empty());
     }
 }

--- a/crates/claudepot-core/src/project/core.rs
+++ b/crates/claudepot-core/src/project/core.rs
@@ -769,6 +769,52 @@ pub fn move_project(
         }
     }
 
+    // Phase 10: Repoint project-scoped plugin bindings in the global
+    // registry (<config_dir>/plugins/installed_plugins.json). Claude Code
+    // binds `scope:"project"` plugin installs to the project by ABSOLUTE
+    // `projectPath` in this global file — which lives outside the project
+    // dir, so the physical move (P3) and every path-rewrite phase above
+    // miss it, and the moved project's plugins silently appear
+    // uninstalled. Snapshots before mutating; no-op when the registry has
+    // no binding to the old path.
+    //
+    // Gated on scenario (not `actual_dir_moved`) like P7/P9 — AlreadyMoved
+    // still needs the binding repointed.
+    if !cc_dir_conflict {
+        let registry_path = args
+            .config_dir
+            .join("plugins")
+            .join("installed_plugins.json");
+        let snapshots_dir = args
+            .snapshots_dir
+            .clone()
+            .unwrap_or_else(|| repair_root(args).join("snapshots"));
+        match crate::project_config_rewrite::rewrite_installed_plugins(
+            &registry_path,
+            &snapshots_dir,
+            &old_norm,
+            &new_norm,
+            &new_san,
+        ) {
+            Ok(r) => {
+                result.plugin_bindings_rewritten = r.bindings_rewritten;
+                result.plugin_registry_snapshot_path = r.snapshot_path.clone();
+                if let Some(snap) = r.snapshot_path {
+                    let _ = journal.record_snapshot(snap);
+                }
+                if result.plugin_bindings_rewritten > 0 {
+                    let _ = journal.mark_phase("P10");
+                    sink.phase("P10", PhaseStatus::Complete);
+                }
+            }
+            Err(e) => {
+                let msg = format!("P10 (installed_plugins.json) failed: {e}");
+                let _ = journal.mark_error(&msg);
+                return Err(ProjectError::Ambiguous(msg));
+            }
+        }
+    }
+
     // All phases complete. Delete the journal. (Lock is released via
     // RAII when `_lock` drops at end of scope.)
     journal.finish()?;
@@ -782,6 +828,7 @@ pub fn move_project(
         config_renamed = result.config_key_renamed,
         config_collision = result.config_had_collision,
         settings_rewritten = result.project_settings_rewritten,
+        plugin_bindings_rewritten = result.plugin_bindings_rewritten,
         "project move complete"
     );
     Ok(result)

--- a/crates/claudepot-core/src/project/core_tests.rs
+++ b/crates/claudepot-core/src/project/core_tests.rs
@@ -946,6 +946,90 @@ fn test_move_project_rewrites_claude_json() {
     );
 }
 
+/// P10 end-to-end: a project-scoped plugin binding in the global
+/// `<config_dir>/plugins/installed_plugins.json` registry is repointed
+/// from old_path to new_path when move_project runs. This is the fix for
+/// "plugins not properly moved after a project rename".
+#[test]
+fn test_move_project_repoints_plugin_bindings() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = canonical_test_path(tmp.path());
+
+    let src = base.join("origproj");
+    fs::create_dir(&src).unwrap();
+    let projects_dir = base.join("projects");
+    fs::create_dir(&projects_dir).unwrap();
+
+    let old_str = src.to_string_lossy().to_string();
+    let old_san = sanitize_path(&old_str);
+    let cc_old = projects_dir.join(&old_san);
+    fs::create_dir(&cc_old).unwrap();
+
+    // Global plugin registry at <config_dir>/plugins/installed_plugins.json.
+    let plugins_dir = base.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    let registry = plugins_dir.join("installed_plugins.json");
+    let reg_before = serde_json::json!({
+        "version": 2,
+        "plugins": {
+            "sample@acme": [{
+                "scope": "project",
+                "projectPath": old_str.clone(),
+                // installPath sits in the global cache — must NOT move.
+                "installPath": base.join("plugins/cache/acme/sample/1.0.0")
+                    .to_string_lossy(),
+                "version": "1.0.0"
+            }],
+            // A different project's binding — must be left alone.
+            "other@x": [{
+                "scope": "project",
+                "projectPath": "/some/other/project",
+                "installPath": "/cache/other",
+                "version": "1.0.0"
+            }]
+        }
+    });
+    fs::write(
+        &registry,
+        serde_json::to_string_pretty(&reg_before).unwrap(),
+    )
+    .unwrap();
+
+    let dst = base.join("newproj");
+    let args = MoveArgs {
+        old_path: src.clone(),
+        new_path: dst.clone(),
+        config_dir: base.clone(),
+        claude_json_path: None,
+        snapshots_dir: Some(base.join("snaps")),
+        no_move: false,
+        merge: false,
+        overwrite: false,
+        force: true,
+        dry_run: false,
+        ignore_pending_journals: false,
+        claudepot_state_dir: None,
+    };
+    let result = move_project(&args, &crate::project_progress::NoopSink).unwrap();
+
+    assert_eq!(result.plugin_bindings_rewritten, 1);
+    assert!(result.plugin_registry_snapshot_path.is_some());
+
+    let reg_after: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&registry).unwrap()).unwrap();
+    let new_str = dst.to_string_lossy().to_string();
+    // Our project's binding repointed to the new path.
+    assert_eq!(
+        reg_after["plugins"]["sample@acme"][0]["projectPath"],
+        serde_json::json!(new_str)
+    );
+    // The unrelated project's binding is untouched.
+    assert_eq!(
+        reg_after["plugins"]["other@x"][0]["projectPath"],
+        serde_json::json!("/some/other/project")
+    );
+}
+
 /// Tests without claude_json_path should not touch any config file
 /// (hermetic). Confirmed by no P7 fields being set and no file being
 /// created.

--- a/crates/claudepot-core/src/project/display.rs
+++ b/crates/claudepot-core/src/project/display.rs
@@ -107,6 +107,23 @@ pub(crate) fn compute_dry_run_plan(
             .join("settings.json")
             .exists();
 
+    // P10 preview: does the global plugin registry hold a binding to the
+    // old project path? Cheap containment check on the JSON-escaped needle
+    // (only `projectPath` fields carry a project path, so a raw substring
+    // hit is accurate in practice; the Windows-escaped form keeps this
+    // correct when the registry stores backslash paths).
+    let would_rewrite_installed_plugins = {
+        let registry = config_dir.join("plugins").join("installed_plugins.json");
+        fs::read_to_string(&registry)
+            .map(|contents| {
+                let escaped =
+                    serde_json::to_string(old_norm).unwrap_or_else(|_| format!("\"{old_norm}\""));
+                let needle = escaped.trim_matches('"');
+                contents.contains(needle) || contents.contains(old_norm)
+            })
+            .unwrap_or(false)
+    };
+
     Ok(DryRunPlan {
         would_move_dir: *scenario == super::core::MoveScenario::MoveAndUpdate,
         old_cc_dir: old_san.to_string(),
@@ -119,6 +136,7 @@ pub(crate) fn compute_dry_run_plan(
         would_rewrite_claude_json,
         would_move_memory_dir,
         would_rewrite_project_settings,
+        would_rewrite_installed_plugins,
     })
 }
 
@@ -204,6 +222,14 @@ pub(crate) fn format_dry_run_plan(plan: &DryRunPlan, old_norm: &str, new_norm: &
     if plan.would_rewrite_project_settings {
         out.push_str(&format!(
             "  {}. Rewrite project-local .claude/settings.json autoMemoryDirectory (P9)\n",
+            step
+        ));
+        step += 1;
+    }
+
+    if plan.would_rewrite_installed_plugins {
+        out.push_str(&format!(
+            "  {}. Repoint project-scoped plugin bindings in installed_plugins.json (P10)\n",
             step
         ));
         step += 1;

--- a/crates/claudepot-core/src/project/mod.rs
+++ b/crates/claudepot-core/src/project/mod.rs
@@ -48,3 +48,8 @@ pub mod types;
 // `crate::project::ProjectError`, `crate::project::move_project`, …
 // resolve exactly as they did when `project.rs` was a single file.
 pub use core::*;
+
+// The plugin-registry health check is a read-only surface CLI/GUI call
+// (the rest of `config_rewrite` stays crate-private, invoked only by the
+// move phases).
+pub use config_rewrite::{detect_stale_plugin_bindings, StalePluginBinding};

--- a/crates/claudepot-core/src/project/types.rs
+++ b/crates/claudepot-core/src/project/types.rs
@@ -98,6 +98,11 @@ pub struct MoveResult {
     pub config_nested_rewrites: usize,
     /// P9 (project-local .claude/settings.json autoMemoryDirectory) rewrote.
     pub project_settings_rewritten: bool,
+    /// P10 (plugins/installed_plugins.json) — count of project-scoped
+    /// plugin `projectPath` bindings repointed to the new path.
+    pub plugin_bindings_rewritten: usize,
+    /// P10 snapshot of the pre-rewrite plugin registry, if it was touched.
+    pub plugin_registry_snapshot_path: Option<PathBuf>,
     /// P8 (auto-memory dir move on git-root change) stats.
     pub memory_git_root_changed: bool,
     pub memory_dir_moved: bool,
@@ -156,4 +161,7 @@ pub struct DryRunPlan {
     pub would_move_memory_dir: bool,
     /// P9 preview: would project-local settings.json be touched?
     pub would_rewrite_project_settings: bool,
+    /// P10 preview: does the global plugin registry hold a binding to
+    /// the old project path that a move would repoint?
+    pub would_rewrite_installed_plugins: bool,
 }

--- a/src-tauri/src/dto_project.rs
+++ b/src-tauri/src/dto_project.rs
@@ -158,6 +158,7 @@ pub struct DryRunPlanDto {
     pub would_rewrite_claude_json: bool,
     pub would_move_memory_dir: bool,
     pub would_rewrite_project_settings: bool,
+    pub would_rewrite_installed_plugins: bool,
 }
 
 impl From<&claudepot_core::project_types::DryRunPlan> for DryRunPlanDto {
@@ -174,6 +175,7 @@ impl From<&claudepot_core::project_types::DryRunPlan> for DryRunPlanDto {
             would_rewrite_claude_json: p.would_rewrite_claude_json,
             would_move_memory_dir: p.would_move_memory_dir,
             would_rewrite_project_settings: p.would_rewrite_project_settings,
+            would_rewrite_installed_plugins: p.would_rewrite_installed_plugins,
         }
     }
 }

--- a/src-tauri/src/ops.rs
+++ b/src-tauri/src/ops.rs
@@ -61,6 +61,7 @@ pub struct MoveResultSummary {
     pub config_had_collision: bool,
     pub config_snapshot_path: Option<String>,
     pub memory_dir_moved: bool,
+    pub plugin_bindings_rewritten: usize,
     pub warnings: Vec<String>,
 }
 
@@ -77,6 +78,7 @@ impl MoveResultSummary {
                 .as_ref()
                 .map(|p| p.to_string_lossy().to_string()),
             memory_dir_moved: r.memory_dir_moved,
+            plugin_bindings_rewritten: r.plugin_bindings_rewritten,
             warnings: r.warnings.clone(),
         }
     }

--- a/src/sections/projects/RenameProjectModal.test.tsx
+++ b/src/sections/projects/RenameProjectModal.test.tsx
@@ -32,6 +32,7 @@ function okPlan(overrides: Partial<DryRunPlan> = {}): DryRunPlan {
     would_rewrite_claude_json: true,
     would_move_memory_dir: false,
     would_rewrite_project_settings: false,
+    would_rewrite_installed_plugins: false,
     ...overrides,
   };
 }

--- a/src/sections/projects/RenameProjectModal.tsx
+++ b/src/sections/projects/RenameProjectModal.tsx
@@ -337,6 +337,10 @@ export function RenameProjectModal({
                   Project-local settings:{" "}
                   {preview.plan.would_rewrite_project_settings ? "rewrite" : "skip"}
                 </li>
+                <li>
+                  Plugin bindings:{" "}
+                  {preview.plan.would_rewrite_installed_plugins ? "repoint" : "skip"}
+                </li>
                 {preview.plan.estimated_history_lines > 0 && (
                   <li>
                     History lines potentially updated: ~{preview.plan.estimated_history_lines}

--- a/src/sections/projects/projectMoveProgress.tsx
+++ b/src/sections/projects/projectMoveProgress.tsx
@@ -16,6 +16,7 @@ export const PROJECT_MOVE_PHASES: PhaseSpec[] = [
   { id: "P7", label: "Updating Claude Code config" },
   { id: "P8", label: "Moving auto-memory directory" },
   { id: "P9", label: "Updating project settings" },
+  { id: "P10", label: "Repointing plugin bindings" },
 ];
 
 /**
@@ -37,6 +38,12 @@ export function renderProjectMoveResult(info: RunningOpInfo | null): ReactNode {
         </li>
       )}
       {result.memory_dir_moved && <li>Auto-memory directory moved.</li>}
+      {result.plugin_bindings_rewritten > 0 && (
+        <li>
+          {result.plugin_bindings_rewritten} plugin binding
+          {result.plugin_bindings_rewritten === 1 ? "" : "s"} repointed.
+        </li>
+      )}
       {result.config_had_collision && result.config_snapshot_path && (
         <li>
           Pre-existing data preserved at{" "}

--- a/src/types/ops.ts
+++ b/src/types/ops.ts
@@ -111,6 +111,7 @@ export interface MoveResultSummary {
   config_had_collision: boolean;
   config_snapshot_path: string | null;
   memory_dir_moved: boolean;
+  plugin_bindings_rewritten: number;
   warnings: string[];
 }
 

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -217,4 +217,5 @@ export interface DryRunPlan {
   would_rewrite_claude_json: boolean;
   would_move_memory_dir: boolean;
   would_rewrite_project_settings: boolean;
+  would_rewrite_installed_plugins: boolean;
 }


### PR DESCRIPTION
## Problem

Claude Code binds project-scoped plugins to a project by **absolute `projectPath`** in the global `~/.claude/plugins/installed_plugins.json`. That file lives *outside* the project directory, so `move_project`'s nine phases never touched it — a moved project's plugins silently orphaned to a path that no longer exists.

Reported after an external rename left four plugins bound to a vanished directory. The full blast-radius scan then found **20 pre-existing stale bindings** on a real machine from earlier moves — this was a latent, unobserved failure class.

## What this does

**Phase 10 — migrate on move (`rewrite_installed_plugins`)**
- Repoints `projectPath` (project root *and* descendants) via the same P6/P7 boundary rule; leaves `installPath` (global plugin cache) untouched.
- Snapshots the registry before the atomic replace; journaled + rollback-recorded like P7.
- Surfaced everywhere the other phases are: dry-run plan, CLI result line, `MoveResultSummary`/`DryRunPlan` DTOs, TS types, and the GUI progress map (`projectMoveProgress.tsx`).

**Detection — the external-move case (`detect_stale_plugin_bindings` + `project plugin-bindings`)**
- The failure that actually bites users is a **manual** move (Finder / `mv` / `git`), which bypasses *every* move phase. P10 alone can't help there.
- New read-only CLI verb reports project-scoped bindings whose `projectPath` is gone, and points at the fix (`project move <old> <new>`, which runs P10). This is the plugin dimension that transcript-orphan detection (`session list-orphans`) never covered.

**Invariant — `.claude/rules/cc-state-move-blast-radius.md`**
- Documents every path-keyed global CC file, its owning move phase, and the rule that new path-keyed state must get *both* a phase and a detector.

## Tests

12 unit tests (all four path shapes per `rules/paths.md` — Unix root/descendant, Windows drive, UNC; plus no-op, snapshot, idempotency, and detector scope) + one end-to-end `move_project` test proving P10 fires and leaves unrelated bindings alone.

## Notes

- Pre-existing flaky test spotted during validation: `desktop_backend::swap::test_switch_not_installed_returns_error` lacks the `lock_data_dir()` guard its siblings have and flakes under parallel scheduling. Unrelated to this change; flagged for a separate fix.