### PR TITLE
fix: bump root postcss + dompurify vuln pins (batch C)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   "pnpm": {
     "overrides": {
       "@babel/core": "^7.29.6",
-      "dompurify": "3.4.11",
+      "dompurify": "3.4.12",
       "esbuild": "^0.28.1",
-      "postcss": "8.5.10",
+      "postcss": "8.5.12",
       "undici": "^7.28.0",
       "uuid": "11.1.1"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,9 @@ settings:
 
 overrides:
   '@babel/core': ^7.29.6
-  dompurify: 3.4.11
+  dompurify: 3.4.12
   esbuild: ^0.28.1
-  postcss: 8.5.10
+  postcss: 8.5.12
   undici: ^7.28.0
   uuid: 11.1.1
 
@@ -1239,8 +1239,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   electron-to-chromium@1.5.393:
     resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
@@ -1653,8 +1653,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -3030,7 +3030,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -3440,7 +3440,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       es-toolkit: 1.49.0
       katex: 0.16.45
       khroma: 2.1.0
@@ -3695,7 +3695,7 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss@8.5.10:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -3976,7 +3976,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.12
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
Closes the **2 remaining root Tauri-app** Dependabot alerts by refreshing stale `pnpm.overrides` pins.

| Package | Change | Advisory (real risk here) |
|---|---|---|
| `postcss` | 8.5.10 → **8.5.12** | file read via `sourceMappingURL` — **build-time only, first-party CSS → ~nil real exposure** |
| `dompurify` | 3.4.11 → **3.4.12** | custom-element sanitizer bypass — **not imported in the renderer** → no real exposure |

Both are low real-risk in a desktop app that builds only its own CSS and doesn't sanitize untrusted HTML with DOMPurify, but bumped for a clean board.

### Verification
- `pnpm build` — clean (postcss CSS pipeline)
- `pnpm test` — 855 passed