### PR TITLE
fix(web): bump @hono/node-server to 2.0.11

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -73,7 +73,7 @@
       "sharp"
     ],
     "overrides": {
-      "@hono/node-server": "2.0.5",
+      "@hono/node-server": "2.0.11",
       "body-parser": "2.3.0",
       "dompurify": "3.4.12",
       "fast-uri": "3.1.4",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@hono/node-server': 2.0.5
+  '@hono/node-server': 2.0.11
   body-parser: 2.3.0
   dompurify: 3.4.12
   fast-uri: 3.1.4
@@ -719,8 +719,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@hono/node-server@2.0.5':
-    resolution: {integrity: sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: 4.12.27
@@ -3204,7 +3204,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@hono/node-server@2.0.5(hono@4.12.27)':
+  '@hono/node-server@2.0.11(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -3372,7 +3372,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 2.0.5(hono@4.12.27)
+      '@hono/node-server': 2.0.11(hono@4.12.27)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5


### PR DESCRIPTION
Follow-up to #38. The 2.0.5 bump cleared alert #126 (serve-static path traversal), but Dependabot's re-scan surfaced **#163** — a second advisory (unauthenticated memory-leak DoS via aborted WebSocket handshake, affects `<=2.0.9`, patched `2.0.10`). Bumping to the latest **2.0.11** clears it and any interim ones.

Still `node>=20` / `hono ^4` compatible; the transport remains dead code here (only `server/streamableHttp.js` imports `@hono/node-server`, which the app never loads). frozen-lockfile, tsc, web tests green.