### PR TITLE
fix(web): patch critical @auth/core auth-bypass (batch A)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.209",
     "@anthropic-ai/sdk": "^0.111.0",
     "@atproto/api": "^0.19.11",
-    "@auth/drizzle-adapter": "^1.11.2",
+    "@auth/drizzle-adapter": "^1.11.3",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@modelcontextprotocol/sdk": "~1.29.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^0.19.11
         version: 0.19.11
       '@auth/drizzle-adapter':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.11.3
+        version: 1.11.3
       '@mdx-js/loader':
         specifier: ^3.1.1
         version: 3.1.1
@@ -234,20 +234,6 @@ packages:
   '@atproto/xrpc@0.7.7':
     resolution: {integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==}
 
-  '@auth/core@0.41.2':
-    resolution: {integrity: sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==}
-    peerDependencies:
-      '@simplewebauthn/browser': ^9.0.1
-      '@simplewebauthn/server': ^9.0.2
-      nodemailer: ^7.0.7
-    peerDependenciesMeta:
-      '@simplewebauthn/browser':
-        optional: true
-      '@simplewebauthn/server':
-        optional: true
-      nodemailer:
-        optional: true
-
   '@auth/core@0.41.3':
     resolution: {integrity: sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==}
     peerDependencies:
@@ -262,8 +248,8 @@ packages:
       nodemailer:
         optional: true
 
-  '@auth/drizzle-adapter@1.11.2':
-    resolution: {integrity: sha512-VOuj7REI8jfJjpSbsYwDM/Zrn55T6lS9Yc+29V+EXMcel8eqG7x+7LodNfd1WHjakfkLYi+qsbYUHB3E6aDA4w==}
+  '@auth/drizzle-adapter@1.11.3':
+    resolution: {integrity: sha512-TxqVasPVuf7LDAT1Yuu6bftpuet8o0tjdXW+mXpnXWdSRPQsomdzMoz9RsXkFN/JfdK+/DwdgOEmOTv1gbiFNw==}
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -2957,14 +2943,6 @@ snapshots:
       '@atproto/lexicon': 0.6.2
       zod: 3.25.76
 
-  '@auth/core@0.41.2':
-    dependencies:
-      '@panva/hkdf': 1.2.1
-      jose: 6.2.3
-      oauth4webapi: 3.8.6
-      preact: 10.24.3
-      preact-render-to-string: 6.5.11(preact@10.24.3)
-
   '@auth/core@0.41.3':
     dependencies:
       '@panva/hkdf': 1.2.1
@@ -2973,9 +2951,9 @@ snapshots:
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
 
-  '@auth/drizzle-adapter@1.11.2':
+  '@auth/drizzle-adapter@1.11.3':
     dependencies:
-      '@auth/core': 0.41.2
+      '@auth/core': 0.41.3
     transitivePeerDependencies:
       - '@simplewebauthn/browser'
       - '@simplewebauthn/server'


### PR DESCRIPTION
Closes the **critical** `@auth/core` Dependabot alert (+ 1 high, 1 medium) on `web/`.

### Root cause
The lockfile carried **two** `@auth/core` copies: `0.41.3` (via `next-auth@5.0.0-beta.32`, patched) and `0.41.2` (via `@auth/drizzle-adapter@1.11.2`, **vulnerable**). Dependabot's `next-auth` bump didn't touch the adapter, so the vulnerable copy stayed.

### Fix
Bump `@auth/drizzle-adapter` `^1.11.2 → ^1.11.3` — upstream released `1.11.3` specifically to depend on `@auth/core@0.41.3`. This dedupes to the single patched version. **Not** a forced override; the actual offending package moves to a version its author intends to pull the fix.

| Alert | Severity | Fixed by |
|---|---|---|
| Email homoglyph `@` bypass (validation before Unicode normalization) | 🔴 critical | @auth/core 0.41.3 |
| `getToken()` uncaught exception on malformed Bearer header | 🟠 high | @auth/core 0.41.3 |
| OAuth state/nonce/PKCE cookies not bound to their provider | 🟡 medium | @auth/core 0.41.3 |

### Verification
- `pnpm install --frozen-lockfile` — consistent
- `tsc --noEmit` — clean (no API breakage across next-auth / drizzle-adapter / @auth/core)
- `pnpm test` (full web suite) — green
- Lockfile now has **only** `@auth/core@0.41.3` (0.41.2 gone)

### ⚠️ Human check before merge
Automated tests can't exercise real auth. Please **smoke-test login on the Vercel preview** — email magic-link **and** GitHub/Google OAuth — before merging, since this touches the auth core.