### PR TITLE
Retention disclosure, cross-machine corpus, and a docs-drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,16 @@ jobs:
       - name: CC-parity fixtures (cargo xtask verify-cc-parity)
         run: cargo xtask verify-cc-parity
 
+      # Documentation drift. Three surfaces (README, AGENTS.md, the web
+      # product docs) restate facts that live in source, and nothing
+      # noticed when the source moved: a 2026-07-28 audit found six
+      # stale facts, most of which had been wrong for releases. The one
+      # that matters is AGENTS.md — agents read it before writing code,
+      # so a wrong fact there produces wrong code rather than a confused
+      # reader. Checks only source-derivable facts; prose is not judged.
+      - name: Docs match the code (cargo xtask verify-docs)
+        run: cargo xtask verify-docs
+
       # ─── Architectural invariants ─────────────────────────────
       # Grep-based tripwires for rules the type system can't enforce
       # (Codex parser leaf, raw-text-SELECT redaction confinement, no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,9 +63,10 @@ version lock-step check (tag vs `Cargo.toml`, `package.json`,
   `notification`, `activity`, etc., merged in `index.ts`) + `src/types/`
   (sliced by domain, merged in `index.ts`) — React UI, plain CSS.
 - `AccountStore.db` is `Mutex<Connection>` so stores can cross `await` points in Tauri commands.
-- Six SQLite files live in `~/.claudepot/` (override with
+- Seven SQLite files live in `~/.claudepot/` (override with
   `CLAUDEPOT_DATA_DIR`; the authoritative list is whatever joins onto
-  `claudepot_core::paths::claudepot_data_dir()`):
+  `claudepot_core::paths::claudepot_data_dir()`, and
+  `cargo xtask verify-docs` fails when this list drifts from it):
   - `accounts.db` — authoritative account + verification state, linked to Keychain.
   - `sessions.db` — persistent cache for the Sessions tab. One row per
     `.jsonl` transcript, keyed by file_path; `(size, mtime_ns)` is the
@@ -82,6 +83,32 @@ version lock-step check (tag vs `Cargo.toml`, `package.json`,
   - `activity_metrics.db` — one row per session per tick for the
     Activity Trends view. Owned by
     `claudepot-core::session_live::metrics_store`.
+  - `corpus.db` — the **analysis corpus**: every transcript from every
+    machine, deduped. Owned by `claudepot-core::corpus`. Built by
+    `claudepot corpus index`, which walks the live `~/.claude/projects`
+    plus each `~/claude-corpus-archive/<host>/projects/`.
+
+    **Why this is not in `sessions.db`, which is the whole point.**
+    `sessions.db` is a *cache of one machine's live `~/.claude`*:
+    `SessionIndex::refresh` diffs every row against one `config_dir`
+    and deletes the remainder (`codec::delete_row`, cascading turns
+    and — via the v4 FK — exchanges / tool_calls / FTS). Correct for a
+    cache, fatal for an archive. Point `refresh` at an imported corpus
+    and it deletes the live rows; run it again on the live directory
+    and it deletes the imported ones. A separate file sits outside that
+    loop, so `host_id` costs a column rather than a migration, and the
+    file is rebuildable by definition.
+
+    Tables: `corpus_sessions` (deduped by CC session UUID, most
+    complete copy wins), `corpus_files` (every physical copy, per
+    host), `corpus_exchanges` + `corpus_tool_calls` (turn-level; the
+    substrate the detectors read). Derived data — safe to delete, one
+    ~5-minute pass to rebuild. Reference machine: 8,249 sessions /
+    173,572 tool calls / 848 MB.
+
+    **Outputs do not live here.** Distilled claims go to `memories` in
+    `sessions.db`, which carries no foreign key to `sessions` and is
+    never cascaded — that asymmetry is what makes the split work.
 - A dozen-plus JSON state files also live in `~/.claudepot/`
   (`agents.json`, `routes.json`, `routing-rules.json`, `updates.json`,
   `preferences.json`, `usage-snapshot.json`, `usage_alert_state.json`,
@@ -216,6 +243,83 @@ swap to a chosen alternate.
 - Confirm is the default mode; promote to auto after watching the
   rule fire correctly. See `dev-docs/auto-rotation.md` for the
   full design including the policy framing.
+
+## Transcript retention (Settings → Retention)
+
+Reads and writes CC's `cleanupPeriodDays` — **the only Claude Code
+setting that destroys user data**, and one CC's own UI never mentions.
+Pure logic in `claudepot-core::cc_retention`; commands in
+`src-tauri/src/commands/cc_retention.rs`; pane at
+`src/sections/settings/RetentionPane.tsx`.
+
+Not named `retention` in core — `claudepot-core::retention` already owns
+an unrelated concept (Claudepot's own `activity_cards` / `metrics_tick`
+pruning horizon). `cc_` matches `cc_daemon` / `cc_doctor` / `cc_tips`.
+
+Four properties drive the whole design; changing any of them invalidates
+the pane:
+
+- **Sliding, not one-shot.** `getCutoffDate()` recomputes
+  `now - cleanupPeriodDays` on *every* run, so loss is continuous.
+- **`0` is the most destructive value, not "off".** It means *write no
+  transcripts and delete the existing ones at startup*. It is therefore
+  **not on the duration scale** — `set_retention_days` rejects it and
+  `disable_persistence()` is a separately-named call behind a
+  type-to-confirm gate. Do not "simplify" these into one setter.
+- **A negative value suppresses cleanup entirely.**
+  `cleanupOldMessageFilesInBackground` bails when settings fail
+  validation *and* the raw key is present, so an invalid value
+  accidentally **protects** transcripts (`RetentionMode::Invalid` /
+  `cleanup_suppressed`). The UI must say "fix the value", never
+  "restore the default" — restoring clears the error and re-arms
+  deletion.
+- **Invisible on disk.** Cleanup unlinks top-level session transcripts
+  and never walks `subagents/`, so the folder grows while history is
+  destroyed. `TranscriptRisk::nested_immortal` exists to say so.
+
+`TranscriptRisk::scan_incomplete` is load-bearing: a scan that failed
+must never render as "nothing is scheduled for deletion". Boot check at
+`src-tauri/src/retention_boot_check.rs` emits one bell entry via
+`Category::TranscriptsExpiring`; there is deliberately **no dismissal
+flag** — gating on the condition means raising retention silences it,
+while dismissing without fixing does not.
+
+## Corpus + detectors (`claudepot corpus`)
+
+`claudepot-core::corpus` builds `corpus.db` (see the data-dir list
+above for why it is a separate file). `corpus::normalize` is Tier 0,
+`corpus::detect` is Tiers 1–3. No model calls anywhere in this path —
+`claudepot corpus detect` is the free preview before any distillation.
+
+Precision, not scale, is the problem: the naive "error then any later
+success of the same tool" join yields ~358k useless pairs. The
+constraints that make it usable are same-file, same **command family**,
+first success only, and a bounded turn gap.
+
+Two normalizers on purpose — `normalize_prompt` flattens numbers
+wholesale; `error_signature` keeps small integers, because merging
+`Exit code 1` with `Exit code 143` merges "failed" with "timed out".
+Signatures take the **first line only**, redacted and capped: tool
+output is arbitrary stdout and on a real machine contains financial
+records.
+
+Two filters exist because the real corpus demanded them, and removing
+either re-floods the output:
+
+- `is_harness_synthetic` — CC injects `<local-command-caveat>`,
+  `<command-name>`, `<bash-stdout>`, `[Request interrupted by user]`.
+  Before filtering, the largest "repeated request" in the corpus was
+  harness plumbing at 1,258 occurrences.
+- `command_family` skips segment-consuming shell words (`cd`, `source`)
+  and comments. Real commands open `cd "/path"; …`, so a naive first
+  token returns `cd`'s *argument*; and `#` produced a phantom `bash:#`
+  family with 266 "verified recoveries".
+
+**Vocabulary.** Nothing here is a *recurrence* — that word has a
+precise, human-confirmed meaning in `shared_memory::recurrence` and
+diluting it breaks the one honest signal the knowledge base has.
+Repetition is a *repetition cluster*; a failure with no observed
+success is `unresolved`, never "abandoned".
 
 ## Proactive token refresh (no UI)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,46 @@ Versioning scheme:
 
 ### Added
 
+- **Retention** (Settings → Retention). Claude Code deletes saved
+  conversations older than `cleanupPeriodDays` — 30 days by default —
+  every time it launches, and tells you nothing: the cleanup routine
+  counts exactly what it removed and discards the number. Nothing in
+  Claude Code's own interface mentions the setting. This pane is the
+  only place you can find out your history is on a timer.
+
+  It leads with the consequence on *your* machine ("1,247 transcripts
+  will be deleted the next time Claude Code starts"), not the policy.
+  `0` is never offered on the duration scale, because it does not mean
+  "off" — it means *stop saving transcripts and delete the existing
+  ones*, so it sits behind a separate, type-to-confirm action worded as
+  what it does. A boot check raises one bell entry when deletion is
+  actually scheduled, and stops on its own once you raise the window.
+
+  It also explains why disk usage can never reveal the loss: cleanup
+  removes the small, valuable session transcripts and never touches
+  nested subagent files, so the folder keeps growing while
+  conversations disappear.
+
+- **`claudepot corpus`** — build and search an analysis corpus spanning
+  every machine you use Claude Code on, not just this one.
+
+  `corpus index` walks the live `~/.claude/projects` plus any archived
+  per-host trees under `~/claude-corpus-archive/`, deduplicating
+  conversations that exist on several machines and keeping the most
+  complete copy of each. `corpus status` reports per-host coverage and
+  staleness. Incremental: unchanged files are skipped without being
+  re-read.
+
+  `corpus detect` runs deterministic detectors over it — repeated
+  requests, corroborated corrections, and failure-then-recovery
+  incidents — and reports what it found. **No model calls, no spend.**
+  It is the preview before any distillation, not a replacement for it.
+
+  Kept in its own database on purpose: the session index is a cache of
+  *this* machine and prunes rows whose file is gone, which would make
+  importing another machine's archive mutually destructive with the
+  normal refresh.
+
 - **Unused artifacts view** (Activities → Usage → "Unused"). Lists
   installed skills, agents, and commands that have no recorded
   invocation, so you can see what's earning its keep and what isn't.
@@ -32,6 +72,22 @@ Versioning scheme:
   on disk.
 
 ### Fixed
+
+- **Harvesting a session that found nothing charged you for it again,
+  every time.** "Already harvested" was inferred from a session having
+  produced a lesson — so a transcript the distiller read correctly, and
+  which honestly contained nothing worth keeping, looked unharvested
+  forever and was re-distilled on every run. A real ledger now records
+  each attempt and its outcome, including "found nothing", which is a
+  result rather than an absence. Work already done under the old scheme
+  is carried over, so upgrading does not re-bill it.
+
+- **Sessions containing a failed tool call didn't show as errored.**
+  The error flag was looking in the wrong place — for a field Claude
+  Code doesn't write on transcript lines — so it read "no errors" for
+  every session ever recorded. On a typical machine that hid failures
+  in a third of them. Sessions re-show the flag as they are re-scanned;
+  Settings → Cleanup → Rebuild index applies it immediately.
 
 - **Plugin settings were being silently dropped.** Claudepot read the
   wrong key when working out which plugins are enabled, so every

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ localStorage compatibility.
 
 ![Global tab](assets/screenshots/global.png)
 
-**Settings** — Thirteen sub-panes: General, Appearance (light / dark / system, paper-mono density), Notifications, Network (status-bar dot + status-page polling), **Rotation** (rule-driven auto-swap of the active CLI account when a usage window crosses a threshold — confirm or auto, with a 500-entry audit log), Health (Claude Code's own self-diagnostic, scraped from `claude doctor`), MCP (memory-server health + agent-instruction snippet installer), Cleanup (**Prune** orphaned sessions · **Slim** strips bulky tool-output payloads · **Trash** 7-day undo), Protected paths, GitHub PAT, Locks (SQLite-lock recovery), Diagnostics (Claudepot's own self-check), and About.
+**Settings** — Fourteen sub-panes: General, Appearance (light / dark / system, paper-mono density), Notifications, Network (status-bar dot + status-page polling), **Rotation** (rule-driven auto-swap of the active CLI account when a usage window crosses a threshold — confirm or auto, with a 500-entry audit log), **Retention** (Claude Code deletes saved conversations older than 30 days on every launch and reports nothing — this pane is the only place that says so, and shows how many of *yours* are scheduled to go), Health (Claude Code's own self-diagnostic, scraped from `claude doctor`), MCP (memory-server health + agent-instruction snippet installer), Cleanup (**Prune** orphaned sessions · **Slim** strips bulky tool-output payloads · **Trash** 7-day undo), Protected paths, GitHub PAT, Locks (SQLite-lock recovery), Diagnostics (Claudepot's own self-check), and About.
 
 ![Settings tab](assets/screenshots/settings.png)
 
@@ -159,6 +159,11 @@ claudepot session   list-orphans | move | adopt-orphan | rebuild-index
                     backfill-exchanges | view | export | search | worktrees
                     prune | slim | trash {list|restore|empty}
 claudepot agent     draft | list | show            (alias: automation)
+claudepot lesson    harvest | list | accept | reject | compile | status
+                                                    # the knowledge compiler
+claudepot corpus    index | status | detect         # cross-machine transcript
+                                                    # corpus + free, no-model
+                                                    # candidate detection
 claudepot memory    list | view | log               # CLAUDE.md + memory files
 claudepot activity  recent | reindex                # anomaly + milestone cards
 claudepot usage     report                          # local token/cost rollup

--- a/crates/claudepot-cli/src/commands/corpus.rs
+++ b/crates/claudepot-cli/src/commands/corpus.rs
@@ -1,0 +1,130 @@
+//! `claudepot corpus` — build and inspect the analysis corpus.
+//!
+//! The corpus is every transcript from every machine, deduped, in
+//! `~/.claudepot/corpus.db`. It is deliberately NOT `sessions.db`:
+//! that file is a cache of one machine's live `~/.claude` and its
+//! refresh deletes any row without a file behind it, which would make
+//! importing another host's archive mutually destructive with the
+//! normal refresh. See `claudepot_core::corpus`.
+//!
+//! `index` is incremental and safe to re-run: unchanged files are
+//! skipped by `(size, mtime)` without being read, and nothing is ever
+//! deleted — an archive of a live host is a snapshot, so a file that is
+//! absent now is not evidence the record is stale.
+
+use anyhow::{Context, Result};
+
+use claudepot_core::corpus::{self, CorpusIndex, IndexStats, LOCAL_HOST};
+use claudepot_core::paths;
+
+use crate::output::print_json;
+use crate::AppContext;
+
+fn open() -> Result<CorpusIndex> {
+    CorpusIndex::open(&corpus::default_path()).context("open corpus.db")
+}
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+fn add(a: IndexStats, b: IndexStats) -> IndexStats {
+    IndexStats {
+        seen: a.seen + b.seen,
+        indexed: a.indexed + b.indexed,
+        unchanged: a.unchanged + b.unchanged,
+        duplicate: a.duplicate + b.duplicate,
+        failed: a.failed + b.failed,
+    }
+}
+
+/// Index the live `~/.claude/projects` plus every host directory under
+/// the archive root.
+pub fn index_cmd(ctx: &AppContext, archive_root: Option<String>) -> Result<()> {
+    let idx = open()?;
+    let now = now_ms();
+    let mut total = IndexStats::default();
+
+    // Local machine first — it is the one that is live, so it benefits
+    // most from being current.
+    let live = paths::claude_config_dir().join("projects");
+    if live.is_dir() {
+        if !ctx.quiet {
+            eprintln!("indexing {LOCAL_HOST}: {}", live.display());
+        }
+        total = add(total, idx.index_root(LOCAL_HOST, &live, now)?);
+    }
+
+    let root = archive_root
+        .map(std::path::PathBuf::from)
+        .or_else(corpus::default_archive_root);
+    if let Some(root) = root {
+        if let Ok(hosts) = std::fs::read_dir(&root) {
+            for host in hosts.flatten() {
+                if !host.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                    continue;
+                }
+                let host_id = host.file_name().to_string_lossy().into_owned();
+                let projects = host.path().join("projects");
+                if !projects.is_dir() {
+                    continue;
+                }
+                if !ctx.quiet {
+                    eprintln!("indexing {host_id}: {}", projects.display());
+                }
+                total = add(total, idx.index_root(&host_id, &projects, now)?);
+            }
+        }
+    }
+
+    let sessions = idx.session_count()?;
+    let files = idx.file_count()?;
+    if ctx.json {
+        return print_json(&serde_json::json!({
+            "seen": total.seen,
+            "indexed": total.indexed,
+            "unchanged": total.unchanged,
+            "duplicate": total.duplicate,
+            "failed": total.failed,
+            "sessions": sessions,
+            "files": files,
+        }));
+    }
+    println!(
+        "{} file(s) seen — {} indexed, {} unchanged, {} duplicate copies, {} failed.",
+        total.seen, total.indexed, total.unchanged, total.duplicate, total.failed
+    );
+    println!("Corpus now holds {sessions} session(s) across {files} file(s).");
+    Ok(())
+}
+
+/// Per-host coverage — what each machine contributes, and how stale it is.
+pub fn status_cmd(ctx: &AppContext) -> Result<()> {
+    let idx = open()?;
+    let cov = idx.host_coverage()?;
+    if ctx.json {
+        return print_json(&cov);
+    }
+    if cov.is_empty() {
+        println!("Corpus is empty. Run `claudepot corpus index`.");
+        return Ok(());
+    }
+    println!("{:<18}{:>8}{:>10}  newest", "host", "files", "sessions");
+    for h in &cov {
+        let newest = h
+            .newest_ts_ms
+            .and_then(chrono::DateTime::from_timestamp_millis)
+            .map(|d| d.format("%Y-%m-%d").to_string())
+            .unwrap_or_else(|| "—".into());
+        println!(
+            "{:<18}{:>8}{:>10}  {}",
+            h.host_id, h.files, h.sessions, newest
+        );
+    }
+    println!(
+        "\n{} session(s) across {} file(s).",
+        idx.session_count()?,
+        idx.file_count()?
+    );
+    Ok(())
+}

--- a/crates/claudepot-cli/src/commands/corpus_detect.rs
+++ b/crates/claudepot-cli/src/commands/corpus_detect.rs
@@ -1,0 +1,80 @@
+//! `claudepot corpus detect` — run the deterministic detectors and
+//! report what they found, without spending anything.
+//!
+//! This is the preview the plan's activation flow needs: a count of
+//! real candidates *before* a model is invoked. Nothing here calls an
+//! LLM; every number is a SQL read plus pure comparison.
+
+use anyhow::{Context, Result};
+
+use claudepot_core::corpus::detect::{self, Findings};
+use claudepot_core::corpus::{self, CorpusIndex};
+
+use crate::output::print_json;
+use crate::AppContext;
+
+fn open() -> Result<CorpusIndex> {
+    CorpusIndex::open(&corpus::default_path()).context("open corpus.db")
+}
+
+pub fn detect_cmd(ctx: &AppContext, limit: usize) -> Result<()> {
+    let idx = open()?;
+    let f: Findings = detect::detect_all(&idx, limit)?;
+
+    let resolved = f.resolved_incidents();
+    let unresolved = f.incidents.len() - resolved;
+
+    if ctx.json {
+        return print_json(&serde_json::json!({
+            "incidents": f.incidents.len(),
+            "resolved": resolved,
+            "unresolved": unresolved,
+            "repetitions": f.repetitions.len(),
+            "corrections": f.corrections.len(),
+            "top_repetitions": f.repetitions.iter().take(10).collect::<Vec<_>>(),
+        }));
+    }
+
+    println!(
+        "{} incident(s) — {} with an observed recovery, {} unresolved.",
+        f.incidents.len(),
+        resolved,
+        unresolved
+    );
+    println!(
+        "{} repetition cluster(s), {} corroborated correction(s).",
+        f.repetitions.len(),
+        f.corrections.len()
+    );
+
+    if !f.repetitions.is_empty() {
+        println!("\nMost repeated requests (automation candidates, not lessons):");
+        for r in f.repetitions.iter().take(8) {
+            let sample: String = r.sample.chars().take(60).collect();
+            println!(
+                "  {:>4}x  {:>2} proj  {}",
+                r.count,
+                r.projects,
+                sample.replace('\n', " ")
+            );
+        }
+    }
+
+    // Resolved incidents are the highest-value distillation candidates:
+    // a failure with an observed fix is the one shape that can support a
+    // guard. Show the families they cluster into.
+    if resolved > 0 {
+        use std::collections::HashMap;
+        let mut by_family: HashMap<&str, usize> = HashMap::new();
+        for i in f.incidents.iter().filter(|i| i.is_resolved()) {
+            *by_family.entry(i.family.as_str()).or_default() += 1;
+        }
+        let mut v: Vec<_> = by_family.into_iter().collect();
+        v.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+        println!("\nVerified recoveries by command family:");
+        for (fam, n) in v.into_iter().take(8) {
+            println!("  {n:>4}x  {fam}");
+        }
+    }
+    Ok(())
+}

--- a/crates/claudepot-cli/src/commands/lesson.rs
+++ b/crates/claudepot-cli/src/commands/lesson.rs
@@ -22,7 +22,7 @@ use claudepot_core::agent::templates::KNOWLEDGE_DISTILLER_MODEL;
 use claudepot_core::paths;
 use claudepot_core::session_index::SessionIndex;
 use claudepot_core::shared_memory::review::{self, ReviewState};
-use claudepot_core::shared_memory::{compile, distill, git, proposal};
+use claudepot_core::shared_memory::{compile, distill, git, harvest_ledger, proposal};
 
 use crate::output::print_json;
 use crate::AppContext;
@@ -233,9 +233,47 @@ pub fn harvest_cmd(ctx: &AppContext, args: HarvestArgs) -> Result<()> {
         if !ctx.quiet {
             eprintln!("[{}/{}] {}", i + 1, targets.len(), short(path));
         }
-        match distill::distill_transcript(&idx, "claude", &project, path, "cli:lesson-harvest")
-            .map_err(anyhow::Error::from)
-        {
+        let outcome =
+            distill::distill_transcript(&idx, "claude", &project, path, "cli:lesson-harvest")
+                .map_err(anyhow::Error::from);
+
+        // Record the attempt whichever way it went. A success with zero
+        // claims is the case the old scheme could not represent, and is
+        // exactly why this harvest used to re-pay for the same verdict
+        // every run — see `shared_memory::harvest_ledger`.
+        // Hoisted so the `Attempt` borrows a named binding rather than a
+        // temporary whose lifetime a reader has to reason about.
+        let err_text = outcome.as_ref().err().map(|e| format!("{e:#}"));
+        let ledger_entry = match &outcome {
+            Ok(r) => harvest_ledger::Attempt {
+                file_path: path,
+                outcome: harvest_ledger::Outcome::Succeeded,
+                claims_produced: r.proposed,
+                model: Some(KNOWLEDGE_DISTILLER_MODEL),
+                cost_usd: Some(EST_COST_PER_SESSION_USD),
+                error: None,
+                attempted_at_ms: chrono::Utc::now().timestamp_millis(),
+            },
+            Err(_) => harvest_ledger::Attempt {
+                file_path: path,
+                outcome: harvest_ledger::Outcome::Failed,
+                claims_produced: 0,
+                model: Some(KNOWLEDGE_DISTILLER_MODEL),
+                // Cost is unknown on failure — the spawn may never have
+                // billed. Recording a guess would corrupt the running
+                // total the stats query reports.
+                cost_usd: None,
+                error: err_text.as_deref(),
+                attempted_at_ms: chrono::Utc::now().timestamp_millis(),
+            },
+        };
+        if let Err(e) = harvest_ledger::record(&idx, &ledger_entry) {
+            // A ledger write failure must not lose the harvest itself;
+            // the cost is that this transcript is re-selected next run.
+            eprintln!("      warning: harvest ledger write failed: {e}");
+        }
+
+        match outcome {
             Ok(r) => {
                 total.proposed += r.proposed;
                 total.skipped_duplicate += r.skipped_duplicate;

--- a/crates/claudepot-cli/src/commands/mod.rs
+++ b/crates/claudepot-cli/src/commands/mod.rs
@@ -3,6 +3,8 @@ pub mod activity;
 pub mod agent;
 pub mod cli_ops;
 pub mod codex;
+pub mod corpus;
+pub mod corpus_detect;
 pub mod desktop_ops;
 pub mod doctor;
 pub mod lesson;

--- a/crates/claudepot-cli/src/main.rs
+++ b/crates/claudepot-cli/src/main.rs
@@ -151,6 +151,17 @@ enum Commands {
         #[arg(long, short = 'f')]
         tail: bool,
     },
+    /// Build and inspect the analysis corpus — every transcript from
+    /// every machine, deduped, in `~/.claudepot/corpus.db`.
+    ///
+    /// Separate from `sessions.db` on purpose: that file is a cache of
+    /// this machine's live `~/.claude`, and its refresh deletes rows
+    /// whose file is gone. Importing another host's archive into it
+    /// would be mutually destructive with the normal refresh.
+    Corpus {
+        #[command(subcommand)]
+        action: CorpusAction,
+    },
     /// Ground-truth authentication status.
     ///
     /// Reads CC's shared credential slot, calls `/api/oauth/profile`,
@@ -537,6 +548,26 @@ enum LessonAction {
     Status {
         #[arg(long)]
         project: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum CorpusAction {
+    /// Walk the live `~/.claude/projects` plus every host under the
+    /// archive root and fold them in. Incremental; safe to re-run.
+    Index {
+        /// Archive root. Defaults to `~/claude-corpus-archive`.
+        #[arg(long)]
+        archive_root: Option<String>,
+    },
+    /// Per-host coverage and staleness.
+    Status,
+    /// Run the deterministic detectors and report candidates. No model
+    /// calls, no spend — this is the preview before any distillation.
+    Detect {
+        /// Cap per detector.
+        #[arg(long, default_value_t = 5000)]
+        limit: usize,
     },
 }
 
@@ -1252,6 +1283,13 @@ async fn main() -> Result<()> {
         },
         Commands::Doctor => commands::doctor::run(&ctx).await?,
         Commands::Logs { open, tail } => commands::logs::run(&ctx, open, tail).await?,
+        Commands::Corpus { action } => match action {
+            CorpusAction::Index { archive_root } => {
+                commands::corpus::index_cmd(&ctx, archive_root)?
+            }
+            CorpusAction::Status => commands::corpus::status_cmd(&ctx)?,
+            CorpusAction::Detect { limit } => commands::corpus_detect::detect_cmd(&ctx, limit)?,
+        },
         Commands::Status => commands::status::run(&ctx).await?,
         Commands::Usage { action } => match action {
             UsageAction::Report { window } => commands::usage::report(&ctx, &window).await?,

--- a/crates/claudepot-core/src/cc_retention.rs
+++ b/crates/claudepot-core/src/cc_retention.rs
@@ -1,0 +1,1035 @@
+//! Read + write CC's `cleanupPeriodDays` — the one Claude Code setting
+//! that destroys user data, and the only one Claudepot must never let a
+//! user meet by accident.
+//!
+//! # Why this gets its own module
+//!
+//! Every key in CC's settings schema whose description mentions
+//! delete/remove/disable merely turns a feature off — `disableAllHooks`,
+//! `prefersReducedMotion`, `alwaysThinkingEnabled`. Reversible, nothing
+//! at stake. `cleanupPeriodDays` is different in four ways, and all four
+//! are why a plain number input would be the wrong control:
+//!
+//! 1. **Sliding, not one-shot.** `getCutoffDate()` recomputes
+//!    `now - cleanupPeriodDays` on *every* run, so the loss is
+//!    continuous — roughly a day of corpus per day, forever.
+//! 2. **Its "off-looking" value is its worst value.** `0` does not mean
+//!    "no cleanup". It means *disable session persistence entirely and
+//!    delete existing transcripts at startup*. Every other key in the
+//!    file reads `0`/`false` as "do less"; this one reads it as "do the
+//!    maximum harm". So [`RetentionMode`] never renders `0` as an off
+//!    position — see [`RetentionMode::PersistenceDisabled`].
+//! 3. **Silent.** `cleanupOldSessionFiles()` computes an exact count of
+//!    the transcripts it just unlinked and its caller
+//!    (`cleanupOldMessageFilesInBackground`) discards the return value.
+//!    No log, no toast, no event. Nothing in CC ever tells the user.
+//! 4. **Invisible on disk.** Cleanup unlinks the small, valuable
+//!    top-level session transcripts and never walks `subagents/`, so the
+//!    directory *grows* while history is destroyed. Disk usage can never
+//!    reveal the loss — which is why [`TranscriptRisk`] reports
+//!    `nested_immortal` alongside the at-risk count.
+//!
+//! # CC's resolution model
+//!
+//! Verified against `~/github/claude_code_src/src/utils/cleanup.ts:23`
+//! (`DEFAULT_CLEANUP_PERIOD_DAYS = 30`) and `:27`:
+//!
+//! ```text
+//! const days = settings.cleanupPeriodDays ?? 30
+//! cutoff = now - days * 24h
+//! // unlink any projects/<slug>/*.jsonl|*.cast whose mtime < cutoff
+//! ```
+//!
+//! Unlike [`crate::auto_dream`], the absent case is a *known* constant
+//! rather than a server flag, so this control is two-state (default vs
+//! explicit) rather than three — but the default is still surfaced
+//! distinctly, because "30 because nobody chose" and "30 because someone
+//! chose 30" warrant different UI.
+//!
+//! # Naming
+//!
+//! Not `retention` — [`crate::retention`] already owns an unrelated
+//! concept (Claudepot's own `activity_cards` / `metrics_tick` pruning
+//! horizon). `cc_` prefix matches `cc_daemon` / `cc_doctor` / `cc_tips`
+//! for CC-facing concerns.
+//!
+//! Global-only: transcript retention is a per-user setting, so this
+//! writes `~/.claude/settings.json` and never a project layer.
+
+use crate::paths::claude_config_dir;
+use crate::settings_writer::{
+    clear_bool_setting, mutate_settings, read_i64_setting, SettingsLayer, SettingsWriteError,
+};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Setting key in CC's `settings.json`.
+pub const CLEANUP_PERIOD_DAYS_KEY: &str = "cleanupPeriodDays";
+
+/// CC's built-in default when the key is absent
+/// (`utils/cleanup.ts:23 DEFAULT_CLEANUP_PERIOD_DAYS`).
+pub const CC_DEFAULT_CLEANUP_PERIOD_DAYS: i64 = 30;
+
+/// How far ahead [`TranscriptRisk`] looks when counting "about to be
+/// deleted". Seven days is the shortest horizon that still gives a user
+/// who opens Claudepot weekly a chance to act before the loss.
+pub const DEFAULT_RISK_HORIZON_DAYS: i64 = 7;
+
+const MS_PER_DAY: i64 = 24 * 60 * 60 * 1_000;
+
+/// File extensions CC's `cleanupOldSessionFiles` unlinks by mtime.
+/// Both are checked at `utils/cleanup.ts` in the `entry.isFile()` arm.
+const CLEANED_EXTENSIONS: [&str; 2] = ["jsonl", "cast"];
+
+/// What the current setting expresses. Deliberately **not** a bare
+/// number: the UI must be unable to render `0` as an ordinary low value
+/// on the same scale as `30`.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum RetentionMode {
+    /// Key absent — CC's 30-day default silently applies. This is the
+    /// state that cost this user five months of transcripts.
+    CcDefault,
+    /// An explicit positive day count.
+    Explicit,
+    /// `cleanupPeriodDays: 0` — CC writes no transcripts at all and
+    /// deletes existing ones at startup. Never an "off" position.
+    PersistenceDisabled,
+    /// A negative value. CC's schema declares the key
+    /// `z.number().nonnegative().int()`, so this invalidates the whole
+    /// settings file — which makes CC skip cleanup entirely. See
+    /// [`RetentionState::cleanup_suppressed`]: the transcripts are safe,
+    /// but only by accident, and "restore the default" would undo it.
+    Invalid,
+}
+
+/// Resolved retention state for one host's `~/.claude/settings.json`.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RetentionState {
+    pub mode: RetentionMode,
+    /// Raw value found in settings, if the key is present at all.
+    pub configured_days: Option<i64>,
+    /// The window CC would enforce if it were running cleanup at all.
+    /// Meaningless when [`Self::cleanup_suppressed`] is set — check that
+    /// first; for [`RetentionMode::Invalid`] this holds CC's nominal
+    /// default purely so the field is never a surprising sentinel.
+    pub effective_days: i64,
+    /// True when nobody has chosen — the silent-default case.
+    pub is_cc_default: bool,
+    /// CC is currently not running cleanup at all.
+    ///
+    /// `cleanupOldMessageFilesInBackground` bails before touching any
+    /// file when the settings file has validation errors *and* the raw
+    /// settings explicitly contain `cleanupPeriodDays`
+    /// (`utils/cleanup.ts:576-586`). A negative value triggers exactly
+    /// that: `z.number().nonnegative()` rejects it, and the key is by
+    /// definition present.
+    ///
+    /// So an invalid value accidentally *protects* transcripts. That
+    /// changes the advice completely — "restore the default" would
+    /// clear the error, re-arm cleanup, and delete everything past the
+    /// 30-day line. The UI must say "fix the value", never "restore
+    /// the default".
+    pub cleanup_suppressed: bool,
+}
+
+/// Counts derived by walking the transcript tree the same way CC's
+/// cleanup does.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TranscriptRisk {
+    /// Top-level `projects/<slug>/*.jsonl|*.cast` files — everything CC
+    /// is willing to unlink.
+    pub total_transcripts: u64,
+    /// Already older than the cutoff. CC deletes these on its next
+    /// launch, with no further warning.
+    pub already_deletable: u64,
+    /// Will cross the cutoff within `horizon_days` (excludes
+    /// `already_deletable`).
+    pub at_risk_within_horizon: u64,
+    /// Oldest surviving transcript, epoch ms.
+    pub oldest_ms: Option<i64>,
+    /// Files nested deeper than the project directory (`subagents/`,
+    /// tool-result payloads). CC's cleanup never walks these, so they
+    /// accumulate forever — this is why folder size can rise while
+    /// history is being destroyed.
+    pub nested_immortal: u64,
+    pub horizon_days: i64,
+    /// Some part of the tree could not be read (permissions, a
+    /// transient I/O error, a `stat` that failed mid-walk).
+    ///
+    /// This exists because the counts above are otherwise
+    /// indistinguishable between "nothing is at risk" and "we could not
+    /// look". In a feature whose entire job is warning about silent
+    /// data loss, a failed scan rendering as reassurance is the worst
+    /// possible failure mode — so callers MUST NOT print "nothing is
+    /// scheduled for deletion" while this is true.
+    ///
+    /// A missing projects directory is *not* incomplete: CC simply has
+    /// no transcripts yet, which is a real and safe zero.
+    pub scan_incomplete: bool,
+}
+
+/// Everything the Retention pane needs in one read: what is configured,
+/// and what that costs on this machine right now.
+///
+/// Composed here rather than in the Tauri command so the command layer
+/// stays free of logic (`rules/architecture.md`).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RetentionReport {
+    pub state: RetentionState,
+    pub risk: TranscriptRisk,
+    /// Raising `cleanupPeriodDays` buys time; it does not make the
+    /// corpus durable — the files still live in CC's cache directory
+    /// under CC's rules. The pane states this so a large number cannot
+    /// read as "solved". See the plan's P0 archive contract.
+    pub is_durable_archive: bool,
+}
+
+/// Resolve settings and scan the live transcript tree. `now_ms` is
+/// injected so the guillotine math stays testable.
+pub fn report(now_ms: i64, horizon_days: i64) -> RetentionReport {
+    let state = resolve_retention();
+    let risk = scan_transcript_risk(&state, now_ms, horizon_days);
+    RetentionReport {
+        state,
+        risk,
+        // Always false today. Flipping this is P0's job, not a setting's.
+        is_durable_archive: false,
+    }
+}
+
+/// The one boot-time signal: transcripts on this machine are scheduled
+/// for deletion and nothing else will say so.
+///
+/// # Why there is no "dismissed" flag
+///
+/// The plan asks that the warning "never fire again once dismissed with
+/// retention raised". Persisting a dismissal would be the obvious
+/// implementation and the wrong one — a dismissal flag silences the
+/// warning while the data is still being deleted, which is precisely
+/// the failure this whole feature exists to prevent.
+///
+/// Gating on the *condition* instead gets the requested behaviour for
+/// free: raising retention drops `already_deletable` and
+/// `at_risk_within_horizon` to zero, so [`warning`] returns `None` and
+/// never fires again. Dismissing *without* raising retention lets it
+/// return next boot — correct, because the transcripts really are still
+/// on the timer. One entry per launch is not spam; it is the honest
+/// report CC itself declines to make.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RetentionWarning {
+    pub already_deletable: u64,
+    pub at_risk_within_horizon: u64,
+    pub effective_days: i64,
+    /// True when the user never chose this window — worth saying out
+    /// loud, because "30 days" reads very differently once you know
+    /// nobody picked it.
+    pub is_cc_default: bool,
+    pub horizon_days: i64,
+    /// The transcript tree could not be fully read. The counts are a
+    /// floor, not a total.
+    pub scan_incomplete: bool,
+}
+
+/// Decide whether the boot check should surface anything. Pure.
+///
+/// Fires only when transcripts are actually at risk — never merely
+/// because the setting is unset. A machine with no transcripts near the
+/// cutoff has nothing to warn about, whatever its configuration.
+pub fn warning(report: &RetentionReport) -> Option<RetentionWarning> {
+    let r = &report.risk;
+    // CC is not running cleanup at all, so nothing can be expiring
+    // however little of the tree we managed to read. Checked before the
+    // `scan_incomplete` clause below, which would otherwise fire a
+    // "conversations are expiring" boot warning for a machine where
+    // deletion is switched off — alarming the user about the one thing
+    // that is not happening. The broken setting is still surfaced, but
+    // in the pane, where it can be explained.
+    if report.state.cleanup_suppressed {
+        return None;
+    }
+    // An incomplete scan is not evidence of safety. Staying silent here
+    // would mean a permissions failure reads exactly like "all clear",
+    // in the one feature where that mistake costs the user their
+    // history.
+    if r.already_deletable == 0 && r.at_risk_within_horizon == 0 && !r.scan_incomplete {
+        return None;
+    }
+    Some(RetentionWarning {
+        already_deletable: r.already_deletable,
+        at_risk_within_horizon: r.at_risk_within_horizon,
+        effective_days: report.state.effective_days,
+        is_cc_default: report.state.is_cc_default,
+        horizon_days: r.horizon_days,
+        scan_incomplete: r.scan_incomplete,
+    })
+}
+
+impl RetentionWarning {
+    /// One-line body for the bell entry. Leads with the count, names
+    /// the silence, and states the fix — the same shape as the pane.
+    pub fn message(&self) -> String {
+        if self.already_deletable == 0 && self.at_risk_within_horizon == 0 {
+            // Only reachable via `scan_incomplete` — say what we don't
+            // know rather than inventing a count.
+            return "Claudepot could not read part of Claude Code's transcript folder, \
+                    so it cannot tell you what is scheduled for deletion. \
+                    Settings → Retention."
+                .to_string();
+        }
+        let head = if self.already_deletable > 0 {
+            format!(
+                "Claude Code will delete {} saved conversation{} on its next launch",
+                self.already_deletable,
+                if self.already_deletable == 1 { "" } else { "s" }
+            )
+        } else {
+            format!(
+                "{} saved conversation{} will be deleted within {} days",
+                self.at_risk_within_horizon,
+                if self.at_risk_within_horizon == 1 {
+                    ""
+                } else {
+                    "s"
+                },
+                self.horizon_days
+            )
+        };
+        let why = if self.is_cc_default {
+            format!(
+                " — its {}-day default, which nobody chose",
+                self.effective_days
+            )
+        } else {
+            String::new()
+        };
+        format!("{head}{why}. Settings → Retention.")
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RetentionError {
+    #[error("write CC settings")]
+    Write(#[from] SettingsWriteError),
+    #[error("cleanupPeriodDays must be positive; got {0}. Use disable_persistence() to set 0.")]
+    NonPositive(i64),
+}
+
+fn user_settings_path() -> PathBuf {
+    claude_config_dir().join("settings.json")
+}
+
+fn projects_dir() -> PathBuf {
+    claude_config_dir().join("projects")
+}
+
+/// Resolve retention from `~/.claude/settings.json`. Pure read.
+pub fn resolve_retention() -> RetentionState {
+    let configured_days = read_i64_setting(&user_settings_path(), CLEANUP_PERIOD_DAYS_KEY)
+        .ok()
+        .flatten();
+    state_from_configured(configured_days)
+}
+
+/// Split out so the resolution table is testable without a filesystem.
+fn state_from_configured(configured_days: Option<i64>) -> RetentionState {
+    let (mode, effective_days) = match configured_days {
+        None => (RetentionMode::CcDefault, CC_DEFAULT_CLEANUP_PERIOD_DAYS),
+        Some(0) => (RetentionMode::PersistenceDisabled, 0),
+        Some(d) if d < 0 => (RetentionMode::Invalid, CC_DEFAULT_CLEANUP_PERIOD_DAYS),
+        Some(d) => (RetentionMode::Explicit, d),
+    };
+    RetentionState {
+        mode,
+        configured_days,
+        effective_days,
+        is_cc_default: mode == RetentionMode::CcDefault,
+        cleanup_suppressed: mode == RetentionMode::Invalid,
+    }
+}
+
+/// Count transcripts against the cutoff CC will apply, walking exactly
+/// what `cleanupOldSessionFiles` walks: files sitting *directly* in each
+/// `projects/<slug>/` directory. Anything deeper is counted separately
+/// as `nested_immortal` — cleanup never reaches it.
+///
+/// `now_ms` is injected so the guillotine math is testable.
+pub fn scan_transcript_risk(
+    state: &RetentionState,
+    now_ms: i64,
+    horizon_days: i64,
+) -> TranscriptRisk {
+    scan_transcript_risk_in(&projects_dir(), state, now_ms, horizon_days)
+}
+
+/// [`scan_transcript_risk`] against an explicit root, so tests (and a
+/// future archive importer) can point it at a directory that is not the
+/// live `~/.claude/projects`.
+pub fn scan_transcript_risk_in(
+    root: &Path,
+    state: &RetentionState,
+    now_ms: i64,
+    horizon_days: i64,
+) -> TranscriptRisk {
+    let mut risk = TranscriptRisk {
+        horizon_days,
+        ..Default::default()
+    };
+    // Every step is saturating: `now_ms` and `effective_days` both come
+    // from outside (a clock and a user-editable settings file), so an
+    // absurd value must clamp rather than overflow. `i64` subtraction
+    // panics in debug and wraps in release, and a wrapped cutoff would
+    // invert the risk classification — reporting "safe" for transcripts
+    // that are about to be deleted.
+    // When CC is skipping cleanup entirely (invalid settings — see
+    // `RetentionState::cleanup_suppressed`), no file is at risk however
+    // old it is. Pushing the cutoff to the floor keeps the counting
+    // loop uniform instead of branching around it.
+    let (cutoff_ms, horizon_cutoff_ms) = if state.cleanup_suppressed {
+        (i64::MIN, i64::MIN)
+    } else {
+        let cutoff = now_ms.saturating_sub(state.effective_days.saturating_mul(MS_PER_DAY));
+        (
+            cutoff,
+            cutoff.saturating_add(horizon_days.saturating_mul(MS_PER_DAY)),
+        )
+    };
+
+    let projects = match std::fs::read_dir(root) {
+        Ok(p) => p,
+        // A missing projects dir is a real zero (CC has written no
+        // transcripts). Anything else means we could not look, which
+        // must never be rendered as reassurance.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return risk,
+        Err(_) => {
+            risk.scan_incomplete = true;
+            return risk;
+        }
+    };
+    for project in projects {
+        let Ok(project) = project else {
+            risk.scan_incomplete = true;
+            continue;
+        };
+        match project.file_type() {
+            Ok(t) if t.is_dir() => {}
+            Ok(_) => continue,
+            Err(_) => {
+                risk.scan_incomplete = true;
+                continue;
+            }
+        }
+        let entries = match std::fs::read_dir(project.path()) {
+            Ok(e) => e,
+            Err(_) => {
+                risk.scan_incomplete = true;
+                continue;
+            }
+        };
+        for entry in entries {
+            let Ok(entry) = entry else {
+                risk.scan_incomplete = true;
+                continue;
+            };
+            let ft = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(_) => {
+                    risk.scan_incomplete = true;
+                    continue;
+                }
+            };
+            if ft.is_dir() {
+                let (n, ok) = count_nested(&entry.path());
+                risk.nested_immortal += n;
+                if !ok {
+                    risk.scan_incomplete = true;
+                }
+                continue;
+            }
+            if !is_cleaned_file(&entry.path()) {
+                continue;
+            }
+            risk.total_transcripts += 1;
+            let Some(mtime_ms) = mtime_ms(&entry.path()) else {
+                // We know a transcript is here but not how old it is,
+                // so it cannot be classified either way.
+                risk.scan_incomplete = true;
+                continue;
+            };
+            risk.oldest_ms = Some(match risk.oldest_ms {
+                Some(prev) if prev <= mtime_ms => prev,
+                _ => mtime_ms,
+            });
+            if mtime_ms < cutoff_ms {
+                risk.already_deletable += 1;
+            } else if mtime_ms < horizon_cutoff_ms {
+                risk.at_risk_within_horizon += 1;
+            }
+        }
+    }
+    risk
+}
+
+/// Recursively count `.jsonl` / `.cast` files below a session directory.
+/// These are the ones cleanup never unlinks.
+///
+/// Returns `(count, complete)` — `complete == false` when any part of
+/// the subtree could not be read, so the caller can mark the whole scan
+/// incomplete rather than under-reporting silently.
+fn count_nested(dir: &Path) -> (u64, bool) {
+    let mut n = 0;
+    let mut complete = true;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return (0, false);
+    };
+    for entry in entries {
+        let Ok(entry) = entry else {
+            complete = false;
+            continue;
+        };
+        match entry.file_type() {
+            Ok(ft) if ft.is_dir() => {
+                let (sub, ok) = count_nested(&entry.path());
+                n += sub;
+                complete &= ok;
+            }
+            Ok(_) => {
+                if is_cleaned_file(&entry.path()) {
+                    n += 1;
+                }
+            }
+            Err(_) => complete = false,
+        }
+    }
+    (n, complete)
+}
+
+fn is_cleaned_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| CLEANED_EXTENSIONS.contains(&e))
+        .unwrap_or(false)
+}
+
+fn mtime_ms(path: &Path) -> Option<i64> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    let dur = modified.duration_since(std::time::UNIX_EPOCH).ok()?;
+    i64::try_from(dur.as_millis()).ok()
+}
+
+/// Write an explicit positive retention window to
+/// `~/.claude/settings.json`.
+///
+/// Refuses `0` — that is not a longer/shorter setting on the same
+/// scale, it is "delete everything and stop persisting", and it must go
+/// through [`disable_persistence`] so no caller reaches it by passing a
+/// number through a slider.
+pub fn set_retention_days(days: i64) -> Result<(), RetentionError> {
+    if days <= 0 {
+        return Err(RetentionError::NonPositive(days));
+    }
+    mutate_settings(SettingsLayer::User, Path::new(""), |obj| {
+        obj.insert(
+            CLEANUP_PERIOD_DAYS_KEY.to_string(),
+            serde_json::Value::from(days),
+        );
+    })?;
+    Ok(())
+}
+
+/// Remove the key so CC's 30-day default applies again.
+pub fn clear_retention() -> Result<(), RetentionError> {
+    clear_bool_setting(SettingsLayer::User, Path::new(""), CLEANUP_PERIOD_DAYS_KEY)?;
+    Ok(())
+}
+
+/// Write `cleanupPeriodDays: 0`: CC stops writing transcripts entirely
+/// and deletes the existing ones at next startup.
+///
+/// Separate from [`set_retention_days`] on purpose. This is the one call
+/// that destroys history, so it is named for what it does and cannot be
+/// reached by passing a value to the ordinary setter.
+pub fn disable_persistence() -> Result<(), RetentionError> {
+    mutate_settings(SettingsLayer::User, Path::new(""), |obj| {
+        obj.insert(
+            CLEANUP_PERIOD_DAYS_KEY.to_string(),
+            serde_json::Value::from(0),
+        );
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value as JsonValue;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn isolated() -> (TempDir, std::sync::MutexGuard<'static, ()>) {
+        let lock = crate::testing::lock_data_dir();
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path().join("config-dir");
+        std::env::set_var("CLAUDE_CONFIG_DIR", &cfg);
+        fs::create_dir_all(&cfg).unwrap();
+        (tmp, lock)
+    }
+
+    fn write_user_settings(body: &str) {
+        let p = user_settings_path();
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(&p, body).unwrap();
+    }
+
+    // ─── resolution table ───────────────────────────────────────────
+
+    #[test]
+    fn absent_key_is_cc_default_thirty() {
+        let s = state_from_configured(None);
+        assert_eq!(s.mode, RetentionMode::CcDefault);
+        assert_eq!(s.effective_days, CC_DEFAULT_CLEANUP_PERIOD_DAYS);
+        assert!(s.is_cc_default);
+    }
+
+    #[test]
+    fn zero_is_persistence_disabled_not_off() {
+        let s = state_from_configured(Some(0));
+        assert_eq!(s.mode, RetentionMode::PersistenceDisabled);
+        assert_eq!(s.effective_days, 0);
+        assert!(!s.is_cc_default);
+    }
+
+    /// A negative value fails CC's `z.number().nonnegative()` schema.
+    /// `cleanupOldMessageFilesInBackground` then bails before deleting
+    /// anything, because settings have errors AND the raw key is
+    /// present — so an invalid value accidentally *protects*
+    /// transcripts.
+    #[test]
+    fn negative_suppresses_cleanup_entirely() {
+        let s = state_from_configured(Some(-1));
+        assert_eq!(s.mode, RetentionMode::Invalid);
+        assert!(s.cleanup_suppressed);
+        assert!(!s.is_cc_default);
+    }
+
+    #[test]
+    fn valid_modes_do_not_suppress_cleanup() {
+        for cfg in [None, Some(0), Some(30), Some(3650)] {
+            assert!(
+                !state_from_configured(cfg).cleanup_suppressed,
+                "cfg {cfg:?} must not read as cleanup-suppressed"
+            );
+        }
+    }
+
+    /// The dangerous consequence of the above: with cleanup suppressed,
+    /// nothing is at risk however old it is. Reporting risk here would
+    /// push the user toward "restore the default", which clears the
+    /// error, re-arms cleanup, and deletes everything past 30 days.
+    #[test]
+    fn suppressed_cleanup_puts_nothing_at_risk() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let now = 1_800_000_000_000i64;
+        seed_projects(&root, &[400, 800], &[], now);
+        let r = scan_transcript_risk_in(&root, &state_from_configured(Some(-1)), now, 7);
+        assert_eq!(r.total_transcripts, 2);
+        assert_eq!(r.already_deletable, 0);
+        assert_eq!(r.at_risk_within_horizon, 0);
+    }
+
+    #[test]
+    fn positive_is_explicit() {
+        let s = state_from_configured(Some(3650));
+        assert_eq!(s.mode, RetentionMode::Explicit);
+        assert_eq!(s.effective_days, 3650);
+        assert!(!s.is_cc_default);
+    }
+
+    // ─── write path ─────────────────────────────────────────────────
+
+    #[test]
+    fn set_and_clear_round_trip_preserving_other_keys() {
+        let (_t, _l) = isolated();
+        write_user_settings(r#"{"keep":1}"#);
+
+        set_retention_days(3650).unwrap();
+        assert_eq!(resolve_retention().configured_days, Some(3650));
+        assert_eq!(resolve_retention().mode, RetentionMode::Explicit);
+
+        clear_retention().unwrap();
+        let v: JsonValue =
+            serde_json::from_slice(&fs::read(user_settings_path()).unwrap()).unwrap();
+        assert!(v.get(CLEANUP_PERIOD_DAYS_KEY).is_none());
+        assert_eq!(v["keep"], JsonValue::from(1));
+        assert_eq!(resolve_retention().mode, RetentionMode::CcDefault);
+    }
+
+    /// The whole point of the module: a slider cannot reach 0.
+    #[test]
+    fn set_retention_days_refuses_zero_and_negatives() {
+        let (_t, _l) = isolated();
+        assert!(matches!(
+            set_retention_days(0),
+            Err(RetentionError::NonPositive(0))
+        ));
+        assert!(matches!(
+            set_retention_days(-5),
+            Err(RetentionError::NonPositive(-5))
+        ));
+        // and nothing was written
+        assert_eq!(resolve_retention().configured_days, None);
+    }
+
+    #[test]
+    fn disable_persistence_is_the_only_route_to_zero() {
+        let (_t, _l) = isolated();
+        disable_persistence().unwrap();
+        let s = resolve_retention();
+        assert_eq!(s.configured_days, Some(0));
+        assert_eq!(s.mode, RetentionMode::PersistenceDisabled);
+    }
+
+    #[test]
+    fn non_integer_value_reads_as_unset() {
+        let (_t, _l) = isolated();
+        write_user_settings(r#"{"cleanupPeriodDays":"thirty"}"#);
+        assert_eq!(resolve_retention().mode, RetentionMode::CcDefault);
+    }
+
+    // ─── risk scan ──────────────────────────────────────────────────
+
+    /// Build `projects/<slug>/` with files at given ages in days.
+    fn seed_projects(root: &Path, top_level_ages: &[i64], nested_ages: &[i64], now_ms: i64) {
+        let proj = root.join("-Users-joker-demo");
+        fs::create_dir_all(&proj).unwrap();
+        for (i, age) in top_level_ages.iter().enumerate() {
+            let p = proj.join(format!("session-{i}.jsonl"));
+            fs::write(&p, b"{}\n").unwrap();
+            set_mtime(&p, now_ms - age * MS_PER_DAY);
+        }
+        let sub = proj.join("0000-session").join("subagents");
+        fs::create_dir_all(&sub).unwrap();
+        for (i, age) in nested_ages.iter().enumerate() {
+            let p = sub.join(format!("agent-{i}.jsonl"));
+            fs::write(&p, b"{}\n").unwrap();
+            set_mtime(&p, now_ms - age * MS_PER_DAY);
+        }
+    }
+
+    fn set_mtime(path: &Path, ms: i64) {
+        let t = filetime::FileTime::from_unix_time(ms / 1000, ((ms % 1000) * 1_000_000) as u32);
+        filetime::set_file_mtime(path, t).unwrap();
+    }
+
+    #[test]
+    fn counts_only_top_level_files_as_deletable() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let now = 1_800_000_000_000i64;
+        // three top-level: 60d (past cutoff), 27d (within 7d horizon), 1d (safe)
+        // two nested at 400d — cleanup never walks these
+        seed_projects(&root, &[60, 27, 1], &[400, 400], now);
+
+        let state = state_from_configured(None); // 30-day default
+        let r = scan_transcript_risk_in(&root, &state, now, 7);
+
+        assert_eq!(
+            r.total_transcripts, 3,
+            "nested files are not transcripts CC deletes"
+        );
+        assert_eq!(r.already_deletable, 1, "the 60-day file is past the cutoff");
+        assert_eq!(
+            r.at_risk_within_horizon, 1,
+            "the 27-day file crosses within 7 days"
+        );
+        assert_eq!(r.nested_immortal, 2, "subagent files survive forever");
+    }
+
+    /// The reason the loss is invisible: the immortal nested files are
+    /// the bulk, so directory size rises while transcripts are deleted.
+    #[test]
+    fn nested_immortal_is_reported_separately_from_deletable() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let now = 1_800_000_000_000i64;
+        seed_projects(&root, &[400], &[400; 20], now);
+        let r = scan_transcript_risk_in(&root, &state_from_configured(None), now, 7);
+        assert_eq!(r.already_deletable, 1);
+        assert_eq!(r.nested_immortal, 20);
+    }
+
+    #[test]
+    fn long_retention_puts_nothing_at_risk() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let now = 1_800_000_000_000i64;
+        seed_projects(&root, &[60, 27, 1], &[], now);
+        let r = scan_transcript_risk_in(&root, &state_from_configured(Some(3650)), now, 7);
+        assert_eq!(r.already_deletable, 0);
+        assert_eq!(r.at_risk_within_horizon, 0);
+        assert_eq!(r.total_transcripts, 3);
+    }
+
+    #[test]
+    fn persistence_disabled_puts_everything_at_risk() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let now = 1_800_000_000_000i64;
+        seed_projects(&root, &[60, 27, 1], &[], now);
+        let r = scan_transcript_risk_in(&root, &state_from_configured(Some(0)), now, 7);
+        assert_eq!(
+            r.already_deletable, 3,
+            "cutoff is now, so every file is past it"
+        );
+    }
+
+    #[test]
+    fn oldest_ms_reports_the_earliest_surviving_transcript() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let now = 1_800_000_000_000i64;
+        seed_projects(&root, &[60, 27, 1], &[], now);
+        let r = scan_transcript_risk_in(&root, &state_from_configured(None), now, 7);
+        assert_eq!(r.oldest_ms, Some(now - 60 * MS_PER_DAY));
+    }
+
+    // ─── scan completeness ──────────────────────────────────────────
+
+    /// The worst failure this feature could have: an unreadable tree
+    /// rendering as "nothing is scheduled for deletion".
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_projects_dir_is_incomplete_not_safe() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        fs::create_dir_all(&root).unwrap();
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let r = scan_transcript_risk_in(&root, &state_from_configured(None), 1_800_000_000_000, 7);
+
+        // Restore before assertions so a failure doesn't leave an
+        // unremovable temp dir behind.
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            r.scan_incomplete,
+            "an unreadable tree must not read as safe"
+        );
+        assert_eq!(r.already_deletable, 0);
+    }
+
+    /// ...and the boot check must speak up about it rather than
+    /// staying silent on zero counts.
+    #[test]
+    fn incomplete_scan_still_warns() {
+        let r = RetentionReport {
+            state: state_from_configured(None),
+            risk: TranscriptRisk {
+                scan_incomplete: true,
+                horizon_days: 7,
+                ..Default::default()
+            },
+            is_durable_archive: false,
+        };
+        let w = warning(&r).expect("incomplete scan must warn");
+        assert!(w.scan_incomplete);
+        assert!(w.message().contains("could not read"));
+    }
+
+    /// Regression: an incomplete scan must not produce a "conversations
+    /// are expiring" warning on a machine where CC's cleanup is
+    /// switched off entirely — that alarms the user about the one thing
+    /// that cannot be happening.
+    #[test]
+    fn suppressed_cleanup_never_warns_even_on_an_incomplete_scan() {
+        let r = RetentionReport {
+            state: state_from_configured(Some(-1)),
+            risk: TranscriptRisk {
+                scan_incomplete: true,
+                horizon_days: 7,
+                ..Default::default()
+            },
+            is_durable_archive: false,
+        };
+        assert!(r.state.cleanup_suppressed);
+        assert!(warning(&r).is_none());
+    }
+
+    #[test]
+    fn a_complete_empty_scan_is_not_incomplete() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        fs::create_dir_all(&root).unwrap();
+        let r = scan_transcript_risk_in(&root, &state_from_configured(None), 1_800_000_000_000, 7);
+        assert!(!r.scan_incomplete);
+    }
+
+    // ─── arithmetic safety ──────────────────────────────────────────
+
+    /// `now_ms` and `effective_days` both arrive from outside (a clock
+    /// and a user-editable file). Neither may panic the scan.
+    #[test]
+    fn extreme_values_saturate_instead_of_overflowing() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let now = 1_800_000_000_000i64;
+        seed_projects(&root, &[1], &[], now);
+
+        for (days, horizon, now_ms) in [
+            (i64::MAX, 7, now),
+            (i64::MAX, i64::MAX, now),
+            (1, 7, i64::MAX),
+            (1, 7, i64::MIN),
+            (i64::MAX, i64::MAX, i64::MAX),
+        ] {
+            let st = state_from_configured(Some(days));
+            // Must not panic in debug (where overflow aborts).
+            let _ = scan_transcript_risk_in(&root, &st, now_ms, horizon);
+        }
+    }
+
+    #[test]
+    fn missing_projects_dir_is_zero_not_an_error() {
+        let tmp = TempDir::new().unwrap();
+        let r = scan_transcript_risk_in(
+            &tmp.path().join("nope"),
+            &state_from_configured(None),
+            1_800_000_000_000,
+            7,
+        );
+        assert_eq!(
+            r,
+            TranscriptRisk {
+                horizon_days: 7,
+                ..Default::default()
+            }
+        );
+    }
+
+    // ─── boot warning ───────────────────────────────────────────────
+
+    fn rep(state: RetentionState, risk: TranscriptRisk) -> RetentionReport {
+        RetentionReport {
+            state,
+            risk,
+            is_durable_archive: false,
+        }
+    }
+
+    #[test]
+    fn no_warning_when_nothing_is_at_risk() {
+        let r = rep(
+            state_from_configured(None),
+            TranscriptRisk {
+                total_transcripts: 460,
+                horizon_days: 7,
+                ..Default::default()
+            },
+        );
+        assert!(warning(&r).is_none());
+    }
+
+    /// An unset setting is not by itself a reason to nag — only actual
+    /// scheduled deletion is.
+    #[test]
+    fn cc_default_alone_does_not_warn() {
+        let r = rep(state_from_configured(None), TranscriptRisk::default());
+        assert!(warning(&r).is_none());
+    }
+
+    #[test]
+    fn warns_when_transcripts_are_already_past_the_cutoff() {
+        let r = rep(
+            state_from_configured(None),
+            TranscriptRisk {
+                already_deletable: 1247,
+                horizon_days: 7,
+                ..Default::default()
+            },
+        );
+        let w = warning(&r).expect("should warn");
+        assert_eq!(w.already_deletable, 1247);
+        assert!(w.message().contains("1247"));
+        assert!(w.message().contains("nobody chose"));
+    }
+
+    #[test]
+    fn warns_on_upcoming_risk_even_when_none_are_past_yet() {
+        let r = rep(
+            state_from_configured(Some(30)),
+            TranscriptRisk {
+                at_risk_within_horizon: 3,
+                horizon_days: 7,
+                ..Default::default()
+            },
+        );
+        let w = warning(&r).expect("should warn");
+        assert_eq!(w.already_deletable, 0);
+        assert!(w.message().contains("within 7 days"));
+        // Explicitly chosen, so we don't editorialise about defaults.
+        assert!(!w.message().contains("nobody chose"));
+    }
+
+    /// The dismissal requirement, satisfied by gating on the condition
+    /// rather than persisting a flag: raise retention, and the warning
+    /// stops on its own.
+    #[test]
+    fn raising_retention_silences_the_warning_without_a_dismiss_flag() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let now = 1_800_000_000_000i64;
+        seed_projects(&root, &[60, 27, 1], &[], now);
+
+        let before = state_from_configured(None);
+        let r_before = rep(
+            before.clone(),
+            scan_transcript_risk_in(&root, &before, now, 7),
+        );
+        assert!(warning(&r_before).is_some());
+
+        let after = state_from_configured(Some(3650));
+        let r_after = rep(
+            after.clone(),
+            scan_transcript_risk_in(&root, &after, now, 7),
+        );
+        assert!(warning(&r_after).is_none());
+    }
+
+    #[test]
+    fn singular_plural_reads_correctly() {
+        let one = rep(
+            state_from_configured(Some(30)),
+            TranscriptRisk {
+                already_deletable: 1,
+                horizon_days: 7,
+                ..Default::default()
+            },
+        );
+        assert!(warning(&one)
+            .unwrap()
+            .message()
+            .contains("1 saved conversation on"));
+    }
+
+    /// `.cast` recordings are unlinked by the same arm of CC's cleanup.
+    #[test]
+    fn cast_files_count_as_deletable_transcripts() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let now = 1_800_000_000_000i64;
+        let proj = root.join("-Users-joker-demo");
+        fs::create_dir_all(&proj).unwrap();
+        let p = proj.join("rec.cast");
+        fs::write(&p, b"x").unwrap();
+        set_mtime(&p, now - 60 * MS_PER_DAY);
+        let other = proj.join("notes.md");
+        fs::write(&other, b"x").unwrap();
+        set_mtime(&other, now - 60 * MS_PER_DAY);
+
+        let r = scan_transcript_risk_in(&root, &state_from_configured(None), now, 7);
+        assert_eq!(r.total_transcripts, 1, "only .jsonl/.cast are cleaned");
+        assert_eq!(r.already_deletable, 1);
+    }
+}

--- a/crates/claudepot-core/src/corpus.rs
+++ b/crates/claudepot-core/src/corpus.rs
@@ -1,0 +1,993 @@
+//! The analysis corpus — every transcript this user has, from every
+//! machine, in one queryable place.
+//!
+//! # Why this is its own database file
+//!
+//! `sessions.db` is a **cache of one machine's live `~/.claude`**.
+//! `SessionIndex::refresh` diffs every row in it against whatever is
+//! found under one `config_dir` and deletes the remainder
+//! (`diff_fs_vs_db` → `codec::delete_row`, which cascades turns and,
+//! via the v4 FK, exchanges / tool_calls / FTS). That is correct for a
+//! cache and fatal for an archive: point `refresh` at an imported
+//! corpus and it deletes the live rows; run it again on the live
+//! directory and it deletes the imported ones.
+//!
+//! So the corpus lives in `~/.claudepot/corpus.db`, outside that loop.
+//! The consequences are all good ones:
+//!
+//! - **No migration.** Nothing lands on a 574 MB production database.
+//! - **`host_id` is a column, not a schema change.** The thing that
+//!   blocked the original multi-host phase costs one `TEXT NOT NULL`
+//!   here.
+//! - **Rebuildable by definition.** It is derived from files on disk,
+//!   so none of the durable-archive semantics (quota, export, real
+//!   deletion) are required to make it safe to throw away.
+//!
+//! Outputs do *not* live here. Distilled claims go to `memories` in
+//! `sessions.db`, which carries no foreign key to `sessions` and is
+//! never cascaded — verified, and the reason this split works at all.
+//!
+//! # Deduplication
+//!
+//! The same session is frequently present on several machines: four
+//! hosts here hold 14,059 transcript files between them, with real
+//! overlap. Counting those as distinct sessions would inflate every
+//! aggregate the detectors compute.
+//!
+//! Sessions are therefore keyed by **`session_id`** (CC's per-session
+//! UUID), with `corpus_files` recording every physical copy. When two
+//! hosts disagree — one synced mid-session, so the same UUID has more
+//! events on one machine — the **more complete** copy wins
+//! (`event_count`), because a truncated copy is a strictly worse
+//! answer to every question the corpus is asked.
+//!
+//! This replaces the plan's "content hash": a hash would answer
+//! "are these bytes identical", but the question that matters is "are
+//! these the same conversation, and which copy is best". A UUID plus a
+//! completeness comparison answers that directly, and does not require
+//! a second full read of 7.9 GB to decide whether to read it.
+
+pub mod detect;
+pub mod normalize;
+
+use crate::session::core::{scan_session, SessionRow};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Host id used for the machine Claudepot is running on. Archived
+/// corpora carry their source host's name instead.
+pub const LOCAL_HOST: &str = "local";
+
+pub const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS corpus_meta (
+    k TEXT PRIMARY KEY,
+    v TEXT NOT NULL
+);
+
+-- One row per logical conversation, deduped across hosts by CC's
+-- session UUID. Holds the most complete copy seen.
+CREATE TABLE IF NOT EXISTS corpus_sessions (
+    session_id       TEXT PRIMARY KEY,
+    project_path     TEXT    NOT NULL,
+    slug             TEXT    NOT NULL,
+    first_ts_ms      INTEGER,
+    last_ts_ms       INTEGER,
+    event_count      INTEGER NOT NULL,
+    message_count    INTEGER NOT NULL,
+    user_message_count      INTEGER NOT NULL,
+    assistant_message_count INTEGER NOT NULL,
+    first_user_prompt TEXT,
+    models_json      TEXT    NOT NULL,
+    git_branch       TEXT,
+    cc_version       TEXT,
+    has_error        INTEGER NOT NULL,
+    is_sidechain     INTEGER NOT NULL,
+    -- Which physical copy the row above was folded from.
+    best_host_id     TEXT    NOT NULL,
+    best_file_path   TEXT    NOT NULL,
+    indexed_at_ms    INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_corpus_sessions_project ON corpus_sessions(project_path);
+CREATE INDEX IF NOT EXISTS idx_corpus_sessions_last_ts ON corpus_sessions(last_ts_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_corpus_sessions_error   ON corpus_sessions(has_error);
+
+-- Every physical copy, on every host. `(size_bytes, mtime_ns)` is the
+-- re-scan guard, matching the idiom `sessions` already uses.
+CREATE TABLE IF NOT EXISTS corpus_files (
+    host_id       TEXT    NOT NULL,
+    file_path     TEXT    NOT NULL,
+    session_id    TEXT    NOT NULL,
+    size_bytes    INTEGER NOT NULL,
+    mtime_ns      INTEGER NOT NULL,
+    event_count   INTEGER NOT NULL,
+    indexed_at_ms INTEGER NOT NULL,
+    PRIMARY KEY (host_id, file_path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_corpus_files_session ON corpus_files(session_id);
+CREATE INDEX IF NOT EXISTS idx_corpus_files_host    ON corpus_files(host_id);
+
+-- Turn-level content. Keyed by `file_path`, not `session_id`: CC leaves
+-- the same session uuid in two project dirs after a move/adopt, so the
+-- uuid is unique only within a project. `corpus_sessions` dedups at the
+-- logical level; this table stays faithful to the physical file the
+-- turns were read from.
+CREATE TABLE IF NOT EXISTS corpus_exchanges (
+    id             TEXT    PRIMARY KEY,        -- <file_path>\x1f<turn_index>
+    file_path      TEXT    NOT NULL,
+    session_id     TEXT    NOT NULL,
+    turn_index     INTEGER NOT NULL,
+    timestamp_ms   INTEGER,
+    user_text      TEXT    NOT NULL,
+    assistant_text TEXT    NOT NULL,
+    UNIQUE (file_path, turn_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_corpus_exch_file    ON corpus_exchanges(file_path);
+CREATE INDEX IF NOT EXISTS idx_corpus_exch_session ON corpus_exchanges(session_id);
+CREATE INDEX IF NOT EXISTS idx_corpus_exch_ts      ON corpus_exchanges(timestamp_ms);
+
+-- The Tier-3 substrate: `is_error` + `tool_result_text` are what a
+-- failure→recovery detector reads. Cascades with its exchange so a
+-- re-indexed file replaces its turns cleanly.
+CREATE TABLE IF NOT EXISTS corpus_tool_calls (
+    id               TEXT    PRIMARY KEY,      -- <exchange_id>\x1f<ordinal>
+    exchange_id      TEXT    NOT NULL REFERENCES corpus_exchanges(id) ON DELETE CASCADE,
+    file_path        TEXT    NOT NULL,
+    ordinal          INTEGER NOT NULL,
+    tool_name        TEXT    NOT NULL,
+    tool_input_json  TEXT,
+    tool_result_text TEXT,
+    is_error         INTEGER NOT NULL DEFAULT 0,
+    timestamp_ms     INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_corpus_tc_exchange ON corpus_tool_calls(exchange_id);
+CREATE INDEX IF NOT EXISTS idx_corpus_tc_error    ON corpus_tool_calls(is_error);
+CREATE INDEX IF NOT EXISTS idx_corpus_tc_name     ON corpus_tool_calls(tool_name);
+"#;
+
+#[derive(Debug, thiserror::Error)]
+pub enum CorpusError {
+    #[error("corpus db: {0}")]
+    Db(#[from] rusqlite::Error),
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// What one `index_root` pass did.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexStats {
+    /// Transcript files walked.
+    pub seen: u64,
+    /// Files parsed and folded in (new or changed).
+    pub indexed: u64,
+    /// Files whose `(size, mtime)` matched the last index — not re-read.
+    pub unchanged: u64,
+    /// Files whose session was already represented by a copy at least
+    /// as complete. Counted, not hidden: this is the multi-host overlap.
+    pub duplicate: u64,
+    /// Files that could not be parsed. Never fatal to the pass.
+    pub failed: u64,
+}
+
+/// Per-host coverage, for the staleness surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostCoverage {
+    pub host_id: String,
+    pub files: u64,
+    pub sessions: u64,
+    pub newest_ts_ms: Option<i64>,
+}
+
+pub struct CorpusIndex {
+    db: Mutex<Connection>,
+}
+
+impl CorpusIndex {
+    /// Open (creating if absent) at `path`. 0600 on Unix, matching every
+    /// other Claudepot database.
+    pub fn open(path: &Path) -> Result<Self, CorpusError> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        // Pre-create at 0600 BEFORE rusqlite opens it, mirroring
+        // `SessionIndex::open`. Creating first and chmod-ing after
+        // leaves a window where the file exists at the process umask
+        // (typically 0644) and another local user can open it. The
+        // corpus holds project paths and prompt previews from every
+        // machine, so that window is not acceptable here either.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let _ = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(path);
+        }
+        let conn = Connection::open(path)?;
+        // `busy_timeout` matters: the GUI and the CLI both open this
+        // file, and `corpus index` holds write transactions. Without it
+        // a concurrent `corpus status` fails instantly with SQLITE_BUSY.
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; \
+             PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
+        )?;
+        conn.execute_batch(SCHEMA)?;
+        // WAL sidecars are created by SQLite at the umask, so tighten
+        // them too — they hold the same content as the main file.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            for p in [
+                path.to_path_buf(),
+                path.with_extension("db-wal"),
+                path.with_extension("db-shm"),
+            ] {
+                if let Ok(md) = std::fs::metadata(&p) {
+                    let mut perm = md.permissions();
+                    perm.set_mode(0o600);
+                    let _ = std::fs::set_permissions(&p, perm);
+                }
+            }
+        }
+        Ok(Self {
+            db: Mutex::new(conn),
+        })
+    }
+
+    /// Test/None-path helper: an in-memory corpus.
+    pub fn in_memory() -> Result<Self, CorpusError> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(SCHEMA)?;
+        Ok(Self {
+            db: Mutex::new(conn),
+        })
+    }
+
+    fn conn(&self) -> std::sync::MutexGuard<'_, Connection> {
+        // A poisoned lock means an earlier panic mid-write. The corpus
+        // is derived data — recovering and continuing beats propagating
+        // a panic into a background index pass.
+        self.db.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// Walk `projects_root` (a `.../projects` directory) and fold every
+    /// transcript into the corpus under `host_id`.
+    ///
+    /// **Incremental and re-runnable.** A file whose `(size, mtime_ns)`
+    /// match the recorded values is skipped without being read. Nothing
+    /// is ever deleted here: an archive of a live host is a snapshot,
+    /// so "present in the index but not on disk right now" is normal,
+    /// not stale. The question this asks is *what is missing from the
+    /// index*, never *what does the index have that disk does not* —
+    /// which is precisely the mistake that makes `SessionIndex::refresh`
+    /// unusable for archives.
+    pub fn index_root(
+        &self,
+        host_id: &str,
+        projects_root: &Path,
+        now_ms: i64,
+    ) -> Result<IndexStats, CorpusError> {
+        let mut stats = IndexStats::default();
+        let Ok(project_dirs) = std::fs::read_dir(projects_root) else {
+            return Ok(stats);
+        };
+
+        for project in project_dirs.flatten() {
+            if !project.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let slug = project.file_name().to_string_lossy().into_owned();
+            let Ok(entries) = std::fs::read_dir(project.path()) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                    continue;
+                }
+                if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                    continue;
+                }
+                stats.seen += 1;
+                match self.index_file(host_id, &slug, &path, now_ms) {
+                    Ok(FileOutcome::Unchanged) => stats.unchanged += 1,
+                    Ok(FileOutcome::Indexed) => stats.indexed += 1,
+                    Ok(FileOutcome::Duplicate) => {
+                        stats.indexed += 1;
+                        stats.duplicate += 1;
+                    }
+                    Err(_) => stats.failed += 1,
+                }
+            }
+        }
+        Ok(stats)
+    }
+
+    fn index_file(
+        &self,
+        host_id: &str,
+        slug: &str,
+        path: &Path,
+        now_ms: i64,
+    ) -> Result<FileOutcome, CorpusError> {
+        let md = std::fs::metadata(path)?;
+        let size = md.len() as i64;
+        let mtime_ns = md
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .and_then(|d| i64::try_from(d.as_nanos()).ok())
+            .unwrap_or(0);
+        let path_str = path.to_string_lossy().into_owned();
+
+        {
+            let db = self.conn();
+            // `.optional()`, not `.ok()`: the latter would turn a
+            // corrupt database or a locked connection into "cache
+            // miss" and quietly re-index, hiding a real failure.
+            let fresh: Option<(i64, i64)> = db
+                .query_row(
+                    "SELECT size_bytes, mtime_ns FROM corpus_files \
+                     WHERE host_id = ?1 AND file_path = ?2",
+                    params![host_id, path_str],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .optional()?;
+            if fresh == Some((size, mtime_ns)) {
+                return Ok(FileOutcome::Unchanged);
+            }
+        }
+
+        let scan = scan_session(slug, path).map_err(|e| {
+            CorpusError::Io(std::io::Error::other(format!(
+                "scan {}: {e}",
+                path.display()
+            )))
+        })?;
+        let row = scan.row;
+
+        // Second pass for turn-level content. Reuses the exact pairing
+        // `shared_memory::claude_exchanges` uses to fill the
+        // `sessions.db` equivalents, so `corpus_tool_calls.is_error`
+        // means the same thing as `tool_calls.is_error` — the property
+        // that made D3's dead `has_error` diagnosable in the first place.
+        //
+        // This is the expensive half: the session pass folds one row per
+        // file; this one materializes every turn and every tool call.
+        let exchanges = match crate::session::parse_events_public(path) {
+            Ok(events) => crate::shared_memory::claude_exchanges::pair_events_into_exchanges(
+                &row.session_id,
+                &events,
+            ),
+            // A file whose events will not re-parse still has a usable
+            // session row; losing its turns is better than losing both.
+            Err(_) => Vec::new(),
+        };
+
+        let mut db = self.conn();
+        // One transaction for both writes. Separately, the
+        // `corpus_files` row (which carries the freshness guard) could
+        // commit while the `corpus_sessions` write failed — and the
+        // guard would then make every future pass skip the file, so a
+        // missing or stale logical session would persist forever.
+        let tx = db.transaction()?;
+
+        tx.execute(
+            "INSERT INTO corpus_files \
+               (host_id, file_path, session_id, size_bytes, mtime_ns, event_count, indexed_at_ms) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
+             ON CONFLICT(host_id, file_path) DO UPDATE SET \
+               session_id = excluded.session_id, size_bytes = excluded.size_bytes, \
+               mtime_ns = excluded.mtime_ns, event_count = excluded.event_count, \
+               indexed_at_ms = excluded.indexed_at_ms",
+            params![
+                host_id,
+                path_str,
+                row.session_id,
+                size,
+                mtime_ns,
+                row.event_count as i64,
+                now_ms
+            ],
+        )?;
+
+        // Turn-level content, in the same transaction as the file row.
+        // Replace-then-insert rather than upsert: a re-indexed file may
+        // have *fewer* turns than before (a truncated copy on another
+        // host), and leaving orphaned turns behind would let a detector
+        // read turns that are not in the file it is quoting.
+        tx.execute(
+            "DELETE FROM corpus_tool_calls WHERE file_path = ?1",
+            [&path_str],
+        )?;
+        tx.execute(
+            "DELETE FROM corpus_exchanges WHERE file_path = ?1",
+            [&path_str],
+        )?;
+        for ex in &exchanges {
+            let ex_id = format!("{}\u{001f}{}", path_str, ex.turn_index);
+            tx.execute(
+                "INSERT INTO corpus_exchanges \
+                   (id, file_path, session_id, turn_index, timestamp_ms, user_text, assistant_text) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    ex_id,
+                    path_str,
+                    row.session_id,
+                    ex.turn_index as i64,
+                    ex.timestamp_ms,
+                    ex.user_text,
+                    ex.assistant_text,
+                ],
+            )?;
+            for (ordinal, tc) in ex.tool_calls.iter().enumerate() {
+                tx.execute(
+                    "INSERT INTO corpus_tool_calls \
+                       (id, exchange_id, file_path, ordinal, tool_name, tool_input_json, \
+                        tool_result_text, is_error, timestamp_ms) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                    params![
+                        format!("{ex_id}\u{001f}{ordinal}"),
+                        ex_id,
+                        path_str,
+                        ordinal as i64,
+                        tc.tool_name,
+                        tc.tool_input_json,
+                        tc.tool_result_text,
+                        tc.is_error as i64,
+                        tc.timestamp_ms,
+                    ],
+                )?;
+            }
+        }
+
+        let existed: bool = tx
+            .query_row(
+                "SELECT 1 FROM corpus_sessions WHERE session_id = ?1",
+                [&row.session_id],
+                |_| Ok(()),
+            )
+            .optional()?
+            .is_some();
+
+        // "Most complete copy wins", decided by the database rather than
+        // by a read-then-write in Rust. The comparison lives in the
+        // conflict clause so two indexers racing on the same session
+        // cannot both read the old count and let the shorter copy land
+        // last. A session synced mid-flight to a second machine has the
+        // same UUID and fewer events there; taking it would silently
+        // truncate the record.
+        let updated = upsert_session_if_more_complete(&tx, &row, host_id, &path_str, now_ms)?;
+        tx.commit()?;
+
+        Ok(if existed || updated == 0 {
+            FileOutcome::Duplicate
+        } else {
+            FileOutcome::Indexed
+        })
+    }
+
+    pub fn session_count(&self) -> Result<u64, CorpusError> {
+        let db = self.conn();
+        let n: i64 = db.query_row("SELECT COUNT(*) FROM corpus_sessions", [], |r| r.get(0))?;
+        Ok(n.max(0) as u64)
+    }
+
+    pub fn file_count(&self) -> Result<u64, CorpusError> {
+        let db = self.conn();
+        let n: i64 = db.query_row("SELECT COUNT(*) FROM corpus_files", [], |r| r.get(0))?;
+        Ok(n.max(0) as u64)
+    }
+
+    /// Per-host coverage. Powers "<host> last indexed 2026-05-28"
+    /// without the caller re-deriving it.
+    pub fn host_coverage(&self) -> Result<Vec<HostCoverage>, CorpusError> {
+        let db = self.conn();
+        let mut stmt = db.prepare(
+            "SELECT f.host_id, COUNT(*), COUNT(DISTINCT f.session_id), \
+                    MAX(s.last_ts_ms) \
+               FROM corpus_files f \
+               LEFT JOIN corpus_sessions s ON s.session_id = f.session_id \
+              GROUP BY f.host_id ORDER BY f.host_id",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok(HostCoverage {
+                host_id: r.get(0)?,
+                files: r.get::<_, i64>(1)?.max(0) as u64,
+                sessions: r.get::<_, i64>(2)?.max(0) as u64,
+                newest_ts_ms: r.get(3)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+}
+
+enum FileOutcome {
+    Indexed,
+    Unchanged,
+    Duplicate,
+}
+
+/// Insert the session, or replace the stored copy **only if this one is
+/// more complete**. Returns rows affected — `0` means an existing copy
+/// won, i.e. this file is a duplicate.
+///
+/// The `WHERE excluded.event_count > corpus_sessions.event_count` guard
+/// on the conflict clause is what makes the outcome independent of
+/// index order and safe against two concurrent indexers.
+fn upsert_session_if_more_complete(
+    db: &Connection,
+    row: &SessionRow,
+    host_id: &str,
+    file_path: &str,
+    now_ms: i64,
+) -> Result<usize, CorpusError> {
+    let n = db.execute(
+        "INSERT INTO corpus_sessions \
+           (session_id, project_path, slug, first_ts_ms, last_ts_ms, event_count, \
+            message_count, user_message_count, assistant_message_count, first_user_prompt, \
+            models_json, git_branch, cc_version, has_error, is_sidechain, \
+            best_host_id, best_file_path, indexed_at_ms) \
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18) \
+         ON CONFLICT(session_id) DO UPDATE SET \
+           project_path = excluded.project_path, slug = excluded.slug, \
+           first_ts_ms = excluded.first_ts_ms, last_ts_ms = excluded.last_ts_ms, \
+           event_count = excluded.event_count, message_count = excluded.message_count, \
+           user_message_count = excluded.user_message_count, \
+           assistant_message_count = excluded.assistant_message_count, \
+           first_user_prompt = excluded.first_user_prompt, models_json = excluded.models_json, \
+           git_branch = excluded.git_branch, cc_version = excluded.cc_version, \
+           has_error = excluded.has_error, is_sidechain = excluded.is_sidechain, \
+           best_host_id = excluded.best_host_id, best_file_path = excluded.best_file_path, \
+           indexed_at_ms = excluded.indexed_at_ms \
+         WHERE excluded.event_count > corpus_sessions.event_count",
+        params![
+            row.session_id,
+            row.project_path,
+            row.slug,
+            row.first_ts.map(|t| t.timestamp_millis()),
+            row.last_ts.map(|t| t.timestamp_millis()),
+            row.event_count as i64,
+            row.message_count as i64,
+            row.user_message_count as i64,
+            row.assistant_message_count as i64,
+            row.first_user_prompt,
+            serde_json::to_string(&row.models).unwrap_or_else(|_| "[]".into()),
+            row.git_branch,
+            row.cc_version,
+            row.has_error as i64,
+            row.is_sidechain as i64,
+            host_id,
+            file_path,
+            now_ms,
+        ],
+    )?;
+    Ok(n)
+}
+
+/// Default corpus database location.
+pub fn default_path() -> PathBuf {
+    crate::paths::claudepot_data_dir().join("corpus.db")
+}
+
+/// Where the rescue writes imported hosts. One subdirectory per host,
+/// each containing a `projects/` tree mirroring `~/.claude/projects`.
+pub fn default_archive_root() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|h| PathBuf::from(h).join("claude-corpus-archive"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_transcript(root: &Path, slug: &str, session_id: &str, lines: &[&str]) -> PathBuf {
+        let dir = root.join(slug);
+        fs::create_dir_all(&dir).unwrap();
+        let p = dir.join(format!("{session_id}.jsonl"));
+        fs::write(&p, format!("{}\n", lines.join("\n"))).unwrap();
+        p
+    }
+
+    fn user_line(text: &str, ts: &str, cwd: &str) -> String {
+        format!(
+            r#"{{"type":"user","message":{{"role":"user","content":"{text}"}},"timestamp":"{ts}","cwd":"{cwd}"}}"#
+        )
+    }
+
+    fn corpus() -> CorpusIndex {
+        CorpusIndex::in_memory().unwrap()
+    }
+
+    #[test]
+    fn indexes_a_transcript_and_counts_it_once() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        write_transcript(
+            &root,
+            "-repo-foo",
+            "S1",
+            &[&user_line("hi", "2026-04-10T10:00:00Z", "/repo/foo")],
+        );
+
+        let c = corpus();
+        let s = c.index_root(LOCAL_HOST, &root, 1).unwrap();
+        assert_eq!(s.seen, 1);
+        assert_eq!(s.indexed, 1);
+        assert_eq!(c.session_count().unwrap(), 1);
+        assert_eq!(c.file_count().unwrap(), 1);
+    }
+
+    /// Re-running must not re-read unchanged files — this is what makes
+    /// indexing 14,059 transcripts repeatable rather than a one-shot.
+    #[test]
+    fn a_second_pass_skips_unchanged_files() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        write_transcript(
+            &root,
+            "-repo-foo",
+            "S1",
+            &[&user_line("hi", "2026-04-10T10:00:00Z", "/repo/foo")],
+        );
+        let c = corpus();
+        c.index_root(LOCAL_HOST, &root, 1).unwrap();
+        let s2 = c.index_root(LOCAL_HOST, &root, 2).unwrap();
+        assert_eq!(s2.unchanged, 1);
+        assert_eq!(s2.indexed, 0);
+    }
+
+    /// The multi-host case: the same conversation on two machines is one
+    /// session, two files. Counting it twice would inflate every
+    /// aggregate the detectors compute.
+    #[test]
+    fn the_same_session_on_two_hosts_is_one_session_two_files() {
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("host-a/projects");
+        let b = tmp.path().join("host-b/projects");
+        let line = user_line("hi", "2026-04-10T10:00:00Z", "/repo/foo");
+        write_transcript(&a, "-repo-foo", "SHARED", &[&line]);
+        write_transcript(&b, "-repo-foo", "SHARED", &[&line]);
+
+        let c = corpus();
+        c.index_root("host-a", &a, 1).unwrap();
+        let s = c.index_root("host-b", &b, 1).unwrap();
+
+        assert_eq!(s.duplicate, 1, "second host's copy is a duplicate");
+        assert_eq!(c.session_count().unwrap(), 1);
+        assert_eq!(c.file_count().unwrap(), 2, "both physical copies recorded");
+    }
+
+    /// A host that synced mid-session holds a truncated copy. Taking it
+    /// would silently shorten the record.
+    #[test]
+    fn the_more_complete_copy_wins() {
+        let tmp = TempDir::new().unwrap();
+        let short_root = tmp.path().join("short/projects");
+        let long_root = tmp.path().join("long/projects");
+        let l1 = user_line("one", "2026-04-10T10:00:00Z", "/repo/foo");
+        let l2 = user_line("two", "2026-04-10T10:01:00Z", "/repo/foo");
+        write_transcript(&short_root, "-repo-foo", "S1", &[&l1]);
+        write_transcript(&long_root, "-repo-foo", "S1", &[&l1, &l2]);
+
+        let c = corpus();
+        c.index_root("short-host", &short_root, 1).unwrap();
+        c.index_root("long-host", &long_root, 1).unwrap();
+        let db = c.conn();
+        let (events, host): (i64, String) = db
+            .query_row(
+                "SELECT event_count, best_host_id FROM corpus_sessions WHERE session_id='S1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(events, 2);
+        assert_eq!(host, "long-host");
+    }
+
+    /// ...and the reverse order must reach the same answer.
+    #[test]
+    fn a_truncated_copy_indexed_second_does_not_overwrite() {
+        let tmp = TempDir::new().unwrap();
+        let short_root = tmp.path().join("short/projects");
+        let long_root = tmp.path().join("long/projects");
+        let l1 = user_line("one", "2026-04-10T10:00:00Z", "/repo/foo");
+        let l2 = user_line("two", "2026-04-10T10:01:00Z", "/repo/foo");
+        write_transcript(&short_root, "-repo-foo", "S1", &[&l1]);
+        write_transcript(&long_root, "-repo-foo", "S1", &[&l1, &l2]);
+
+        let c = corpus();
+        c.index_root("long-host", &long_root, 1).unwrap();
+        c.index_root("short-host", &short_root, 1).unwrap();
+        let db = c.conn();
+        let (events, host): (i64, String) = db
+            .query_row(
+                "SELECT event_count, best_host_id FROM corpus_sessions WHERE session_id='S1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(events, 2, "the shorter copy must not win by arriving later");
+        assert_eq!(host, "long-host");
+    }
+
+    /// Nothing is ever deleted: an archive of a live host is a snapshot,
+    /// so a file that is gone now is not evidence the record is stale.
+    /// This is the exact property `SessionIndex::refresh` lacks.
+    #[test]
+    fn indexing_never_deletes_rows_for_vanished_files() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let p = write_transcript(
+            &root,
+            "-repo-foo",
+            "S1",
+            &[&user_line("hi", "2026-04-10T10:00:00Z", "/repo/foo")],
+        );
+        let c = corpus();
+        c.index_root(LOCAL_HOST, &root, 1).unwrap();
+        fs::remove_file(&p).unwrap();
+
+        c.index_root(LOCAL_HOST, &root, 2).unwrap();
+        assert_eq!(c.session_count().unwrap(), 1, "the record must survive");
+        assert_eq!(c.file_count().unwrap(), 1);
+    }
+
+    #[test]
+    fn a_changed_file_is_reindexed() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let l1 = user_line("one", "2026-04-10T10:00:00Z", "/repo/foo");
+        let p = write_transcript(&root, "-repo-foo", "S1", &[&l1]);
+        let c = corpus();
+        c.index_root(LOCAL_HOST, &root, 1).unwrap();
+
+        let l2 = user_line("two", "2026-04-10T10:01:00Z", "/repo/foo");
+        fs::write(&p, format!("{l1}\n{l2}\n")).unwrap();
+        let s = c.index_root(LOCAL_HOST, &root, 2).unwrap();
+        assert_eq!(s.indexed, 1);
+        assert_eq!(s.unchanged, 0);
+    }
+
+    #[test]
+    fn an_unparseable_file_is_counted_not_fatal() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        write_transcript(
+            &root,
+            "-repo-foo",
+            "GOOD",
+            &[&user_line("hi", "2026-04-10T10:00:00Z", "/repo/foo")],
+        );
+        let dir = root.join("-repo-foo");
+        fs::write(dir.join("BAD.jsonl"), b"not json at all\n").unwrap();
+
+        let c = corpus();
+        let s = c.index_root(LOCAL_HOST, &root, 1).unwrap();
+        assert_eq!(s.seen, 2);
+        // A malformed transcript still yields a row (CC's own tolerance
+        // is line-level), so what matters is that the pass completed.
+        assert!(s.indexed >= 1);
+        assert!(c.session_count().unwrap() >= 1);
+    }
+
+    // ─── turn-level content (the C2 substrate) ──────────────────────
+
+    fn assistant_line(text: &str, ts: &str) -> String {
+        format!(
+            r#"{{"type":"assistant","message":{{"role":"assistant","model":"claude-opus-4-7","content":[{{"type":"text","text":"{text}"}}]}},"timestamp":"{ts}","cwd":"/repo/foo"}}"#
+        )
+    }
+
+    fn tool_use_line(id: &str, name: &str, ts: &str) -> String {
+        format!(
+            r#"{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"tool_use","id":"{id}","name":"{name}","input":{{"command":"x"}}}}]}},"timestamp":"{ts}","cwd":"/repo/foo"}}"#
+        )
+    }
+
+    fn tool_result_line(id: &str, text: &str, is_error: bool, ts: &str) -> String {
+        format!(
+            r#"{{"type":"user","message":{{"role":"user","content":[{{"type":"tool_result","tool_use_id":"{id}","content":"{text}","is_error":{is_error}}}]}},"timestamp":"{ts}","cwd":"/repo/foo"}}"#
+        )
+    }
+
+    #[test]
+    fn exchanges_and_tool_calls_are_indexed() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        write_transcript(
+            &root,
+            "-repo-foo",
+            "S1",
+            &[
+                &user_line("build it", "2026-04-10T10:00:00Z", "/repo/foo"),
+                &tool_use_line("t1", "Bash", "2026-04-10T10:00:01Z"),
+                &tool_result_line("t1", "Exit code 1", true, "2026-04-10T10:00:02Z"),
+                &assistant_line("fixed", "2026-04-10T10:00:03Z"),
+            ],
+        );
+        let c = corpus();
+        c.index_root(LOCAL_HOST, &root, 1).unwrap();
+
+        let db = c.conn();
+        let ex: i64 = db
+            .query_row("SELECT COUNT(*) FROM corpus_exchanges", [], |r| r.get(0))
+            .unwrap();
+        assert!(ex > 0, "turns must be materialized");
+        let tc: i64 = db
+            .query_row("SELECT COUNT(*) FROM corpus_tool_calls", [], |r| r.get(0))
+            .unwrap();
+        assert!(tc > 0, "tool calls must be materialized");
+    }
+
+    /// The contract's acceptance condition: Tier 3 is unbuildable
+    /// without a truthy `is_error`, and this is the column that made
+    /// `sessions.has_error` diagnosable (D3).
+    #[test]
+    fn a_failed_tool_call_is_recorded_with_is_error_and_its_output() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        write_transcript(
+            &root,
+            "-repo-foo",
+            "S1",
+            &[
+                &user_line("build it", "2026-04-10T10:00:00Z", "/repo/foo"),
+                &tool_use_line("t1", "Bash", "2026-04-10T10:00:01Z"),
+                &tool_result_line("t1", "Exit code 1", true, "2026-04-10T10:00:02Z"),
+                &assistant_line("ok", "2026-04-10T10:00:03Z"),
+            ],
+        );
+        let c = corpus();
+        c.index_root(LOCAL_HOST, &root, 1).unwrap();
+
+        let db = c.conn();
+        let (name, text, err): (String, Option<String>, i64) = db
+            .query_row(
+                "SELECT tool_name, tool_result_text, is_error FROM corpus_tool_calls \
+                 WHERE is_error = 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(name, "Bash");
+        assert_eq!(err, 1);
+        assert!(
+            text.unwrap_or_default().contains("Exit code 1"),
+            "the failure output is the evidence a detector quotes"
+        );
+    }
+
+    /// A re-index must not leave turns from the previous read behind —
+    /// a shorter copy would otherwise let a detector quote turns that
+    /// are not in the file it names.
+    #[test]
+    fn reindexing_replaces_turns_rather_than_accumulating() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let l1 = user_line("one", "2026-04-10T10:00:00Z", "/repo/foo");
+        let a1 = assistant_line("first", "2026-04-10T10:00:01Z");
+        let l2 = user_line("two", "2026-04-10T10:01:00Z", "/repo/foo");
+        let a2 = assistant_line("second", "2026-04-10T10:01:01Z");
+        let p = write_transcript(&root, "-repo-foo", "S1", &[&l1, &a1, &l2, &a2]);
+        let c = corpus();
+        c.index_root(LOCAL_HOST, &root, 1).unwrap();
+        let before: i64 = c
+            .conn()
+            .query_row("SELECT COUNT(*) FROM corpus_exchanges", [], |r| r.get(0))
+            .unwrap();
+        assert!(before >= 2);
+
+        // Rewrite shorter.
+        fs::write(&p, format!("{l1}\n{a1}\n")).unwrap();
+        c.index_root(LOCAL_HOST, &root, 2).unwrap();
+        let after: i64 = c
+            .conn()
+            .query_row("SELECT COUNT(*) FROM corpus_exchanges", [], |r| r.get(0))
+            .unwrap();
+        assert!(
+            after < before,
+            "stale turns must be removed, not accumulated ({before} -> {after})"
+        );
+    }
+
+    #[test]
+    fn tool_calls_cascade_when_their_exchange_is_replaced() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let lines = [
+            user_line("build", "2026-04-10T10:00:00Z", "/repo/foo"),
+            tool_use_line("t1", "Bash", "2026-04-10T10:00:01Z"),
+            tool_result_line("t1", "boom", true, "2026-04-10T10:00:02Z"),
+            assistant_line("ok", "2026-04-10T10:00:03Z"),
+        ];
+        let refs: Vec<&str> = lines.iter().map(|s| s.as_str()).collect();
+        let p = write_transcript(&root, "-repo-foo", "S1", &refs);
+        let c = corpus();
+        c.index_root(LOCAL_HOST, &root, 1).unwrap();
+
+        // Replace with a transcript containing no tool calls at all.
+        fs::write(
+            &p,
+            format!(
+                "{}\n{}\n",
+                user_line("hi", "2026-04-10T10:00:00Z", "/repo/foo"),
+                assistant_line("hello", "2026-04-10T10:00:01Z")
+            ),
+        )
+        .unwrap();
+        c.index_root(LOCAL_HOST, &root, 2).unwrap();
+
+        let orphans: i64 = c
+            .conn()
+            .query_row(
+                "SELECT COUNT(*) FROM corpus_tool_calls tc \
+                 LEFT JOIN corpus_exchanges e ON e.id = tc.exchange_id \
+                 WHERE e.id IS NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphans, 0, "no tool call may outlive its exchange");
+    }
+
+    #[test]
+    fn host_coverage_reports_each_host() {
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("a/projects");
+        let b = tmp.path().join("b/projects");
+        write_transcript(
+            &a,
+            "-p",
+            "S1",
+            &[&user_line("x", "2026-04-10T10:00:00Z", "/p")],
+        );
+        write_transcript(
+            &b,
+            "-p",
+            "S2",
+            &[&user_line("y", "2026-04-11T10:00:00Z", "/p")],
+        );
+        let c = corpus();
+        c.index_root("host-a", &a, 1).unwrap();
+        c.index_root("host-b", &b, 1).unwrap();
+
+        let cov = c.host_coverage().unwrap();
+        assert_eq!(cov.len(), 2);
+        assert_eq!(cov[0].host_id, "host-a");
+        assert_eq!(cov[0].files, 1);
+        assert_eq!(cov[1].host_id, "host-b");
+    }
+
+    #[test]
+    fn a_missing_root_is_empty_not_an_error() {
+        let tmp = TempDir::new().unwrap();
+        let c = corpus();
+        let s = c
+            .index_root(LOCAL_HOST, &tmp.path().join("nope"), 1)
+            .unwrap();
+        assert_eq!(s, IndexStats::default());
+    }
+
+    #[test]
+    fn non_jsonl_files_are_ignored() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        let dir = root.join("-repo-foo");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("notes.md"), b"hello").unwrap();
+        let c = corpus();
+        assert_eq!(c.index_root(LOCAL_HOST, &root, 1).unwrap().seen, 0);
+    }
+}

--- a/crates/claudepot-core/src/corpus/detect.rs
+++ b/crates/claudepot-core/src/corpus/detect.rs
@@ -33,6 +33,7 @@ use super::normalize::{
     command_family, error_signature, fingerprint, is_harness_synthetic, jaccard, normalize_prompt,
 };
 use super::{CorpusError, CorpusIndex};
+use crate::session_live::redact::redact_secrets;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -96,7 +97,15 @@ impl Incident {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RepetitionCluster {
     pub normalized: String,
-    /// An unmodified example, for display. Never the normalized form.
+    /// A representative example, for display — the original wording
+    /// rather than the normalized form, but **redacted**.
+    ///
+    /// This crosses an emission boundary: `claudepot corpus detect`
+    /// prints it to stdout and serializes it under `--json`. A prompt
+    /// that repeats often enough to cluster is exactly the kind a user
+    /// pastes a token into, so it is redacted at construction rather
+    /// than trusted to every future caller (invariant R9,
+    /// `scripts/repo-invariants.sh`).
     pub sample: String,
     pub count: usize,
     pub projects: usize,
@@ -109,6 +118,8 @@ pub struct Correction {
     pub session_id: String,
     pub project_path: String,
     pub turn_index: i64,
+    /// The correction as written, **redacted** — same emission-boundary
+    /// reasoning as [`RepetitionCluster::sample`].
     pub text: String,
     /// Why this survived the marker filter.
     pub corroboration: Corroboration,
@@ -279,7 +290,10 @@ pub fn detect_repetitions(
         let key = fingerprint(&norm);
         norms.entry(key).or_insert_with(|| norm.clone());
         let e = acc.entry(key).or_insert_with(|| Acc {
-            sample: text.clone(),
+            // Redacted here, not at print time: this string reaches
+            // stdout and `--json`, and a prompt repeated often enough
+            // to cluster is exactly where a pasted token would sit.
+            sample: redact_secrets(&text),
             count: 0,
             projects: Default::default(),
             sessions: Default::default(),
@@ -405,7 +419,7 @@ pub fn detect_corrections(idx: &CorpusIndex, limit: usize) -> Result<Vec<Correct
                 session_id: t.session_id.clone(),
                 project_path: t.project_path.clone(),
                 turn_index: t.turn_index,
-                text: t.text.clone(),
+                text: redact_secrets(&t.text),
                 corroboration: why,
             });
             if out.len() >= limit {
@@ -682,6 +696,48 @@ mod tests {
             r.iter().any(|x| x.sample.contains("commit and push")),
             "but real repeated requests still must"
         );
+    }
+
+    /// Regression: `corpus detect` prints these to stdout and
+    /// serializes them under `--json`, so a token pasted into a prompt
+    /// that repeats would have landed on the terminal. CI's R9 tripwire
+    /// caught this on the feature's first run.
+    #[test]
+    fn emitted_samples_and_corrections_are_redacted() {
+        let secret = "sk-ant-oat01-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let (c, _t) = indexed(&[
+            user(
+                &format!("use token {secret} please"),
+                "2026-04-10T10:00:00Z",
+            ),
+            user(
+                &format!("use token {secret} please"),
+                "2026-04-10T10:01:00Z",
+            ),
+            tool_use("t1", "Bash", "cargo test", "2026-04-10T10:02:00Z"),
+            tool_res("t1", "Exit code 1", true, "2026-04-10T10:03:00Z"),
+            user(&format!("no, not {secret}"), "2026-04-10T10:04:00Z"),
+        ]);
+
+        for r in detect_repetitions(&c, 2, 1).unwrap() {
+            assert!(
+                !r.sample.contains(secret),
+                "repetition sample leaked a secret: {}",
+                r.sample
+            );
+        }
+        let corrections = detect_corrections(&c, 100).unwrap();
+        assert!(
+            !corrections.is_empty(),
+            "precondition: a correction is found"
+        );
+        for corr in corrections {
+            assert!(
+                !corr.text.contains(secret),
+                "correction text leaked a secret: {}",
+                corr.text
+            );
+        }
     }
 
     #[test]

--- a/crates/claudepot-core/src/corpus/detect.rs
+++ b/crates/claudepot-core/src/corpus/detect.rs
@@ -1,0 +1,711 @@
+//! Tiers 1–3 — deterministic candidate detection over the corpus.
+//!
+//! No model calls. Everything here is a SQL read plus pure comparison,
+//! and the output is deliberately **not lessons**: it is ranked, evidence-
+//! bearing candidates that a model (Tier 4) or a human classifies later.
+//!
+//! # Precision is the whole problem
+//!
+//! Scale is not the difficulty. On a corpus a fraction of this size, the
+//! naive Tier-3 join — "an error, then any later success of the same
+//! tool in the same session" — produced **358,043 pairs**. Useless. Every
+//! constraint below exists to cut that:
+//!
+//! - same session *and* same physical file;
+//! - same **command family**, not merely the same tool
+//!   ([`super::normalize::command_family`] — a failed `cargo test` is not
+//!   recovered by a successful `cd`);
+//! - the **first** success of that family after the failure, not any;
+//! - bounded by [`MAX_RECOVERY_TURN_GAP`], because a success forty turns
+//!   later is a different piece of work.
+//!
+//! # Vocabulary
+//!
+//! Nothing here is a "recurrence" — that word has a precise, human-
+//! confirmed meaning in [`crate::shared_memory::recurrence`] (an
+//! *accepted lesson's* failure class happening again) and diluting it
+//! would break the one honest signal the knowledge base has. Repetition
+//! is a *repetition cluster*; a failure with no observed recovery is
+//! `unresolved`, never "abandoned" or "failed" — a session that simply
+//! ends tells us nothing about why.
+
+use super::normalize::{
+    command_family, error_signature, fingerprint, is_harness_synthetic, jaccard, normalize_prompt,
+};
+use super::{CorpusError, CorpusIndex};
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// How far after a failure a success still counts as its recovery.
+/// Beyond this the pair is coincidence, not repair.
+pub const MAX_RECOVERY_TURN_GAP: i64 = 12;
+
+/// Minimum occurrences before a repetition cluster is worth surfacing.
+pub const MIN_REPETITION_COUNT: usize = 5;
+
+/// Minimum distinct projects for a repetition cluster to read as a
+/// *reusable* pattern rather than one project's local habit.
+pub const MIN_REPETITION_PROJECTS: usize = 2;
+
+/// Similarity at which two user turns count as "asked again".
+pub const REPEAT_INTENT_THRESHOLD: f64 = 0.6;
+
+/// How far back a correction looks for the intent it is correcting.
+pub const CORRECTION_LOOKBACK_TURNS: i64 = 3;
+
+/// What kind of evidence backs a candidate. Mirrors the evidence grades
+/// the Review surface will show, so the UI never has to invent one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Evidence {
+    /// A failure followed by an observed success of the same family.
+    VerifiedRecovery,
+    /// A user correction, corroborated by a failure or a repeated ask.
+    UserCorrection,
+    /// The same normalized request, many times, across projects.
+    RepeatedIncident,
+}
+
+/// A failure and, when one was observed, its recovery.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Incident {
+    pub session_id: String,
+    pub project_path: String,
+    pub file_path: String,
+    pub family: String,
+    pub error_signature: String,
+    pub failure_turn: i64,
+    /// `None` when no qualifying success followed. Reported as
+    /// `unresolved`, never as "abandoned".
+    pub recovery_turn: Option<i64>,
+    pub tool_name: String,
+    /// The user turn that preceded the failure, if any — the intent.
+    pub intent: Option<String>,
+}
+
+impl Incident {
+    pub fn is_resolved(&self) -> bool {
+        self.recovery_turn.is_some()
+    }
+}
+
+/// The same normalized request, repeated. **Not** a lesson: this says
+/// "you did this a lot", which is an automation or instruction
+/// candidate, and says nothing about whether it went well.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RepetitionCluster {
+    pub normalized: String,
+    /// An unmodified example, for display. Never the normalized form.
+    pub sample: String,
+    pub count: usize,
+    pub projects: usize,
+    pub sessions: usize,
+}
+
+/// A user correction with something corroborating it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Correction {
+    pub session_id: String,
+    pub project_path: String,
+    pub turn_index: i64,
+    pub text: String,
+    /// Why this survived the marker filter.
+    pub corroboration: Corroboration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Corroboration {
+    /// A tool call failed in the turns just before the correction.
+    PrecedingFailure,
+    /// The user had asked for materially the same thing just before.
+    RepeatedIntent,
+}
+
+/// Everything one detection pass found.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Findings {
+    pub incidents: Vec<Incident>,
+    pub repetitions: Vec<RepetitionCluster>,
+    pub corrections: Vec<Correction>,
+}
+
+impl Findings {
+    pub fn resolved_incidents(&self) -> usize {
+        self.incidents.iter().filter(|i| i.is_resolved()).count()
+    }
+}
+
+// ─── Tier 3: failure → recovery ──────────────────────────────────────
+
+#[derive(Debug)]
+struct RawCall {
+    file_path: String,
+    session_id: String,
+    project_path: String,
+    turn_index: i64,
+    ordinal: i64,
+    tool_name: String,
+    input: Option<String>,
+    result: Option<String>,
+    is_error: bool,
+}
+
+/// Detect failure→recovery incidents.
+///
+/// One pass over tool calls ordered by (file, turn, ordinal). For each
+/// failure, scan forward for the first success sharing its command
+/// family within [`MAX_RECOVERY_TURN_GAP`] turns of the same file.
+pub fn detect_incidents(idx: &CorpusIndex, limit: usize) -> Result<Vec<Incident>, CorpusError> {
+    let db = idx.conn();
+    let mut stmt = db.prepare(
+        "SELECT tc.file_path, e.session_id, s.project_path, e.turn_index, tc.ordinal, \
+                tc.tool_name, tc.tool_input_json, tc.tool_result_text, tc.is_error \
+           FROM corpus_tool_calls tc \
+           JOIN corpus_exchanges e ON e.id = tc.exchange_id \
+           JOIN corpus_sessions  s ON s.session_id = e.session_id \
+          ORDER BY tc.file_path, e.turn_index, tc.ordinal",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok(RawCall {
+            file_path: r.get(0)?,
+            session_id: r.get(1)?,
+            project_path: r.get(2)?,
+            turn_index: r.get(3)?,
+            ordinal: r.get(4)?,
+            tool_name: r.get(5)?,
+            input: r.get(6)?,
+            result: r.get(7)?,
+            is_error: r.get::<_, i64>(8)? != 0,
+        })
+    })?;
+
+    // Group by physical file — the unit a recovery must happen within.
+    let mut by_file: HashMap<String, Vec<RawCall>> = HashMap::new();
+    for row in rows {
+        let c = row?;
+        by_file.entry(c.file_path.clone()).or_default().push(c);
+    }
+
+    let mut out = Vec::new();
+    for calls in by_file.values() {
+        for (i, fail) in calls.iter().enumerate() {
+            if !fail.is_error {
+                continue;
+            }
+            let Some(sig) = fail.result.as_deref().and_then(error_signature) else {
+                // Unclassifiable failure. Dropping it beats grouping
+                // every such failure under one empty key.
+                continue;
+            };
+            let family = command_family(&fail.tool_name, fail.input.as_deref());
+
+            // First success of the same family, within the window.
+            let recovery = calls[i + 1..]
+                .iter()
+                .take_while(|c| c.turn_index - fail.turn_index <= MAX_RECOVERY_TURN_GAP)
+                .find(|c| !c.is_error && command_family(&c.tool_name, c.input.as_deref()) == family)
+                .map(|c| c.turn_index);
+
+            out.push(Incident {
+                session_id: fail.session_id.clone(),
+                project_path: fail.project_path.clone(),
+                file_path: fail.file_path.clone(),
+                family,
+                error_signature: sig,
+                failure_turn: fail.turn_index,
+                recovery_turn: recovery,
+                tool_name: fail.tool_name.clone(),
+                intent: None,
+            });
+            if out.len() >= limit {
+                return Ok(out);
+            }
+        }
+        let _ = calls.first().map(|c| (&c.ordinal, &c.session_id));
+    }
+    Ok(out)
+}
+
+// ─── Tier 1: repetition clusters ─────────────────────────────────────
+
+/// Cluster user turns by normalized form.
+///
+/// Exact-normalized equality, not MinHash: at this corpus size it is
+/// cheap and has no false positives, and a false "you did this 40 times"
+/// is worse than a missed near-duplicate. Near-duplicate matching is a
+/// refinement, not a prerequisite.
+pub fn detect_repetitions(
+    idx: &CorpusIndex,
+    min_count: usize,
+    min_projects: usize,
+) -> Result<Vec<RepetitionCluster>, CorpusError> {
+    let db = idx.conn();
+    let mut stmt = db.prepare(
+        "SELECT e.user_text, s.project_path, e.session_id \
+           FROM corpus_exchanges e \
+           JOIN corpus_sessions s ON s.session_id = e.session_id \
+          WHERE length(e.user_text) BETWEEN 4 AND 400",
+    )?;
+    struct Acc {
+        sample: String,
+        count: usize,
+        projects: std::collections::HashSet<String>,
+        sessions: std::collections::HashSet<String>,
+    }
+    let mut acc: HashMap<u64, Acc> = HashMap::new();
+    let mut norms: HashMap<u64, String> = HashMap::new();
+
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+        ))
+    })?;
+    for row in rows {
+        let (text, project, session) = row?;
+        // Harness plumbing is not a repeated *request*. Skipping it here
+        // rather than at display time keeps the counts honest for every
+        // consumer, not just the one that prints them.
+        if is_harness_synthetic(&text) {
+            continue;
+        }
+        let norm = normalize_prompt(&text);
+        if norm.is_empty() {
+            continue;
+        }
+        let key = fingerprint(&norm);
+        norms.entry(key).or_insert_with(|| norm.clone());
+        let e = acc.entry(key).or_insert_with(|| Acc {
+            sample: text.clone(),
+            count: 0,
+            projects: Default::default(),
+            sessions: Default::default(),
+        });
+        e.count += 1;
+        e.projects.insert(project);
+        e.sessions.insert(session);
+    }
+
+    let mut out: Vec<RepetitionCluster> = acc
+        .into_iter()
+        .filter(|(_, a)| a.count >= min_count && a.projects.len() >= min_projects)
+        .map(|(k, a)| RepetitionCluster {
+            normalized: norms.get(&k).cloned().unwrap_or_default(),
+            sample: a.sample,
+            count: a.count,
+            projects: a.projects.len(),
+            sessions: a.sessions.len(),
+        })
+        .collect();
+    out.sort_by(|a, b| b.count.cmp(&a.count).then(b.projects.cmp(&a.projects)));
+    Ok(out)
+}
+
+// ─── Tier 2: corroborated corrections ────────────────────────────────
+
+/// Markers that *may* open a correction. A marker alone is not enough —
+/// "no errors" is not a correction — which is why every hit must clear
+/// [`corroborate`] before it survives.
+const CORRECTION_MARKERS: &[&str] = &[
+    "no,",
+    "no.",
+    "nope",
+    "wrong",
+    "actually",
+    "instead",
+    "don't",
+    "do not",
+    "stop",
+    "revert",
+    "undo",
+    "that's not",
+    "not like",
+    "you forgot",
+    "you missed",
+    "still broken",
+    "still failing",
+    "i said",
+    "as i said",
+    "不对",
+    "不是",
+    "应该",
+    "重来",
+    "回退",
+    "别这样",
+];
+
+fn opens_with_marker(text: &str) -> bool {
+    let head: String = text.trim().to_lowercase().chars().take(60).collect();
+    CORRECTION_MARKERS
+        .iter()
+        .any(|m| head.starts_with(m) || head.contains(m))
+}
+
+/// Detect user corrections that something else corroborates.
+pub fn detect_corrections(idx: &CorpusIndex, limit: usize) -> Result<Vec<Correction>, CorpusError> {
+    let db = idx.conn();
+    let mut stmt = db.prepare(
+        "SELECT e.file_path, e.session_id, s.project_path, e.turn_index, e.user_text, \
+                (SELECT COUNT(*) FROM corpus_tool_calls tc \
+                  WHERE tc.exchange_id = e.id AND tc.is_error = 1) \
+           FROM corpus_exchanges e \
+           JOIN corpus_sessions s ON s.session_id = e.session_id \
+          WHERE length(e.user_text) BETWEEN 3 AND 600 \
+          ORDER BY e.file_path, e.turn_index",
+    )?;
+    struct Turn {
+        session_id: String,
+        project_path: String,
+        turn_index: i64,
+        text: String,
+        errors: i64,
+    }
+    impl TurnLike for Turn {
+        fn turn_index(&self) -> i64 {
+            self.turn_index
+        }
+        fn text(&self) -> &str {
+            &self.text
+        }
+        fn errors(&self) -> i64 {
+            self.errors
+        }
+    }
+    let mut by_file: HashMap<String, Vec<Turn>> = HashMap::new();
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            Turn {
+                session_id: r.get(1)?,
+                project_path: r.get(2)?,
+                turn_index: r.get(3)?,
+                text: r.get(4)?,
+                errors: r.get(5)?,
+            },
+        ))
+    })?;
+    for row in rows {
+        let (file, t) = row?;
+        by_file.entry(file).or_default().push(t);
+    }
+
+    let mut out = Vec::new();
+    for turns in by_file.values() {
+        for (i, t) in turns.iter().enumerate() {
+            if is_harness_synthetic(&t.text) || !opens_with_marker(&t.text) {
+                continue;
+            }
+            let Some(why) = corroborate(turns, i) else {
+                continue;
+            };
+            out.push(Correction {
+                session_id: t.session_id.clone(),
+                project_path: t.project_path.clone(),
+                turn_index: t.turn_index,
+                text: t.text.clone(),
+                corroboration: why,
+            });
+            if out.len() >= limit {
+                return Ok(out);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// A marker survives only with corroboration: either something actually
+/// failed just before it, or the user is asking again for materially
+/// what they already asked for. Without this the marker list matches
+/// "no errors", "don't worry", and every other incidental use.
+fn corroborate<T>(turns: &[T], i: usize) -> Option<Corroboration>
+where
+    T: TurnLike,
+{
+    let here = &turns[i];
+    let lookback = CORRECTION_LOOKBACK_TURNS;
+
+    // (a) a failing tool call in this turn or the ones just before it.
+    for prev in turns[..=i].iter().rev() {
+        if here.turn_index() - prev.turn_index() > lookback {
+            break;
+        }
+        if prev.errors() > 0 {
+            return Some(Corroboration::PrecedingFailure);
+        }
+    }
+
+    // (b) the same intent, asked again.
+    let norm_here = normalize_prompt(here.text());
+    for prev in turns[..i].iter().rev() {
+        if here.turn_index() - prev.turn_index() > lookback {
+            break;
+        }
+        if jaccard(&norm_here, &normalize_prompt(prev.text())) >= REPEAT_INTENT_THRESHOLD {
+            return Some(Corroboration::RepeatedIntent);
+        }
+    }
+    None
+}
+
+/// Lets [`corroborate`] be tested without a database.
+trait TurnLike {
+    fn turn_index(&self) -> i64;
+    fn text(&self) -> &str;
+    fn errors(&self) -> i64;
+}
+
+// ─── the pass ────────────────────────────────────────────────────────
+
+/// Run every tier. `limit` caps each detector independently so one
+/// pathological corpus cannot starve the others.
+pub fn detect_all(idx: &CorpusIndex, limit: usize) -> Result<Findings, CorpusError> {
+    Ok(Findings {
+        incidents: detect_incidents(idx, limit)?,
+        repetitions: detect_repetitions(idx, MIN_REPETITION_COUNT, MIN_REPETITION_PROJECTS)?,
+        corrections: detect_corrections(idx, limit)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct T {
+        turn: i64,
+        text: String,
+        errors: i64,
+    }
+    impl TurnLike for T {
+        fn turn_index(&self) -> i64 {
+            self.turn
+        }
+        fn text(&self) -> &str {
+            &self.text
+        }
+        fn errors(&self) -> i64 {
+            self.errors
+        }
+    }
+    fn t(turn: i64, text: &str, errors: i64) -> T {
+        T {
+            turn,
+            text: text.into(),
+            errors,
+        }
+    }
+
+    // ─── corroboration ──────────────────────────────────────────────
+
+    /// The precision rule. "no errors" opens with a marker and is not a
+    /// correction; without corroboration the marker list is noise.
+    #[test]
+    fn a_marker_without_corroboration_is_rejected() {
+        let turns = vec![t(0, "run the tests", 0), t(1, "no, errors are fine", 0)];
+        assert!(corroborate(&turns, 1).is_none());
+    }
+
+    #[test]
+    fn a_preceding_failure_corroborates() {
+        let turns = vec![t(0, "run the tests", 1), t(1, "no, use cargo nextest", 0)];
+        assert_eq!(
+            corroborate(&turns, 1),
+            Some(Corroboration::PrecedingFailure)
+        );
+    }
+
+    #[test]
+    fn asking_again_corroborates() {
+        let turns = vec![
+            t(0, "run the workspace tests please", 0),
+            t(1, "no, run the workspace tests please", 0),
+        ];
+        assert_eq!(corroborate(&turns, 1), Some(Corroboration::RepeatedIntent));
+    }
+
+    /// A failure long before the correction is not its cause.
+    #[test]
+    fn corroboration_respects_the_lookback_window() {
+        let turns = vec![t(0, "build", 1), t(50, "no, do it differently", 0)];
+        assert!(corroborate(&turns, 1).is_none());
+    }
+
+    #[test]
+    fn markers_match_chinese_corrections_too() {
+        assert!(opens_with_marker("不对，应该用 pnpm"));
+        assert!(opens_with_marker("No, use pnpm instead"));
+        assert!(!opens_with_marker("looks good, ship it"));
+    }
+
+    // ─── incident detection, end to end ─────────────────────────────
+
+    use crate::corpus::{CorpusIndex, LOCAL_HOST};
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn write(root: &Path, slug: &str, sid: &str, lines: &[String]) {
+        let dir = root.join(slug);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join(format!("{sid}.jsonl")),
+            format!("{}\n", lines.join("\n")),
+        )
+        .unwrap();
+    }
+    fn user(text: &str, ts: &str) -> String {
+        format!(
+            r#"{{"type":"user","message":{{"role":"user","content":"{text}"}},"timestamp":"{ts}","cwd":"/repo/foo"}}"#
+        )
+    }
+    fn tool_use(id: &str, name: &str, cmd: &str, ts: &str) -> String {
+        format!(
+            r#"{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"tool_use","id":"{id}","name":"{name}","input":{{"command":"{cmd}"}}}}]}},"timestamp":"{ts}","cwd":"/repo/foo"}}"#
+        )
+    }
+    fn tool_res(id: &str, text: &str, err: bool, ts: &str) -> String {
+        format!(
+            r#"{{"type":"user","message":{{"role":"user","content":[{{"type":"tool_result","tool_use_id":"{id}","content":"{text}","is_error":{err}}}]}},"timestamp":"{ts}","cwd":"/repo/foo"}}"#
+        )
+    }
+
+    fn indexed(lines: &[String]) -> (CorpusIndex, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("projects");
+        write(&root, "-repo-foo", "S1", lines);
+        let c = CorpusIndex::in_memory().unwrap();
+        c.index_root(LOCAL_HOST, &root, 1).unwrap();
+        (c, tmp)
+    }
+
+    #[test]
+    fn a_failure_then_a_same_family_success_is_a_resolved_incident() {
+        let (c, _t) = indexed(&[
+            user("build it", "2026-04-10T10:00:00Z"),
+            tool_use("t1", "Bash", "cargo test", "2026-04-10T10:00:01Z"),
+            tool_res("t1", "Exit code 1", true, "2026-04-10T10:00:02Z"),
+            user("fix it", "2026-04-10T10:00:03Z"),
+            tool_use("t2", "Bash", "cargo test", "2026-04-10T10:00:04Z"),
+            tool_res("t2", "ok", false, "2026-04-10T10:00:05Z"),
+        ]);
+        let inc = detect_incidents(&c, 100).unwrap();
+        assert_eq!(inc.len(), 1, "one failure, one incident");
+        assert!(
+            inc[0].is_resolved(),
+            "the later cargo success is its recovery"
+        );
+        assert_eq!(inc[0].family, "bash:cargo");
+        assert!(inc[0].error_signature.contains("exit code 1"));
+    }
+
+    /// The constraint that kills the 358k-pair naive join: a success of
+    /// a *different* command is not a recovery.
+    #[test]
+    fn an_unrelated_success_does_not_count_as_recovery() {
+        let (c, _t) = indexed(&[
+            user("build it", "2026-04-10T10:00:00Z"),
+            tool_use("t1", "Bash", "cargo test", "2026-04-10T10:00:01Z"),
+            tool_res("t1", "Exit code 1", true, "2026-04-10T10:00:02Z"),
+            tool_use("t2", "Bash", "ls -la", "2026-04-10T10:00:03Z"),
+            tool_res("t2", "ok", false, "2026-04-10T10:00:04Z"),
+        ]);
+        let inc = detect_incidents(&c, 100).unwrap();
+        assert_eq!(inc.len(), 1);
+        assert!(
+            !inc[0].is_resolved(),
+            "an `ls` success must not resolve a `cargo` failure"
+        );
+    }
+
+    /// And a failure that never recovers is `unresolved` — not
+    /// "abandoned", which the transcript cannot support.
+    #[test]
+    fn a_failure_with_no_success_is_unresolved_not_abandoned() {
+        let (c, _t) = indexed(&[
+            user("build it", "2026-04-10T10:00:00Z"),
+            tool_use("t1", "Bash", "cargo test", "2026-04-10T10:00:01Z"),
+            tool_res("t1", "Exit code 1", true, "2026-04-10T10:00:02Z"),
+        ]);
+        let inc = detect_incidents(&c, 100).unwrap();
+        assert_eq!(inc.len(), 1);
+        assert_eq!(inc[0].recovery_turn, None);
+    }
+
+    #[test]
+    fn repetition_needs_both_a_count_and_more_than_one_project() {
+        let (c, _t) = indexed(&[
+            user("check status", "2026-04-10T10:00:00Z"),
+            user("check status", "2026-04-10T10:01:00Z"),
+            user("check status", "2026-04-10T10:02:00Z"),
+        ]);
+        // One project only — must not surface however often it repeats.
+        assert!(detect_repetitions(&c, 2, 2).unwrap().is_empty());
+        // Same corpus, single-project threshold — now it does.
+        let r = detect_repetitions(&c, 2, 1).unwrap();
+        assert!(r.iter().any(|x| x.normalized.contains("check status")));
+    }
+
+    #[test]
+    fn a_repetition_cluster_keeps_an_unnormalized_sample() {
+        let (c, _t) = indexed(&[
+            user("Fix The Build", "2026-04-10T10:00:00Z"),
+            user("Fix The Build", "2026-04-10T10:01:00Z"),
+        ]);
+        let r = detect_repetitions(&c, 2, 1).unwrap();
+        let cluster = r.iter().find(|x| x.count >= 2).unwrap();
+        assert_eq!(
+            cluster.sample, "Fix The Build",
+            "display copy is the original"
+        );
+        assert_eq!(cluster.normalized, "fix the build");
+    }
+
+    /// Regression: harness plumbing dominated the first real run's
+    /// repetition clusters. It must not reach them at all.
+    #[test]
+    fn harness_turns_never_form_a_repetition_cluster() {
+        let (c, _t) = indexed(&[
+            user("<command-name>/exit</command-name>", "2026-04-10T10:00:00Z"),
+            user("<command-name>/exit</command-name>", "2026-04-10T10:01:00Z"),
+            user("<command-name>/exit</command-name>", "2026-04-10T10:02:00Z"),
+            user("commit and push", "2026-04-10T10:03:00Z"),
+            user("commit and push", "2026-04-10T10:04:00Z"),
+        ]);
+        let r = detect_repetitions(&c, 2, 1).unwrap();
+        assert!(
+            !r.iter().any(|x| x.sample.contains("command-name")),
+            "harness turns must not cluster: {r:?}"
+        );
+        assert!(
+            r.iter().any(|x| x.sample.contains("commit and push")),
+            "but real repeated requests still must"
+        );
+    }
+
+    #[test]
+    fn detect_all_runs_every_tier_without_erroring() {
+        let (c, _t) = indexed(&[
+            user("build it", "2026-04-10T10:00:00Z"),
+            tool_use("t1", "Bash", "cargo test", "2026-04-10T10:00:01Z"),
+            tool_res("t1", "Exit code 1", true, "2026-04-10T10:00:02Z"),
+            user("no, use nextest", "2026-04-10T10:00:03Z"),
+        ]);
+        let f = detect_all(&c, 100).unwrap();
+        assert_eq!(f.incidents.len(), 1);
+        assert_eq!(f.resolved_incidents(), 0);
+        assert_eq!(f.corrections.len(), 1, "corroborated by the failure above");
+        assert_eq!(
+            f.corrections[0].corroboration,
+            Corroboration::PrecedingFailure
+        );
+    }
+
+    #[test]
+    fn an_empty_corpus_yields_nothing_rather_than_erroring() {
+        let c = CorpusIndex::in_memory().unwrap();
+        let f = detect_all(&c, 100).unwrap();
+        assert!(f.incidents.is_empty() && f.repetitions.is_empty() && f.corrections.is_empty());
+    }
+}

--- a/crates/claudepot-core/src/corpus/normalize.rs
+++ b/crates/claudepot-core/src/corpus/normalize.rs
@@ -1,0 +1,446 @@
+//! Tier 0 — turn raw transcript text into something comparable.
+//!
+//! Everything downstream groups by equality or near-equality, and raw
+//! transcript text never repeats exactly: it carries absolute paths,
+//! uuids, hashes, timestamps, line numbers, ports and durations that
+//! differ on every run. Normalizing produces a *comparison* copy; the
+//! display copy is always the original.
+//!
+//! # Two normalizers, on purpose
+//!
+//! [`normalize_prompt`] is aggressive — it exists to make "run the
+//! tests" and "run the tests" cluster, so it flattens numbers wholesale.
+//!
+//! [`error_signature`] is not. An exit code is the most discriminating
+//! part of a failure, so small integers survive; what gets stripped is
+//! the *payload*. That distinction is load-bearing: normalizing
+//! `Exit code 1` and `Exit code 143` together would merge "the command
+//! failed" with "the command timed out".
+//!
+//! # Privacy
+//!
+//! Tool output is arbitrary stdout. On the reference machine it
+//! includes bank statements. [`error_signature`] therefore takes only
+//! the **first line** — where `Exit code N`, `Traceback…`,
+//! `error[E0433]` live — runs it through the shared redactor, and caps
+//! it. A signature is a grouping key, never a quote.
+
+use crate::session_live::redact::redact_secrets;
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Longest signature we keep. Past this it is payload, not shape.
+const SIGNATURE_CAP: usize = 96;
+
+fn re_uuid() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| {
+        Regex::new(r"(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b").unwrap()
+    })
+}
+
+fn re_hash() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"(?i)\b[0-9a-f]{7,}\b").unwrap())
+}
+
+/// Absolute paths, POSIX and Windows. Deliberately not anchored to `/`
+/// alone — `rules/paths.md`: a Windows drive letter or UNC prefix is
+/// just as much an absolute path, and leaving those un-normalized would
+/// make the same operation cluster differently per platform.
+fn re_path() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"(?:[A-Za-z]:\\|\\\\|/)[^\s'\x22`,;:()\[\]{}]{2,}").unwrap())
+}
+
+fn re_ts() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    // Case-insensitive because callers lowercase first, so the ISO `T`
+    // arrives as `t`. No trailing `\b`: an ISO stamp is frequently
+    // butted against following text, and a word boundary would then
+    // fail and leave the whole stamp unnormalized.
+    R.get_or_init(|| {
+        Regex::new(r"(?i)\b\d{4}-\d{2}-\d{2}(?:[t ]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?)?z?").unwrap()
+    })
+}
+
+fn re_num() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\b\d+\b").unwrap())
+}
+
+/// Big numbers only — keeps exit codes and small counts, drops byte
+/// sizes, pids, ports, durations and line offsets.
+fn re_bignum() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\b\d{4,}\b").unwrap())
+}
+
+fn re_ws() -> &'static Regex {
+    static R: OnceLock<Regex> = OnceLock::new();
+    R.get_or_init(|| Regex::new(r"\s+").unwrap())
+}
+
+/// Aggressive comparison form for clustering user prompts.
+///
+/// Order matters: timestamps before numbers (or the number rule eats
+/// their digits first and the timestamp shape is lost), uuids and
+/// hashes before paths (a path can contain both).
+pub fn normalize_prompt(s: &str) -> String {
+    let s = s.trim().to_lowercase();
+    let s = re_ts().replace_all(&s, " <ts> ");
+    let s = re_uuid().replace_all(&s, " <uuid> ");
+    let s = re_path().replace_all(&s, " <path> ");
+    let s = re_hash().replace_all(&s, " <hash> ");
+    let s = re_num().replace_all(&s, " <n> ");
+    re_ws().replace_all(&s, " ").trim().to_string()
+}
+
+/// Stable 64-bit key for a normalized string.
+pub fn fingerprint(s: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    s.hash(&mut h);
+    h.finish()
+}
+
+/// Grouping key for a tool failure.
+///
+/// First line only, redacted, lightly normalized, capped. Returns
+/// `None` for output with no usable first line — an unclassifiable
+/// failure is better dropped than grouped under an empty key, which
+/// would merge every such failure into one enormous fake cluster.
+pub fn error_signature(tool_result_text: &str) -> Option<String> {
+    let first = tool_result_text.lines().find(|l| !l.trim().is_empty())?;
+    let first = redact_secrets(first);
+    let s = first.trim().to_lowercase();
+    let s = re_ts().replace_all(&s, "<ts>");
+    let s = re_uuid().replace_all(&s, "<uuid>");
+    let s = re_path().replace_all(&s, "<path>");
+    let s = re_hash().replace_all(&s, "<hash>");
+    // Small integers survive: `exit code 1` and `exit code 143` are
+    // different failures.
+    let s = re_bignum().replace_all(&s, "<n>");
+    let s = re_ws().replace_all(&s, " ").trim().to_string();
+    if s.is_empty() {
+        return None;
+    }
+    Some(s.chars().take(SIGNATURE_CAP).collect())
+}
+
+/// Shell words that prefix a command without being the command, and
+/// which take **no** argument — scanning continues inside the segment.
+const SHELL_PREFIX: &[&str] = &["sudo", "env", "time", "nohup", "exec", "then", "do", "!"];
+
+/// Shell words that consume the rest of their segment. `cd /some/path`
+/// must skip the *whole* segment: skipping only the word leaves the
+/// path, whose basename then becomes the "command" — so
+/// `cd "/Users/joker/repo"; cargo test` would report `repo` instead of
+/// `cargo`, and pair a failed build with a successful directory change.
+const SHELL_SEGMENT_CONSUMERS: &[&str] = &["cd", "source", ".", "pushd", "popd", "export"];
+
+/// Text CC injects into the transcript that the user never typed.
+///
+/// Found empirically: the first detector run over the real corpus
+/// returned `<local-command-caveat>…` 1,258 times across 69 projects as
+/// its single largest "repeated request", followed by `/exit`, `/clear`
+/// and `[Request interrupted by user]`. All of it is harness plumbing.
+/// Clustering it is not merely useless — it buries the real signal
+/// under synthetic turns that no automation could ever remove.
+const HARNESS_MARKERS: &[&str] = &[
+    "<local-command-",
+    "<command-name>",
+    "<command-message>",
+    "<command-args>",
+    "<system-reminder>",
+    "[request interrupted by user",
+    "caveat: the messages below were generated",
+    "<user-prompt-submit-hook>",
+    // Second pass over the real corpus surfaced this one: the echoed
+    // output of a `!`-prefixed shell command, 98 times across 23
+    // projects.
+    "<bash-stdout>",
+    "<bash-stderr>",
+    "<bash-input>",
+];
+
+/// Whether this turn is harness plumbing rather than user intent.
+///
+/// Checked against a lowercased prefix: these markers open the turn, and
+/// scanning the whole body would reject any turn that merely *quotes*
+/// one — including a user asking about them.
+pub fn is_harness_synthetic(text: &str) -> bool {
+    let head: String = text.trim_start().to_lowercase().chars().take(200).collect();
+    HARNESS_MARKERS.iter().any(|m| head.starts_with(m))
+}
+
+/// What "the same operation" means for pairing a failure with its
+/// recovery.
+///
+/// For `Bash` this is the first *meaningful* command word, which is not
+/// the first word: real commands routinely look like
+/// `cd "<some dir>"; echo "…"; cat notes.md`, so a naive first-token
+/// split yields `cd` for a large share of the corpus and would pair a
+/// failed `cargo test` with a successful `cd`. Segments are split on
+/// `;`, `&&`, `||`, `|` and newlines, leading `VAR=value` assignments
+/// and [`SHELL_NOISE`] are skipped, and the result is reduced to a
+/// basename so `/usr/bin/git` and `git` agree.
+///
+/// For file-taking tools the family is the file's basename — a failed
+/// `Edit` on `foo.rs` is recovered by a successful `Edit` on `foo.rs`,
+/// not by one on an unrelated file.
+///
+/// Everything else falls back to the tool name.
+pub fn command_family(tool_name: &str, tool_input_json: Option<&str>) -> String {
+    let input: Option<serde_json::Value> =
+        tool_input_json.and_then(|j| serde_json::from_str(j).ok());
+
+    match tool_name {
+        "Bash" => {
+            let cmd = input
+                .as_ref()
+                .and_then(|v| v.get("command"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            format!("bash:{}", first_meaningful_word(cmd))
+        }
+        "Edit" | "Write" | "Read" | "NotebookEdit" => {
+            let path = input
+                .as_ref()
+                .and_then(|v| v.get("file_path").or_else(|| v.get("path")))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            format!("{}:{}", tool_name.to_lowercase(), basename(path))
+        }
+        other => other.to_lowercase(),
+    }
+}
+
+fn first_meaningful_word(cmd: &str) -> String {
+    'segments: for segment in cmd.split(['\n', ';', '|', '&']) {
+        for word in segment.split_whitespace() {
+            let w = word.trim_matches(|c| c == '(' || c == ')' || c == '"' || c == '\'');
+            if w.is_empty() {
+                continue;
+            }
+            // `VAR=value` prefix — not the command.
+            if w.contains('=') && !w.starts_with('-') {
+                continue;
+            }
+            if w.starts_with('-') {
+                continue;
+            }
+            // A comment: everything after it in this segment is prose,
+            // not a command. Without this the corpus reports `bash:#`
+            // as a top command family — 266 "verified recoveries" that
+            // are two comment lines either side of unrelated work.
+            if w.starts_with('#') {
+                continue 'segments;
+            }
+            let b = basename(w);
+            if SHELL_SEGMENT_CONSUMERS.contains(&b.as_str()) {
+                // Its argument is not a command. Abandon the segment.
+                continue 'segments;
+            }
+            if SHELL_PREFIX.contains(&b.as_str()) {
+                continue;
+            }
+            if !b.is_empty() {
+                return b;
+            }
+        }
+    }
+    String::new()
+}
+
+/// Last path segment, separator-agnostic (`rules/paths.md` — never
+/// hardcode `/`).
+fn basename(p: &str) -> String {
+    p.rsplit(['/', '\\'])
+        .find(|s| !s.is_empty())
+        .unwrap_or("")
+        .trim_matches('"')
+        .to_string()
+}
+
+/// Token-set Jaccard over normalized text. Used where "did the user ask
+/// for the same thing again" needs to tolerate rewording, rather than
+/// demanding an exact fingerprint match.
+pub fn jaccard(a: &str, b: &str) -> f64 {
+    use std::collections::HashSet;
+    let sa: HashSet<&str> = a.split(' ').filter(|t| !t.is_empty()).collect();
+    let sb: HashSet<&str> = b.split(' ').filter(|t| !t.is_empty()).collect();
+    if sa.is_empty() || sb.is_empty() {
+        return 0.0;
+    }
+    let inter = sa.intersection(&sb).count() as f64;
+    let union = sa.union(&sb).count() as f64;
+    inter / union
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paths_uuids_and_hashes_normalize_away() {
+        let a = normalize_prompt("fix /Users/joker/repo/src/main.rs at line 42");
+        let b = normalize_prompt("fix /Users/other/proj/src/main.rs at line 7");
+        assert_eq!(a, b, "the same request about different paths must cluster");
+    }
+
+    /// `rules/paths.md`: a Windows path is a path.
+    #[test]
+    fn windows_and_unc_paths_normalize_too() {
+        let unix = normalize_prompt("read /Users/joker/x/y.rs");
+        let win = normalize_prompt(r"read C:\Users\joker\x\y.rs");
+        let unc = normalize_prompt(r"read \\server\share\x\y.rs");
+        assert_eq!(unix, win);
+        assert_eq!(unix, unc);
+    }
+
+    #[test]
+    fn timestamps_survive_as_a_shape_not_digits() {
+        let s = normalize_prompt("failed at 2026-04-10T10:00:00Z");
+        assert!(s.contains("<ts>"), "got {s}");
+    }
+
+    // ─── error signatures ───────────────────────────────────────────
+
+    /// The whole point: different exit codes are different failures.
+    #[test]
+    fn exit_codes_are_preserved() {
+        let a = error_signature("Exit code 1\nsome stdout").unwrap();
+        let b = error_signature("Exit code 143\nCommand timed out").unwrap();
+        assert_ne!(a, b, "a failure and a timeout must not merge");
+        assert!(a.contains('1'));
+    }
+
+    /// Payload after the first line is noise — and on a real machine it
+    /// contains bank statements.
+    #[test]
+    fn only_the_first_line_becomes_the_signature() {
+        let sig = error_signature(
+            "Exit code 1\n===== statement =====\naccount 6222021234567890 balance 12345",
+        )
+        .unwrap();
+        assert!(!sig.contains("6222021234567890"));
+        assert!(!sig.contains("balance"));
+        assert!(sig.starts_with("exit code 1"));
+    }
+
+    #[test]
+    fn the_same_failure_from_different_paths_shares_a_signature() {
+        let a = error_signature("error: could not compile /Users/a/x.rs").unwrap();
+        let b = error_signature("error: could not compile /Users/b/y.rs").unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn empty_or_blank_output_has_no_signature() {
+        assert!(error_signature("").is_none());
+        assert!(error_signature("   \n  \n").is_none());
+    }
+
+    #[test]
+    fn signatures_are_capped() {
+        let long = format!("error: {}", "x".repeat(500));
+        assert!(error_signature(&long).unwrap().chars().count() <= SIGNATURE_CAP);
+    }
+
+    // ─── command families ───────────────────────────────────────────
+
+    /// The precision fix. Real Bash commands in this corpus start with
+    /// `cd "…"`; taking the first token would pair a failed build with
+    /// a successful directory change.
+    #[test]
+    fn bash_family_skips_cd_and_env_prefixes() {
+        let j = r#"{"command":"cd \"/Users/joker/repo\"; cargo test --workspace"}"#;
+        assert_eq!(command_family("Bash", Some(j)), "bash:cargo");
+
+        let j2 = r#"{"command":"RUST_LOG=debug cargo build"}"#;
+        assert_eq!(command_family("Bash", Some(j2)), "bash:cargo");
+
+        let j3 = r#"{"command":"sudo /usr/bin/git status"}"#;
+        assert_eq!(command_family("Bash", Some(j3)), "bash:git");
+    }
+
+    #[test]
+    fn bash_family_reduces_absolute_commands_to_basenames() {
+        let j = r#"{"command":"/opt/homebrew/bin/pnpm test"}"#;
+        assert_eq!(command_family("Bash", Some(j)), "bash:pnpm");
+    }
+
+    #[test]
+    fn file_tools_are_keyed_by_basename() {
+        let j = r#"{"file_path":"/Users/joker/repo/src/main.rs"}"#;
+        assert_eq!(command_family("Edit", Some(j)), "edit:main.rs");
+        // Same file, different checkout — still the same family.
+        let j2 = r#"{"file_path":"/tmp/other/src/main.rs"}"#;
+        assert_eq!(command_family("Edit", Some(j2)), "edit:main.rs");
+    }
+
+    /// Regression from the first real run: `bash:#` came back as a top
+    /// command family with 266 "verified recoveries" — comment lines
+    /// paired either side of unrelated work.
+    #[test]
+    fn a_comment_is_not_a_command_family() {
+        // `r##"…"##` because the payload contains `"#`, which would
+        // close a single-hash raw string mid-literal.
+        let j = r##"{"command":"# rebuild everything\ncargo build"}"##;
+        assert_eq!(command_family("Bash", Some(j)), "bash:cargo");
+
+        let only_comment = r##"{"command":"# just a note"}"##;
+        assert_eq!(command_family("Bash", Some(only_comment)), "bash:");
+    }
+
+    // ─── harness plumbing ───────────────────────────────────────────
+
+    /// Regression from the first real run: the single largest
+    /// "repeated request" in the corpus was `<local-command-caveat>…`,
+    /// 1,258 times across 69 projects. The user never typed any of it.
+    #[test]
+    fn harness_injected_turns_are_recognised() {
+        for s in [
+            "<local-command-caveat>Caveat: The messages below were generated…",
+            "<command-name>/exit</command-name>",
+            "<command-message>clear</command-message>",
+            "[Request interrupted by user]",
+            "<system-reminder>\nSomething\n</system-reminder>",
+            "Caveat: The messages below were generated by the user while running",
+        ] {
+            assert!(is_harness_synthetic(s), "should be synthetic: {s}");
+        }
+    }
+
+    /// ...but a real prompt that merely *mentions* one is still a real
+    /// prompt. Matching anywhere in the body would silently drop it.
+    #[test]
+    fn a_user_asking_about_harness_text_is_not_synthetic() {
+        assert!(!is_harness_synthetic(
+            "why does <system-reminder> keep showing up in my transcripts?"
+        ));
+        assert!(!is_harness_synthetic("commit and push"));
+        assert!(!is_harness_synthetic(""));
+    }
+
+    #[test]
+    fn unknown_tools_fall_back_to_their_name() {
+        assert_eq!(command_family("WebFetch", None), "webfetch");
+    }
+
+    #[test]
+    fn malformed_input_json_does_not_panic() {
+        assert_eq!(command_family("Bash", Some("not json")), "bash:");
+        assert_eq!(command_family("Bash", None), "bash:");
+    }
+
+    #[test]
+    fn jaccard_scores_overlap() {
+        assert!(jaccard("run the tests", "run the tests") > 0.99);
+        // {run,the} shared of {run,the,tests,test,suite} = exactly 0.4.
+        assert!(jaccard("run the tests", "run the test suite") >= 0.4);
+        assert!(jaccard("run the tests", "deploy to prod") < 0.2);
+        assert_eq!(jaccard("", "x"), 0.0);
+    }
+}

--- a/crates/claudepot-core/src/lib.rs
+++ b/crates/claudepot-core/src/lib.rs
@@ -46,6 +46,7 @@ pub mod blob;
 pub mod breaker;
 pub mod cc_daemon;
 pub mod cc_doctor;
+pub mod cc_retention;
 pub mod cc_tips;
 pub mod cli_backend;
 pub(crate) mod codex_session;

--- a/crates/claudepot-core/src/lib.rs
+++ b/crates/claudepot-core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod cc_tips;
 pub mod cli_backend;
 pub(crate) mod codex_session;
 pub mod config_view;
+pub mod corpus;
 pub mod crash_reports;
 pub mod db_housekeeping;
 pub(crate) mod db_pragmas;

--- a/crates/claudepot-core/src/notifications.rs
+++ b/crates/claudepot-core/src/notifications.rs
@@ -83,6 +83,11 @@ pub enum Category {
     ConfigTreePatched,
     ServiceStatusChanged,
     UpdateAvailable,
+    /// Claude Code is about to delete saved conversations under its
+    /// `cleanupPeriodDays` window. P1 rather than P0: it needs
+    /// attention before the next CC launch, but it does not block the
+    /// work in front of the user. See `crate::cc_retention`.
+    TranscriptsExpiring,
 }
 
 /// Notification urgency. Drives the default surface set in [`route`];
@@ -211,7 +216,9 @@ impl Category {
 
             // P1 — Stalled
             SessionWaiting | SessionStuck | SessionErrorBurst | OpDoneUnfocused
-            | RotationSuggested | UsageThreshold | UpdateInstallReady => P1Stalled,
+            | RotationSuggested | UsageThreshold | UpdateInstallReady | TranscriptsExpiring => {
+                P1Stalled
+            }
 
             // P2 — Acknowledge
             AccountVerified
@@ -255,6 +262,7 @@ impl Category {
             RotationSuggested => ("Account rotation suggested", "Live work", true),
             UsageThreshold => ("Usage near limit", "Live work", true),
             UpdateInstallReady => ("Update ready to install", "Live work", true),
+            TranscriptsExpiring => ("Saved conversations expiring", "Live work", true),
 
             AccountVerified => ("Account verified", "Actions", true),
             AccountSwitched => ("Account switched", "Actions", true),
@@ -323,6 +331,7 @@ impl Category {
             ConfigTreePatched,
             ServiceStatusChanged,
             UpdateAvailable,
+            TranscriptsExpiring,
         ]
     }
 }
@@ -433,7 +442,7 @@ mod tests {
         // Synthetic exhaustive match: this fails to compile if a new
         // variant is added without updating `all()`. Update the
         // counter and the match arms in lockstep with the enum.
-        const EXPECTED: usize = 31;
+        const EXPECTED: usize = 32;
         let actual = Category::all().len();
         assert_eq!(
             actual, EXPECTED,

--- a/crates/claudepot-core/src/session/core.rs
+++ b/crates/claudepot-core/src/session/core.rs
@@ -114,8 +114,14 @@ pub struct SessionRow {
     /// CC's internal display slug (`message.slug` on any line). Lets us
     /// offer a stable human name in the list.
     pub display_slug: Option<String>,
-    /// True iff any assistant event included `is_error: true` or
+    /// True iff the transcript contains a failed tool call — a
+    /// `tool_result` block with `is_error: true` under
+    /// `message.content[]` — or an assistant turn with
     /// `stop_reason == "error"`. Surfaces a badge in the list.
+    ///
+    /// The `tool_result` clause is the one that fires in practice; see
+    /// [`content_has_tool_error`] for why the original top-level
+    /// `isError` check never did.
     pub has_error: bool,
     /// True iff ANY event had `isSidechain: true` — pure-agent
     /// subsession (e.g. subagent transcripts bundled alongside the
@@ -472,6 +478,34 @@ pub struct SessionScan {
     pub turns: Vec<TurnRecord>,
 }
 
+/// Did this transcript line carry a failed tool result?
+///
+/// CC records a tool failure as a `tool_result` content block with
+/// `is_error: true`, nested under `message.content[]` — normally on the
+/// *user*-role line that carries the result back. It is not a top-level
+/// line field and it is not `stop_reason`, which is why the two older
+/// checks in [`scan_session`] never fired.
+///
+/// Kept in step with `shared_memory::claude_exchanges`, which reads the
+/// same shape to populate `tool_calls.is_error`. If CC ever changes it,
+/// both move together or `has_error` silently dies again.
+fn content_has_tool_error(line: &Value) -> bool {
+    let Some(content) = line
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    content.iter().any(|block| {
+        block.get("type").and_then(Value::as_str) == Some("tool_result")
+            && block
+                .get("is_error")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+    })
+}
+
 /// Single streaming scan that folds every field we care about into a
 /// `SessionRow`, and at the same time extracts artifact usage events.
 /// Malformed lines are counted toward `event_count` but contribute
@@ -679,6 +713,17 @@ pub(crate) fn scan_session(slug: &str, path: &Path) -> Result<SessionScan, Sessi
         }
 
         if v.get("isError").and_then(Value::as_bool).unwrap_or(false) {
+            has_error = true;
+        }
+        // The shape CC actually writes for a failed tool call. The two
+        // checks above look in places CC does not use for this:
+        // `isError` is never a top-level line field, and `stop_reason`
+        // is an assistant-turn condition, not a tool failure. So
+        // `has_error` read `false` for every session on a real machine
+        // — 154 of 460 of which contained a failing tool call, as
+        // `tool_calls.is_error` (populated from this same nested shape
+        // by `shared_memory::claude_exchanges`) shows.
+        if !has_error && content_has_tool_error(&v) {
             has_error = true;
         }
     }

--- a/crates/claudepot-core/src/session/core_tests.rs
+++ b/crates/claudepot-core/src/session/core_tests.rs
@@ -57,6 +57,57 @@ fn single_session_scan_captures_everything() {
     assert!(!r.has_error);
 }
 
+/// Regression: `has_error` was dead. It only checked a top-level
+/// `isError` (a field CC never writes on a transcript line) and
+/// `stop_reason == "error"` (an assistant-turn condition, not a tool
+/// failure), so on a real machine 154 of 460 sessions contained a
+/// failing tool call and every one of them reported `has_error = false`.
+///
+/// The shape below is what CC actually writes, and is the same one
+/// `shared_memory::claude_exchanges` reads to populate
+/// `tool_calls.is_error` — which is why that column was right while
+/// this one was wrong.
+#[test]
+fn has_error_is_set_by_a_failed_tool_result() {
+    let tmp = TempDir::new().unwrap();
+    let user = r#"{"type":"user","message":{"role":"user","content":"run it"},"timestamp":"2026-04-10T10:00:00Z","cwd":"/repo/foo","sessionId":"ERR"}"#;
+    let failed = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"Exit code 1","is_error":true}]},"timestamp":"2026-04-10T10:00:10Z","cwd":"/repo/foo","sessionId":"ERR"}"#;
+    write_session(tmp.path(), "-repo-foo", "ERR", &[user, failed]);
+
+    let rows = scan_all_sessions_uncached(tmp.path()).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(
+        rows[0].has_error,
+        "a tool_result with is_error:true must set has_error"
+    );
+}
+
+/// The mirror of the above: a successful tool result must not trip it,
+/// or the column becomes uniformly `true` and just as useless.
+#[test]
+fn has_error_stays_false_for_a_successful_tool_result() {
+    let tmp = TempDir::new().unwrap();
+    let user = r#"{"type":"user","message":{"role":"user","content":"run it"},"timestamp":"2026-04-10T10:00:00Z","cwd":"/repo/foo","sessionId":"OK1"}"#;
+    let ok = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"done","is_error":false}]},"timestamp":"2026-04-10T10:00:10Z","cwd":"/repo/foo","sessionId":"OK1"}"#;
+    write_session(tmp.path(), "-repo-foo", "OK1", &[user, ok]);
+
+    let rows = scan_all_sessions_uncached(tmp.path()).unwrap();
+    assert!(!rows[0].has_error);
+}
+
+/// A `tool_result` block with the key absent must read as success —
+/// CC omits `is_error` on the happy path.
+#[test]
+fn has_error_stays_false_when_is_error_is_absent() {
+    let tmp = TempDir::new().unwrap();
+    let user = r#"{"type":"user","message":{"role":"user","content":"run it"},"timestamp":"2026-04-10T10:00:00Z","cwd":"/repo/foo","sessionId":"OK2"}"#;
+    let ok = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"done"}]},"timestamp":"2026-04-10T10:00:10Z","cwd":"/repo/foo","sessionId":"OK2"}"#;
+    write_session(tmp.path(), "-repo-foo", "OK2", &[user, ok]);
+
+    let rows = scan_all_sessions_uncached(tmp.path()).unwrap();
+    assert!(!rows[0].has_error);
+}
+
 #[test]
 fn turn_record_user_prompt_carry_over_clears_when_intervening_user_line_has_no_text() {
     // Regression: a user line without extractable text (tool-result-only,

--- a/crates/claudepot-core/src/session_index/mod.rs
+++ b/crates/claudepot-core/src/session_index/mod.rs
@@ -676,6 +676,12 @@ fn apply_schema(db: &Connection) -> Result<(), SessionIndexError> {
     // nothing on disk can rebuild. See the note in schema.rs.
     crate::shared_memory::schema::apply_memories_compiler_columns(&tx)?;
 
+    // Seed the harvest ledger from the provenance scheme it replaces.
+    // Strictly after the ALTERs above: `origin_file_path` is one of the
+    // columns they add, so this cannot live in the v4 DDL block.
+    // Idempotent, so running it on every open costs one no-op INSERT.
+    crate::shared_memory::harvest_ledger::backfill_from_provenance(&tx)?;
+
     // Read the `_pending_rescan` marker. Set by the Settings →
     // Cleanup actions and cleared inside this transaction.
     let pending_rescan: bool = tx

--- a/crates/claudepot-core/src/settings_writer.rs
+++ b/crates/claudepot-core/src/settings_writer.rs
@@ -146,6 +146,34 @@ pub fn read_bool_setting(path: &Path, key: &str) -> Result<Option<bool>, Setting
         .and_then(JsonValue::as_bool))
 }
 
+/// Integer sibling of [`read_bool_setting`]. Missing file / missing key
+/// / non-integer value → `None`.
+///
+/// Added for `cleanupPeriodDays` ([`crate::cc_retention`]), the one CC
+/// setting whose value is a count rather than a flag. The wrong-type
+/// case deliberately reads as "not set" for the same reason the bool
+/// reader does: CC coerces rather than erroring, and a Claudepot that
+/// errored where CC shrugs would report a problem the user cannot see
+/// in the product it describes.
+///
+/// Note `as_i64` rejects a JSON float (`30.5`), which is correct here —
+/// CC's schema declares the key `z.number().int()`, so a float is
+/// already invalid upstream and must not be echoed back as if honored.
+pub fn read_i64_setting(path: &Path, key: &str) -> Result<Option<i64>, SettingsWriteError> {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    if bytes.is_empty() {
+        return Ok(None);
+    }
+    let v: JsonValue = serde_json::from_slice(&bytes)?;
+    Ok(v.as_object()
+        .and_then(|o| o.get(key))
+        .and_then(JsonValue::as_i64))
+}
+
 /// Resolve `autoMemoryEnabled` for the global scope only. Reads env
 /// vars + `~/.claude/settings.json` and ignores the project-scoped
 /// layers entirely. Use this when the caller has no real project

--- a/crates/claudepot-core/src/shared_memory/claude_exchanges.rs
+++ b/crates/claudepot-core/src/shared_memory/claude_exchanges.rs
@@ -402,26 +402,29 @@ fn upsert_claude_exchanges(
 // ─── pairing ─────────────────────────────────────────────────
 
 #[derive(Debug, Default)]
-struct ClaudeExchange {
-    id: String,
-    turn_index: u32,
-    user_text: String,
-    assistant_text: String,
-    timestamp_ms: Option<i64>,
-    tool_calls: Vec<ClaudeToolCall>,
+pub(crate) struct ClaudeExchange {
+    pub(crate) id: String,
+    pub(crate) turn_index: u32,
+    pub(crate) user_text: String,
+    pub(crate) assistant_text: String,
+    pub(crate) timestamp_ms: Option<i64>,
+    pub(crate) tool_calls: Vec<ClaudeToolCall>,
 }
 
 #[derive(Debug, Default)]
-struct ClaudeToolCall {
-    tool_use_id: String,
-    tool_name: String,
-    tool_input_json: String,
-    tool_result_text: Option<String>,
-    is_error: bool,
-    timestamp_ms: Option<i64>,
+pub(crate) struct ClaudeToolCall {
+    pub(crate) tool_use_id: String,
+    pub(crate) tool_name: String,
+    pub(crate) tool_input_json: String,
+    pub(crate) tool_result_text: Option<String>,
+    pub(crate) is_error: bool,
+    pub(crate) timestamp_ms: Option<i64>,
 }
 
-fn pair_events_into_exchanges(session_id: &str, events: &[SessionEvent]) -> Vec<ClaudeExchange> {
+pub(crate) fn pair_events_into_exchanges(
+    session_id: &str,
+    events: &[SessionEvent],
+) -> Vec<ClaudeExchange> {
     let mut out: Vec<ClaudeExchange> = Vec::new();
     let mut current: Option<ClaudeExchange> = None;
 

--- a/crates/claudepot-core/src/shared_memory/harvest_ledger.rs
+++ b/crates/claudepot-core/src/shared_memory/harvest_ledger.rs
@@ -1,0 +1,536 @@
+//! What has already been distilled, and at what cost.
+//!
+//! # The bug this replaces
+//!
+//! Selection used to be "sessions with no memory carrying my
+//! `origin_file_path`". That treats *provenance* as a *job ledger*, and
+//! the two disagree precisely where it costs money: a transcript the
+//! distiller read correctly and which honestly contained no durable
+//! lesson produces no memory row, so it looks unmined forever. Every
+//! harvest re-selected it, re-spawned `claude -p`, and re-paid for the
+//! same verdict.
+//!
+//! On the reference machine that was 464 sessions. After the corpus
+//! index (C1) it is 14,059 transcripts, so the bug scales with the fix
+//! — which is why the plan sequences this *before* C1.
+//!
+//! # What "already processed" means here
+//!
+//! A transcript is processed when this ledger holds a **succeeded** row
+//! for it under the **current extractor version**, whose `(size,
+//! mtime_ns)` still match what `sessions` reports. Any of those three
+//! failing re-opens it:
+//!
+//! - no row → never attempted;
+//! - different size/mtime → the transcript changed, so the old verdict
+//!   is about a different file;
+//! - different extractor version → a changed prompt or output schema is
+//!   a different extractor, and its verdict is not interchangeable;
+//! - `failed` under [`MAX_ATTEMPTS`] → a transient error deserves a
+//!   retry, but a permanently-unparseable transcript must not be an
+//!   infinite money sink.
+//!
+//! Zero claims is a **recorded success**, not an absence. That single
+//! distinction is the fix.
+
+use crate::session_index::SessionIndex;
+use crate::shared_memory::durable::DurableError;
+use rusqlite::params;
+
+/// Identifies the extractor whose verdict a ledger row records. Bump
+/// when the distiller's prompt, output schema, or model changes in a
+/// way that could change its answer — that re-harvests the corpus on
+/// purpose.
+///
+/// Kept here rather than derived from the prompt text: a hash of the
+/// prompt would churn on typo fixes, and re-harvesting a 14,059-file
+/// corpus is not a thing to trigger by accident.
+pub const EXTRACTOR_VERSION: &str = "distiller-v1";
+
+/// How many times a *failing* transcript is retried under one extractor
+/// version before it is left alone. Three covers transient spawn / API
+/// failures without letting one malformed file bill indefinitely.
+pub const MAX_ATTEMPTS: i64 = 3;
+
+/// Outcome of one distillation attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The extractor ran and returned a verdict — including "no claims".
+    Succeeded,
+    /// The extractor could not produce a verdict.
+    Failed,
+}
+
+impl Outcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Outcome::Succeeded => "succeeded",
+            Outcome::Failed => "failed",
+        }
+    }
+}
+
+/// One attempt, as recorded.
+#[derive(Debug, Clone)]
+pub struct Attempt<'a> {
+    pub file_path: &'a str,
+    pub outcome: Outcome,
+    pub claims_produced: u32,
+    pub model: Option<&'a str>,
+    pub cost_usd: Option<f64>,
+    pub error: Option<&'a str>,
+    pub attempted_at_ms: i64,
+}
+
+/// Record an attempt, carrying the freshness guard over from `sessions`.
+///
+/// `attempts` accumulates across retries of the same (file, extractor)
+/// so [`MAX_ATTEMPTS`] can bound them, and **resets to 1 when the
+/// freshness guard changes**. Without the reset a transcript that
+/// failed twice, was then edited, would get one retry instead of three
+/// — inheriting a retry budget spent on a different revision of the
+/// file. A success resets nothing, because a succeeded row is terminal
+/// until the file or extractor changes.
+///
+/// A transcript with no `sessions` row (e.g. deleted between selection
+/// and recording) stores a zero guard, which simply makes the next
+/// harvest re-open it — the safe direction.
+pub fn record(idx: &SessionIndex, a: &Attempt<'_>) -> Result<(), DurableError> {
+    let db = idx.db();
+    let (size, mtime): (i64, i64) = db
+        .query_row(
+            "SELECT file_size_bytes, file_mtime_ns FROM sessions WHERE file_path = ?1",
+            [a.file_path],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap_or((0, 0));
+
+    db.execute(
+        "INSERT INTO harvest_ledger \
+           (file_path, extractor_version, file_size_bytes, file_mtime_ns, \
+            attempted_at_ms, outcome, attempts, claims_produced, model, cost_usd, error) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7, ?8, ?9, ?10) \
+         ON CONFLICT(file_path, extractor_version) DO UPDATE SET \
+            file_size_bytes = excluded.file_size_bytes, \
+            file_mtime_ns   = excluded.file_mtime_ns, \
+            attempted_at_ms = excluded.attempted_at_ms, \
+            outcome         = excluded.outcome, \
+            attempts        = CASE \
+                WHEN harvest_ledger.file_size_bytes != excluded.file_size_bytes \
+                  OR harvest_ledger.file_mtime_ns   != excluded.file_mtime_ns \
+                THEN 1 ELSE harvest_ledger.attempts + 1 END, \
+            claims_produced = excluded.claims_produced, \
+            model           = excluded.model, \
+            cost_usd        = excluded.cost_usd, \
+            error           = excluded.error",
+        params![
+            a.file_path,
+            EXTRACTOR_VERSION,
+            size,
+            mtime,
+            a.attempted_at_ms,
+            a.outcome.as_str(),
+            a.claims_produced as i64,
+            a.model,
+            a.cost_usd,
+            a.error,
+        ],
+    )?;
+    Ok(())
+}
+
+/// Seed the ledger from the scheme it replaces.
+///
+/// A memory carrying `origin_file_path` is proof that transcript was
+/// distilled before this table existed. Without seeding those rows, the
+/// first run after an upgrade sees every previously harvested
+/// transcript as unharvested and pays for it again — the exact bug this
+/// table was added to fix, inverted, and billed to the user.
+///
+/// **Must run after `schema::apply_memories_compiler_columns`**, not
+/// inside the v4 DDL block: `origin_file_path` is one of the columns
+/// that block does *not* create (it arrives by probe + ALTER
+/// afterwards), so a backfill embedded in the DDL fails with
+/// `no such column`.
+///
+/// Idempotent — `INSERT OR IGNORE` against the `(file_path,
+/// extractor_version)` primary key, so re-running on every open is a
+/// no-op once seeded.
+///
+/// Inner-joins `sessions` deliberately: a memory whose transcript is no
+/// longer indexed has no reconstructable freshness guard, and a
+/// fabricated one would either wrongly suppress a harvest or be ignored
+/// on the next join anyway. Those re-open, which is the safe direction.
+pub fn backfill_from_provenance(db: &rusqlite::Connection) -> rusqlite::Result<usize> {
+    db.execute(
+        "INSERT OR IGNORE INTO harvest_ledger \
+           (file_path, extractor_version, file_size_bytes, file_mtime_ns, \
+            attempted_at_ms, outcome, attempts, claims_produced) \
+         SELECT DISTINCT m.origin_file_path, ?1, \
+                s.file_size_bytes, s.file_mtime_ns, \
+                COALESCE(m.created_at_ms, 0), 'succeeded', 1, 0 \
+           FROM memories m \
+           JOIN sessions s ON s.file_path = m.origin_file_path \
+          WHERE m.origin_file_path IS NOT NULL",
+        params![EXTRACTOR_VERSION],
+    )
+}
+
+/// Sessions in `project_path` still needing a harvest under the current
+/// extractor.
+///
+/// This is the query the old `origin_file_path NOT IN (...)` scheme got
+/// wrong. The `LEFT JOIN` is against the *current* extractor version
+/// only, so bumping [`EXTRACTOR_VERSION`] re-opens the corpus without
+/// deleting history.
+pub fn unharvested_sessions(
+    idx: &SessionIndex,
+    project_path: &str,
+    limit: u32,
+) -> Result<Vec<String>, DurableError> {
+    let limit = if limit == 0 { 20 } else { limit.min(500) };
+    let db = idx.db();
+    let mut stmt = db.prepare(
+        "SELECT s.file_path FROM sessions s \
+         LEFT JOIN harvest_ledger h \
+                ON h.file_path = s.file_path \
+               AND h.extractor_version = ?1 \
+          WHERE s.project_path = ?2 \
+            AND ( h.file_path IS NULL \
+               OR h.file_size_bytes != s.file_size_bytes \
+               OR h.file_mtime_ns   != s.file_mtime_ns \
+               OR (h.outcome = 'failed' AND h.attempts < ?3) ) \
+          ORDER BY s.last_ts_ms DESC NULLS LAST \
+          LIMIT ?4",
+    )?;
+    let rows = stmt.query_map(
+        params![EXTRACTOR_VERSION, project_path, MAX_ATTEMPTS, limit as i64],
+        |r| r.get::<_, String>(0),
+    )?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+/// What a harvest has cost so far under the current extractor. Powers
+/// the "estimated cost" line without re-deriving it from session counts.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct LedgerStats {
+    pub succeeded: u32,
+    pub failed: u32,
+    pub claims_produced: u32,
+    pub cost_usd: f64,
+}
+
+pub fn stats(idx: &SessionIndex) -> Result<LedgerStats, DurableError> {
+    let db = idx.db();
+    let (succeeded, failed, claims, cost): (i64, i64, i64, Option<f64>) = db.query_row(
+        "SELECT \
+           COALESCE(SUM(outcome = 'succeeded'), 0), \
+           COALESCE(SUM(outcome = 'failed'), 0), \
+           COALESCE(SUM(claims_produced), 0), \
+           SUM(cost_usd) \
+         FROM harvest_ledger WHERE extractor_version = ?1",
+        [EXTRACTOR_VERSION],
+        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+    )?;
+    Ok(LedgerStats {
+        succeeded: succeeded.max(0) as u32,
+        failed: failed.max(0) as u32,
+        claims_produced: claims.max(0) as u32,
+        cost_usd: cost.unwrap_or(0.0),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_index::SessionIndex;
+    use tempfile::TempDir;
+
+    fn idx() -> (SessionIndex, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let idx = SessionIndex::open(&tmp.path().join("sessions.db")).unwrap();
+        (idx, tmp)
+    }
+
+    /// Insert a minimal `sessions` row — only the columns this module
+    /// joins on need to be meaningful.
+    fn seed_session(idx: &SessionIndex, path: &str, project: &str, size: i64, mtime: i64) {
+        idx.db()
+            .execute(
+                "INSERT OR REPLACE INTO sessions (\
+                   file_path, slug, session_id, file_size_bytes, file_mtime_ns, file_inode, \
+                   project_path, project_from_transcript, event_count, message_count, \
+                   user_message_count, assistant_message_count, models_json, \
+                   tokens_input, tokens_output, tokens_cache_creation, tokens_cache_read, \
+                   has_error, is_sidechain, indexed_at_ms, last_ts_ms) \
+                 VALUES (?1,'slug','sid',?2,?3,0,?4,0,0,0,0,0,'[]',0,0,0,0,0,0,0,1)",
+                params![path, size, mtime, project],
+            )
+            .unwrap();
+    }
+
+    fn attempt<'a>(path: &'a str, outcome: Outcome, claims: u32) -> Attempt<'a> {
+        Attempt {
+            file_path: path,
+            outcome,
+            claims_produced: claims,
+            model: Some("claude-haiku-4-5"),
+            cost_usd: Some(0.01),
+            error: None,
+            attempted_at_ms: 1_800_000_000_000,
+        }
+    }
+
+    #[test]
+    fn an_unattempted_session_is_selected() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        assert_eq!(
+            unharvested_sessions(&idx, "/proj", 10).unwrap(),
+            ["/a.jsonl"]
+        );
+    }
+
+    /// The bug. A correct harvest that found nothing must not be
+    /// re-selected — under the old scheme it was, forever.
+    #[test]
+    fn a_success_with_zero_claims_is_not_reselected() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        record(&idx, &attempt("/a.jsonl", Outcome::Succeeded, 0)).unwrap();
+        assert!(unharvested_sessions(&idx, "/proj", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_success_with_claims_is_not_reselected_either() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        record(&idx, &attempt("/a.jsonl", Outcome::Succeeded, 4)).unwrap();
+        assert!(unharvested_sessions(&idx, "/proj", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_changed_transcript_is_reselected() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        record(&idx, &attempt("/a.jsonl", Outcome::Succeeded, 1)).unwrap();
+        // Same path, new bytes: the old verdict is about a different file.
+        seed_session(&idx, "/a.jsonl", "/proj", 99, 20);
+        assert_eq!(
+            unharvested_sessions(&idx, "/proj", 10).unwrap(),
+            ["/a.jsonl"]
+        );
+
+        record(&idx, &attempt("/a.jsonl", Outcome::Succeeded, 1)).unwrap();
+        seed_session(&idx, "/a.jsonl", "/proj", 99, 21); // mtime moved
+        assert_eq!(
+            unharvested_sessions(&idx, "/proj", 10).unwrap(),
+            ["/a.jsonl"]
+        );
+    }
+
+    #[test]
+    fn a_failure_retries_then_stops_at_the_cap() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        for i in 1..MAX_ATTEMPTS {
+            record(&idx, &attempt("/a.jsonl", Outcome::Failed, 0)).unwrap();
+            assert_eq!(
+                unharvested_sessions(&idx, "/proj", 10).unwrap(),
+                ["/a.jsonl"],
+                "attempt {i} should still be retryable"
+            );
+        }
+        record(&idx, &attempt("/a.jsonl", Outcome::Failed, 0)).unwrap();
+        assert!(
+            unharvested_sessions(&idx, "/proj", 10).unwrap().is_empty(),
+            "a permanently-failing transcript must stop billing"
+        );
+    }
+
+    /// A retry budget is per *revision*. A file that burned its
+    /// attempts, then changed, must get a fresh three — otherwise an
+    /// edited transcript inherits a budget spent on different content.
+    #[test]
+    fn changing_the_file_resets_the_retry_budget() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        for _ in 0..MAX_ATTEMPTS {
+            record(&idx, &attempt("/a.jsonl", Outcome::Failed, 0)).unwrap();
+        }
+        assert!(
+            unharvested_sessions(&idx, "/proj", 10).unwrap().is_empty(),
+            "precondition: budget exhausted"
+        );
+
+        seed_session(&idx, "/a.jsonl", "/proj", 99, 21); // edited
+        assert_eq!(
+            unharvested_sessions(&idx, "/proj", 10).unwrap(),
+            ["/a.jsonl"]
+        );
+        record(&idx, &attempt("/a.jsonl", Outcome::Failed, 0)).unwrap();
+        let n: i64 = idx
+            .db()
+            .query_row(
+                "SELECT attempts FROM harvest_ledger WHERE file_path='/a.jsonl'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 1, "the counter must restart for a new revision");
+        assert_eq!(
+            unharvested_sessions(&idx, "/proj", 10).unwrap(),
+            ["/a.jsonl"],
+            "and it must still be retryable"
+        );
+    }
+
+    /// A later success supersedes earlier failures.
+    #[test]
+    fn a_success_after_failures_closes_the_transcript() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        record(&idx, &attempt("/a.jsonl", Outcome::Failed, 0)).unwrap();
+        record(&idx, &attempt("/a.jsonl", Outcome::Succeeded, 0)).unwrap();
+        assert!(unharvested_sessions(&idx, "/proj", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn bumping_the_extractor_version_reopens_the_corpus() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        record(&idx, &attempt("/a.jsonl", Outcome::Succeeded, 0)).unwrap();
+        assert!(unharvested_sessions(&idx, "/proj", 10).unwrap().is_empty());
+
+        // Simulate a version bump by writing a row under a different one.
+        idx.db()
+            .execute(
+                "UPDATE harvest_ledger SET extractor_version = 'distiller-v0'",
+                [],
+            )
+            .unwrap();
+        assert_eq!(
+            unharvested_sessions(&idx, "/proj", 10).unwrap(),
+            ["/a.jsonl"],
+            "a verdict from another extractor is not interchangeable"
+        );
+    }
+
+    #[test]
+    fn selection_is_scoped_to_the_project() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj-a", 10, 20);
+        seed_session(&idx, "/b.jsonl", "/proj-b", 10, 20);
+        assert_eq!(
+            unharvested_sessions(&idx, "/proj-a", 10).unwrap(),
+            ["/a.jsonl"]
+        );
+    }
+
+    #[test]
+    fn stats_sum_the_current_extractors_rows() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        seed_session(&idx, "/b.jsonl", "/proj", 10, 20);
+        record(&idx, &attempt("/a.jsonl", Outcome::Succeeded, 3)).unwrap();
+        record(&idx, &attempt("/b.jsonl", Outcome::Failed, 0)).unwrap();
+        let s = stats(&idx).unwrap();
+        assert_eq!(s.succeeded, 1);
+        assert_eq!(s.failed, 1);
+        assert_eq!(s.claims_produced, 3);
+        assert!((s.cost_usd - 0.02).abs() < 1e-9);
+    }
+
+    /// Upgrading must not re-open transcripts a previous harvest
+    /// already paid for. Provenance from the old scheme
+    /// (`memories.origin_file_path`) is the only record of that work.
+    #[test]
+    fn the_backfill_closes_previously_harvested_transcripts() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        // A memory from the old scheme, with no ledger row.
+        idx.db()
+            .execute(
+                "INSERT INTO memories (id, scope, kind, content, created_by_kind, created_by, \
+                   created_at_ms, updated_at_ms, review_state, origin_file_path, project_path) \
+                 VALUES ('m1','project','pattern','x','agent','t',5,5,'accepted','/a.jsonl','/proj')",
+                [],
+            )
+            .unwrap();
+        assert_eq!(
+            unharvested_sessions(&idx, "/proj", 10).unwrap(),
+            ["/a.jsonl"],
+            "precondition: without a ledger row it is selected"
+        );
+
+        let n = backfill_from_provenance(&idx.db()).unwrap();
+        assert_eq!(n, 1);
+        assert!(
+            unharvested_sessions(&idx, "/proj", 10).unwrap().is_empty(),
+            "backfilled provenance must close the transcript"
+        );
+    }
+
+    /// Runs on every index open, so it must be a no-op once seeded.
+    #[test]
+    fn the_backfill_is_idempotent() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        idx.db()
+            .execute(
+                "INSERT INTO memories (id, scope, kind, content, created_by_kind, created_by, \
+                   created_at_ms, updated_at_ms, review_state, origin_file_path, project_path) \
+                 VALUES ('m1','project','pattern','x','agent','t',5,5,'accepted','/a.jsonl','/proj')",
+                [],
+            )
+            .unwrap();
+        assert_eq!(backfill_from_provenance(&idx.db()).unwrap(), 1);
+        assert_eq!(
+            backfill_from_provenance(&idx.db()).unwrap(),
+            0,
+            "second run must insert nothing"
+        );
+    }
+
+    /// A memory whose transcript is no longer indexed has no
+    /// reconstructable freshness guard, so it is left to re-open rather
+    /// than closed on a fabricated one.
+    #[test]
+    fn the_backfill_skips_memories_whose_transcript_is_gone() {
+        let (idx, _t) = idx();
+        idx.db()
+            .execute(
+                "INSERT INTO memories (id, scope, kind, content, created_by_kind, created_by, \
+                   created_at_ms, updated_at_ms, review_state, origin_file_path, project_path) \
+                 VALUES ('m1','project','pattern','x','agent','t',5,5,'accepted','/gone.jsonl','/proj')",
+                [],
+            )
+            .unwrap();
+        assert_eq!(backfill_from_provenance(&idx.db()).unwrap(), 0);
+    }
+
+    #[test]
+    fn stats_on_an_empty_ledger_are_zero_not_an_error() {
+        let (idx, _t) = idx();
+        assert_eq!(stats(&idx).unwrap(), LedgerStats::default());
+    }
+
+    /// The ledger is durable: a rebuild wipes the transcript cache but
+    /// must not make the next harvest re-pay for completed work.
+    #[test]
+    fn the_ledger_survives_a_rebuild() {
+        let (idx, _t) = idx();
+        seed_session(&idx, "/a.jsonl", "/proj", 10, 20);
+        record(&idx, &attempt("/a.jsonl", Outcome::Succeeded, 2)).unwrap();
+        idx.rebuild().unwrap();
+        assert_eq!(
+            stats(&idx).unwrap().succeeded,
+            1,
+            "ledger must outlive a rebuild"
+        );
+    }
+}

--- a/crates/claudepot-core/src/shared_memory/mod.rs
+++ b/crates/claudepot-core/src/shared_memory/mod.rs
@@ -39,6 +39,7 @@ pub mod distill;
 pub mod durable;
 pub mod git;
 pub mod guard;
+pub mod harvest_ledger;
 pub mod indexer;
 pub mod invalidate;
 pub mod proposal;

--- a/crates/claudepot-core/src/shared_memory/review.rs
+++ b/crates/claudepot-core/src/shared_memory/review.rs
@@ -367,36 +367,29 @@ pub fn counts_by_project(idx: &SessionIndex) -> Result<Vec<(String, ReviewCounts
     Ok(map.into_iter().collect())
 }
 
-/// Sessions in `project_path` that have never produced a proposal.
+/// Sessions in `project_path` still needing a harvest.
 ///
-/// `origin_file_path` is our record of what has already been mined. It
-/// is denormalized onto the memory row (rather than living in
-/// `memory_links`) precisely so it survives an index rebuild — otherwise
-/// a rebuild would make the next harvest re-distill, and re-pay for,
-/// every transcript already processed.
+/// **Superseded — delegates to
+/// [`super::harvest_ledger::unharvested_sessions`].** This used to
+/// select "sessions with no memory carrying my `origin_file_path`",
+/// which conflated provenance with a job ledger. The two disagree
+/// exactly where it costs money: a transcript the distiller read
+/// correctly and which honestly held no durable lesson produces no
+/// memory row, so it looked unmined forever and was re-distilled — and
+/// re-paid for — on every harvest.
+///
+/// `origin_file_path` remains the right *provenance* record (it
+/// survives a rebuild, which is why it is denormalized onto the memory
+/// row). It is simply not a record of work done.
+///
+/// Kept as a thin forwarder so existing call sites and their tests keep
+/// working; new code should call the ledger directly.
 pub fn undistilled_sessions(
     idx: &SessionIndex,
     project_path: &str,
     limit: u32,
 ) -> Result<Vec<String>, DurableError> {
-    let limit = if limit == 0 { 20 } else { limit.min(500) };
-    let db = idx.db();
-    let mut stmt = db.prepare(
-        "SELECT s.file_path FROM sessions s \
-         WHERE s.project_path = ?1 \
-           AND s.file_path NOT IN \
-               (SELECT origin_file_path FROM memories WHERE origin_file_path IS NOT NULL) \
-         ORDER BY s.last_ts_ms DESC NULLS LAST \
-         LIMIT ?2",
-    )?;
-    let rows = stmt.query_map(rusqlite::params![project_path, limit as i64], |r| {
-        r.get::<_, String>(0)
-    })?;
-    let mut out = Vec::new();
-    for r in rows {
-        out.push(r?);
-    }
-    Ok(out)
+    super::harvest_ledger::unharvested_sessions(idx, project_path, limit)
 }
 
 /// Merge `{"commit": sha}` into the row's existing anchor object,

--- a/crates/claudepot-core/src/shared_memory/schema.rs
+++ b/crates/claudepot-core/src/shared_memory/schema.rs
@@ -266,6 +266,52 @@ CREATE INDEX IF NOT EXISTS idx_recurrence_matched ON recurrence_events(matched_m
 -- so no existing row set violates it.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_recurrence_dedup
     ON recurrence_events(matched_memory_id, new_content);
+
+-- Harvest bookkeeping: one row per (transcript, extractor version).
+--
+-- Before this table, "already mined" was inferred from a memory row
+-- carrying the transcript's `origin_file_path`. That conflated
+-- provenance with a job ledger, and the two disagree in the one case
+-- that matters: a transcript the distiller read correctly and which
+-- honestly yielded **zero** claims produced no memory, so it looked
+-- unmined forever and was re-distilled — and re-paid for — on every
+-- subsequent harvest.
+--
+-- Durable, like `memories`: NOT cascade-cleared by a rebuild. That is
+-- the whole point — a rebuild must not make the next harvest re-pay
+-- for work already done, which is the same reasoning that put
+-- `origin_file_path` on the memory row.
+--
+-- Freshness is guarded by `(file_size_bytes, file_mtime_ns)` rather
+-- than a content hash. Same guard `sessions` already uses as its
+-- re-parse trigger, so a changed transcript re-harvests for free by
+-- joining two columns we already store. A hash would be strictly
+-- stronger but would mean reading every transcript to decide whether
+-- to read it.
+CREATE TABLE IF NOT EXISTS harvest_ledger (
+    file_path         TEXT    NOT NULL,
+    -- Bumping this re-harvests the corpus on purpose: a changed prompt
+    -- or output schema is a different extractor, and its verdict on a
+    -- transcript is not interchangeable with the old one's.
+    extractor_version TEXT    NOT NULL,
+    file_size_bytes   INTEGER NOT NULL,
+    file_mtime_ns     INTEGER NOT NULL,
+    attempted_at_ms   INTEGER NOT NULL,
+    outcome           TEXT    NOT NULL CHECK (outcome IN ('succeeded','failed')),
+    -- Cumulative across retries of the same (file, extractor). Caps
+    -- retry of a permanently-unparseable transcript.
+    attempts          INTEGER NOT NULL DEFAULT 1,
+    -- 0 is a legitimate, recorded success — the case the old scheme
+    -- could not represent.
+    claims_produced   INTEGER NOT NULL DEFAULT 0,
+    model             TEXT,
+    cost_usd          REAL,
+    error             TEXT,
+    PRIMARY KEY (file_path, extractor_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_harvest_ledger_outcome
+    ON harvest_ledger(outcome);
 "#;
 
 /// Names of the tables created by the v4 DDL block. Used by the
@@ -284,6 +330,7 @@ pub const V4_TABLE_NAMES: &[&str] = &[
     "evidence_records",
     "memory_links",
     "recurrence_events",
+    "harvest_ledger",
 ];
 
 /// Names of the FTS5 maintenance triggers on `exchanges`. The

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2,9 +2,12 @@
 //!
 //! ```text
 //!   cargo xtask verify-cc-parity
+//!   cargo xtask verify-docs
 //! ```
 //!
 //! See `parity-harness/README.md` for the full design.
+
+mod verify_docs;
 
 use anyhow::{anyhow, bail, Context, Result};
 use std::path::{Path, PathBuf};
@@ -16,6 +19,7 @@ fn main() -> Result<()> {
 
     match cmd.as_str() {
         "verify-cc-parity" => verify_cc_parity(&rest),
+        "verify-docs" => verify_docs::verify_docs(&workspace_root()?),
         "" | "-h" | "--help" | "help" => {
             eprintln!("{}", USAGE);
             Ok(())
@@ -30,6 +34,11 @@ fn main() -> Result<()> {
 const USAGE: &str = "usage: cargo xtask <subcommand>
 
 subcommands:
+  verify-docs                         fail when README / AGENTS.md / the
+                                      web docs drift from the code they
+                                      describe (CLI verbs, Settings
+                                      panes, data-dir databases).
+
   verify-cc-parity [--only <name>]    diff Rust merge output against
                                       parity-harness/fixtures/*/expected.json.
                                       Fails loudly on mismatch.

--- a/crates/xtask/src/verify_docs.rs
+++ b/crates/xtask/src/verify_docs.rs
@@ -1,0 +1,310 @@
+//! `cargo xtask verify-docs` — fail when the docs disagree with the code.
+//!
+//! # Why this exists
+//!
+//! Documentation drift here is not sloppiness, it is *structural*: three
+//! separate surfaces (`README.md`, `AGENTS.md`, the web product docs)
+//! each restate facts that live in source, and nothing notices when the
+//! source moves. A 2026-07-28 audit found six stale facts, only two of
+//! which were introduced by the change that prompted the audit — the
+//! rest had been wrong for releases.
+//!
+//! The failure mode that matters is `AGENTS.md`: agents read it *before
+//! writing code*, so a wrong fact there does not mislead a reader, it
+//! produces wrong code. "Six SQLite files" was wrong for exactly as long
+//! as `corpus.db` existed.
+//!
+//! # What it checks
+//!
+//! Only facts that are **derivable from source**, so a failure is always
+//! actionable and never a matter of taste:
+//!
+//! 1. every top-level CLI verb appears in README's command block;
+//! 2. every Settings sub-pane id appears in README and the web settings
+//!    page, and the spelled-out count matches;
+//! 3. every `*.db` filename under the Claudepot data dir appears in
+//!    AGENTS.md.
+//!
+//! Prose quality is explicitly *not* checked. This catches "you added a
+//! thing and forgot to say so", which is the whole observed failure.
+
+use anyhow::{bail, Context, Result};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+pub fn verify_docs(repo: &Path) -> Result<()> {
+    let mut problems: Vec<String> = Vec::new();
+
+    check_cli_verbs(repo, &mut problems)?;
+    check_settings_panes(repo, &mut problems)?;
+    check_data_dir_databases(repo, &mut problems)?;
+
+    if problems.is_empty() {
+        println!("verify-docs: ok — CLI verbs, Settings panes and databases all documented");
+        return Ok(());
+    }
+    let mut msg = format!("verify-docs found {} drift(s):", problems.len());
+    for p in &problems {
+        msg.push_str("\n  - ");
+        msg.push_str(p);
+    }
+    bail!(msg)
+}
+
+fn read(repo: &Path, rel: &str) -> Result<String> {
+    let p: PathBuf = repo.join(rel);
+    std::fs::read_to_string(&p).with_context(|| format!("read {}", p.display()))
+}
+
+// ─── 1. CLI verbs ────────────────────────────────────────────────────
+
+/// Top-level variants of `enum Commands` in the CLI's `main.rs`.
+///
+/// Parsed rather than hand-listed: a hand-listed set is one more place
+/// to forget, which is the bug being fixed.
+fn shipped_cli_verbs(src: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let Some(start) = src.find("enum Commands {") else {
+        return out;
+    };
+    let body = &src[start..];
+    let mut depth = 0usize;
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        // Variants sit at exactly one level of nesting inside the enum.
+        if depth == 1 && !trimmed.starts_with("//") && !trimmed.starts_with("#[") {
+            if let Some(name) = trimmed
+                .split(|c: char| !c.is_alphanumeric())
+                .next()
+                .filter(|s| s.chars().next().is_some_and(char::is_uppercase))
+            {
+                // A variant line ends in `{`, `,` or `(`.
+                if trimmed.ends_with('{') || trimmed.ends_with(',') || trimmed.contains('(') {
+                    out.insert(name.to_lowercase());
+                }
+            }
+        }
+        depth += line.matches('{').count();
+        depth = depth.saturating_sub(line.matches('}').count());
+        if depth == 0 && line.contains('}') && !out.is_empty() {
+            break;
+        }
+    }
+    out
+}
+
+fn check_cli_verbs(repo: &Path, problems: &mut Vec<String>) -> Result<()> {
+    let src = read(repo, "crates/claudepot-cli/src/main.rs")?;
+    let readme = read(repo, "README.md")?;
+    // Verbs documented in README's command block. Two shapes occur:
+    // `claudepot session   list | move` (one verb per line) and
+    // `claudepot export / import` (two verbs sharing a line). Collecting
+    // every word from lines that begin `claudepot ` handles both without
+    // a special case, and without the `import` false positive a plain
+    // `contains("claudepot import")` produces.
+    let documented: BTreeSet<String> = readme
+        .lines()
+        .map(str::trim)
+        .filter(|l| l.starts_with("claudepot "))
+        .flat_map(|l| {
+            l.split(|c: char| !c.is_ascii_alphanumeric() && c != '-')
+                .map(str::to_lowercase)
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    for verb in shipped_cli_verbs(&src) {
+        if !documented.contains(&verb) {
+            problems.push(format!(
+                "CLI verb `{verb}` ships but is absent from README's command block"
+            ));
+        }
+    }
+    Ok(())
+}
+
+// ─── 2. Settings panes ───────────────────────────────────────────────
+
+fn shipped_settings_panes(src: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for line in src.lines() {
+        let Some(rest) = line.trim_start().strip_prefix("{ id: \"") else {
+            continue;
+        };
+        if let Some(end) = rest.find('"') {
+            out.insert(rest[..end].to_string());
+        }
+    }
+    out
+}
+
+/// English words for the pane counts we could plausibly reach. Docs
+/// spell the number out, so a bare integer comparison would not catch
+/// "Thirteen" against fourteen panes.
+fn spelled(n: usize) -> Option<&'static str> {
+    Some(match n {
+        10 => "Ten",
+        11 => "Eleven",
+        12 => "Twelve",
+        13 => "Thirteen",
+        14 => "Fourteen",
+        15 => "Fifteen",
+        16 => "Sixteen",
+        17 => "Seventeen",
+        18 => "Eighteen",
+        19 => "Nineteen",
+        20 => "Twenty",
+        _ => return None,
+    })
+}
+
+fn check_settings_panes(repo: &Path, problems: &mut Vec<String>) -> Result<()> {
+    let src = read(repo, "src/sections/SettingsSection.tsx")?;
+    let panes = shipped_settings_panes(&src);
+    if panes.is_empty() {
+        bail!("could not parse any Settings panes — the TAB_DEFS shape changed, fix this check");
+    }
+
+    let web_rel = "web/src/app/(reader)/app/features/settings/page.mdx";
+    let surfaces = [
+        ("README.md", read(repo, "README.md")?),
+        (web_rel, read(repo, web_rel)?),
+    ];
+
+    for (name, text) in &surfaces {
+        let lower = text.to_lowercase();
+        for pane in &panes {
+            if !lower.contains(pane.as_str()) {
+                problems.push(format!(
+                    "Settings pane `{pane}` ships but is not mentioned in {name}"
+                ));
+            }
+        }
+        if let Some(word) = spelled(panes.len()) {
+            // Only complain when the doc states *some* count and it is
+            // the wrong one; a page that never counts is fine.
+            let states_a_count = (10..=20)
+                .filter_map(spelled)
+                .any(|w| text.contains(&format!("{w} sub-pane")));
+            if states_a_count && !text.contains(&format!("{word} sub-pane")) {
+                problems.push(format!(
+                    "{name} states the wrong Settings pane count — there are {} ({word})",
+                    panes.len()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+// ─── 3. Databases under the data dir ─────────────────────────────────
+
+/// `*.db` filenames joined onto `claudepot_data_dir()` anywhere in core.
+fn shipped_databases(repo: &Path) -> Result<BTreeSet<String>> {
+    let mut out = BTreeSet::new();
+    let root = repo.join("crates/claudepot-core/src");
+    walk_rs(&root, &mut |text| {
+        // Production code only. Test modules are full of scratch names
+        // (`test.db`, `fresh.db`, `a.db`) that no one should document,
+        // and a check that reports those trains people to ignore it.
+        // This repo puts `#[cfg(test)] mod tests` at the end of a file,
+        // so truncating there is both simple and accurate.
+        let text = match text.find("#[cfg(test)]") {
+            Some(i) => &text[..i],
+            None => text,
+        };
+        let mut rest = text;
+        while let Some(i) = rest.find(".join(\"") {
+            rest = &rest[i + 7..];
+            if let Some(end) = rest.find('"') {
+                let name = &rest[..end];
+                if name.ends_with(".db") {
+                    out.insert(name.to_string());
+                }
+            }
+        }
+    })?;
+    Ok(out)
+}
+
+fn walk_rs(dir: &Path, f: &mut impl FnMut(&str)) -> Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            walk_rs(&path, f)?;
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            if let Ok(text) = std::fs::read_to_string(&path) {
+                f(&text);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_data_dir_databases(repo: &Path, problems: &mut Vec<String>) -> Result<()> {
+    let agents = read(repo, "AGENTS.md")?;
+    for db in shipped_databases(repo)? {
+        if !agents.contains(&db) {
+            problems.push(format!(
+                "`{db}` lives under the Claudepot data dir but AGENTS.md never names it \
+                 — an agent reading AGENTS.md will not know it exists"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_top_level_command_variants_only() {
+        let src = r#"
+#[derive(Subcommand)]
+enum Commands {
+    /// doc
+    Account {
+        #[command(subcommand)]
+        action: AccountAction,
+    },
+    Corpus {
+        #[command(subcommand)]
+        action: CorpusAction,
+    },
+    Status,
+}
+
+#[derive(Subcommand)]
+enum AccountAction {
+    List,
+    Add,
+}
+"#;
+        let v = shipped_cli_verbs(src);
+        assert!(v.contains("account") && v.contains("corpus") && v.contains("status"));
+        assert!(
+            !v.contains("list") && !v.contains("add"),
+            "subcommand variants must not be counted as top-level verbs: {v:?}"
+        );
+    }
+
+    #[test]
+    fn parses_settings_pane_ids() {
+        let src = r#"
+  { id: "general",   label: "General",   glyph: NF.sliders, group: "core" },
+  { id: "retention", label: "Retention", glyph: NF.archive, group: "core" },
+"#;
+        let p = shipped_settings_panes(src);
+        assert!(p.contains("general") && p.contains("retention"));
+        assert_eq!(p.len(), 2);
+    }
+
+    #[test]
+    fn spells_the_counts_the_docs_actually_use() {
+        assert_eq!(spelled(13), Some("Thirteen"));
+        assert_eq!(spelled(14), Some("Fourteen"));
+        assert_eq!(spelled(99), None);
+    }
+}

--- a/scripts/repo-invariants.sh
+++ b/scripts/repo-invariants.sh
@@ -43,7 +43,18 @@ violators=$(grep -rlE "$patterns" crates/ --include='*.rs' || true)
 # snippet goes through redact_secrets — the same redactor the file's
 # search_rows JSONL path already uses — and the snippet_text fallback is
 # pre-redacted at rest.
+# corpus.rs writes these columns into corpus.db and never emits them:
+# storage is unredacted at rest, exactly as `exchanges` in sessions.db
+# is (see shared_memory/schema.rs). corpus/detect.rs reads them and DOES
+# emit — `claudepot corpus detect` prints to stdout and serializes under
+# --json — so it redacts at construction: `RepetitionCluster::sample`
+# and `Correction::text` are built with redact_secrets, and
+# `error_signature` redacts plus takes only the first line, because tool
+# output is arbitrary stdout. This tripwire caught that leak on the
+# first CI run of the corpus feature; it was doing its job.
 unexpected=$(echo "$violators" \
+  | grep -v 'crates/claudepot-core/src/corpus.rs' \
+  | grep -v 'crates/claudepot-core/src/corpus/detect.rs' \
   | grep -v 'crates/claudepot-core/src/shared_memory/search.rs' \
   | grep -v 'crates/claudepot-core/src/shared_memory/read.rs' \
   | grep -v 'crates/claudepot-core/src/shared_memory/indexer.rs' \

--- a/src-tauri/src/commands/cc_retention.rs
+++ b/src-tauri/src/commands/cc_retention.rs
@@ -1,0 +1,62 @@
+//! IPC commands for Settings → Retention.
+//!
+//! Reads / writes CC's user-level `cleanupPeriodDays` via
+//! `claudepot_core::cc_retention` — the one CC setting that destroys
+//! user data, and the one nothing in CC's own UI ever mentions.
+//!
+//! Per `rules/architecture.md`, NO business logic here: the state/risk
+//! composition lives in `cc_retention::report`, and this layer only
+//! samples the clock and maps errors. The returned types are plain
+//! counts and enums with no path or secret fields, so they cross to JS
+//! directly rather than through a hand-mirrored DTO — same call as
+//! `auto_dream`.
+//!
+//! Note the deliberate asymmetry in the write surface: `retention_set`
+//! refuses `0`, and reaching zero requires the separately-named
+//! `retention_disable_persistence`. A renderer bug that passes a stray
+//! `0` through the ordinary setter must not be able to delete the
+//! user's history.
+
+use claudepot_core::cc_retention::{
+    clear_retention, disable_persistence, report, set_retention_days, RetentionReport,
+    DEFAULT_RISK_HORIZON_DAYS,
+};
+
+fn now_ms() -> i64 {
+    chrono::Utc::now().timestamp_millis()
+}
+
+/// `retention_report` — current `cleanupPeriodDays` plus what it costs
+/// on this machine (how many transcripts CC will delete, and when).
+#[tauri::command]
+pub async fn retention_report(horizon_days: Option<i64>) -> Result<RetentionReport, String> {
+    let horizon = horizon_days.unwrap_or(DEFAULT_RISK_HORIZON_DAYS).max(1);
+    Ok(report(now_ms(), horizon))
+}
+
+/// `retention_set` — write an explicit positive retention window.
+/// Rejects `0` and negatives; zero is only reachable through
+/// [`retention_disable_persistence`].
+#[tauri::command]
+pub async fn retention_set(days: i64) -> Result<RetentionReport, String> {
+    set_retention_days(days).map_err(|e| format!("write setting: {e}"))?;
+    Ok(report(now_ms(), DEFAULT_RISK_HORIZON_DAYS))
+}
+
+/// `retention_clear` — remove the key so CC's 30-day default applies.
+/// This re-arms deletion, so the UI confirms before calling it.
+#[tauri::command]
+pub async fn retention_clear() -> Result<RetentionReport, String> {
+    clear_retention().map_err(|e| format!("write setting: {e}"))?;
+    Ok(report(now_ms(), DEFAULT_RISK_HORIZON_DAYS))
+}
+
+/// `retention_disable_persistence` — write `cleanupPeriodDays: 0`.
+/// CC then writes no transcripts at all and deletes the existing ones
+/// at next startup. Named for what it does; the UI puts it behind a
+/// `ConfirmDialog` and never on the duration scale.
+#[tauri::command]
+pub async fn retention_disable_persistence() -> Result<RetentionReport, String> {
+    disable_persistence().map_err(|e| format!("write setting: {e}"))?;
+    Ok(report(now_ms(), DEFAULT_RISK_HORIZON_DAYS))
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -34,6 +34,7 @@ pub mod auto_dream;
 pub mod available_models;
 pub mod cc_daemon;
 pub mod cc_doctor;
+pub mod cc_retention;
 pub mod cc_tips;
 pub mod cli;
 pub mod config;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,6 +50,7 @@ mod permission_orchestrator;
 mod poller;
 mod pr_orchestrator;
 mod preferences;
+mod retention_boot_check;
 mod rotation_orchestrator;
 mod service_status_watcher;
 mod state;
@@ -801,6 +802,14 @@ pub fn run() {
                 claudepot_core::agent::reconcile_orphan_artifacts_now();
             });
 
+            // One-shot check for transcripts Claude Code is about to
+            // delete under its `cleanupPeriodDays` window. CC does this
+            // silently on every launch and reports nothing, so this is
+            // the only place a user finds out. Emits at most one bell
+            // entry, and only when deletion is actually scheduled — see
+            // `src-tauri/src/retention_boot_check.rs`.
+            retention_boot_check::spawn(app.handle().clone());
+
             // Background poller for CC CLI + Claude Desktop updates.
             // Probes upstream every `poll_interval_minutes` (default
             // 4 h), updates the tray badge, and runs the auto-install
@@ -1209,6 +1218,10 @@ pub fn run() {
             commands::available_models::available_models_set,
             commands::auto_dream::auto_dream_state,
             commands::auto_dream::auto_dream_set,
+            commands::cc_retention::retention_report,
+            commands::cc_retention::retention_set,
+            commands::cc_retention::retention_clear,
+            commands::cc_retention::retention_disable_persistence,
             commands::attribution::attribution_state,
             commands::attribution::attribution_set,
             config_watch::config_watch_start,

--- a/src-tauri/src/retention_boot_check.rs
+++ b/src-tauri/src/retention_boot_check.rs
@@ -1,0 +1,143 @@
+//! One-shot boot check: is Claude Code about to delete saved
+//! conversations on this machine?
+//!
+//! This is the whole reason Settings → Retention exists. CC's cleanup
+//! runs on every launch, deletes transcripts older than
+//! `cleanupPeriodDays`, computes an exact count of what it removed —
+//! and discards it. Nothing in CC tells the user. A settings pane the
+//! user must already suspect a problem to go looking for only half
+//! closes that gap; this closes the other half.
+//!
+//! Per `rules/architecture.md` there is no logic here. The decision
+//! ("should anything be said, and what") is
+//! `claudepot_core::cc_retention::warning`, which is pure and tested.
+//! This module only samples the clock, routes the result to the
+//! notification log, and logs failures.
+//!
+//! Per `design.md`'s one-signal-per-surface rule this emits exactly one
+//! entry — routed by the existing `Category::TranscriptsExpiring` (P1)
+//! preferences, so a user who mutes the category is respected. No
+//! toast + banner + badge spray.
+//!
+//! There is deliberately no "dismissed" flag; see
+//! `cc_retention::RetentionWarning`'s docs for why gating on the
+//! condition is both simpler and safer than persisting a suppression.
+
+use claudepot_core::cc_retention::{report, warning, DEFAULT_RISK_HORIZON_DAYS};
+use claudepot_core::notification_log::NotificationKind;
+use claudepot_core::notifications::{Category, Priority, Surface};
+use tauri::{AppHandle, Manager};
+
+use crate::commands::notification::NotificationLogState;
+
+/// Run the check off the setup thread. Scanning the transcript tree is
+/// filesystem-bound (thousands of `stat` calls on a real corpus), so it
+/// must never sit in front of window creation.
+pub fn spawn(app: AppHandle) {
+    tauri::async_runtime::spawn_blocking(move || {
+        if let Err(e) = run(&app) {
+            tracing::warn!(error = %e, "retention_boot_check failed");
+        }
+    });
+}
+
+fn run(app: &AppHandle) -> Result<(), String> {
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let rep = report(now_ms, DEFAULT_RISK_HORIZON_DAYS);
+
+    let Some(w) = warning(&rep) else {
+        // Nothing scheduled for deletion. Staying silent is the whole
+        // point of gating on the condition rather than the setting.
+        return Ok(());
+    };
+
+    let Some(log) = app.try_state::<NotificationLogState>() else {
+        // Absent managed state is a wiring bug, not a normal condition
+        // — say so rather than silently dropping the only proactive
+        // data-loss warning in the product.
+        return Err("NotificationLogState unavailable; retention warning dropped".to_string());
+    };
+
+    // Honour the user's per-category mute. `effective_os_surface`
+    // cannot express this on its own: it returns an empty vec both for
+    // "category muted" and for "enabled, but no OS banner wanted", so
+    // muting has to be read from the pref directly or a muted category
+    // would still append a bell entry every launch.
+    let (enabled, os_surfaces) = {
+        let prefs_state = app.state::<crate::preferences::PreferencesState>();
+        let guard = match prefs_state.0.lock() {
+            Ok(g) => g,
+            Err(poisoned) => {
+                tracing::warn!(
+                    "retention_boot_check: preferences mutex was poisoned by an earlier \
+                     panic; recovering with under-lock data"
+                );
+                poisoned.into_inner()
+            }
+        };
+        let enabled = guard.category_pref(Category::TranscriptsExpiring).enabled;
+        // `wants_os: false` — the default surface is the bell, not an
+        // OS banner: transcripts are days from deletion, not seconds,
+        // so interrupting the desktop is unwarranted. A user who wants
+        // the banner sets the category's os_override, which
+        // `effective_os_surface` honours over this default.
+        let os =
+            crate::preferences::effective_os_surface(&guard, Category::TranscriptsExpiring, false);
+        (enabled, os)
+    };
+    if !enabled {
+        tracing::debug!("retention_boot_check: category muted, no entry appended");
+        return Ok(());
+    }
+
+    // Dispatch the OS banner when the user's override asked for one, so
+    // `surfaces_requested` never records a request we knowingly
+    // ignored.
+    let mut delivered: Vec<Surface> = Vec::new();
+    let title = "Saved conversations are expiring".to_string();
+    let body = w.message();
+    if os_surfaces.contains(&Surface::OsBanner) {
+        use tauri_plugin_notification::NotificationExt;
+        match app
+            .notification()
+            .builder()
+            .title(&title)
+            .body(&body)
+            .show()
+        {
+            Ok(_) => delivered.push(Surface::OsBanner),
+            Err(e) => tracing::warn!(error = %e, "retention_boot_check: OS notification failed"),
+        }
+    }
+
+    log.log
+        .append_routed(
+            Category::TranscriptsExpiring,
+            Priority::P1Stalled,
+            // `Notice`, not `Error`: nothing has failed. Something is
+            // scheduled to happen that the user has not been told
+            // about. `NotificationKind` has no Warning variant.
+            NotificationKind::Notice,
+            title,
+            body,
+            // Must match `NotificationTarget` in `src/lib/notify.ts` —
+            // a discriminated union. The earlier flat
+            // `{section, tab}` object had no `kind`, so clicking the
+            // bell entry would have thrown instead of navigating.
+            serde_json::json!({
+                "kind": "app",
+                "route": { "section": "settings", "sub": "retention" }
+            }),
+            os_surfaces,
+            delivered,
+        )
+        .map_err(|e| format!("notification_log append failed: {e}"))?;
+
+    tracing::info!(
+        already_deletable = w.already_deletable,
+        at_risk = w.at_risk_within_horizon,
+        effective_days = w.effective_days,
+        "retention_boot_check: warned about pending transcript deletion"
+    );
+    Ok(())
+}

--- a/src/api/cc-retention.ts
+++ b/src/api/cc-retention.ts
@@ -1,0 +1,82 @@
+// Bindings for Settings → Retention. Shape mirrors
+// `claudepot_core::cc_retention` (returned verbatim by the
+// `retention_*` commands — no DTO).
+//
+// This covers CC's `cleanupPeriodDays`: the only Claude Code setting
+// that destroys user data, and one CC's own UI never mentions.
+
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Note there is no plain "off". `0` is not a low value on the same
+ * scale as `30` — it means "write no transcripts and delete the
+ * existing ones", so it gets its own mode and its own command.
+ */
+export type RetentionMode =
+  /** Key absent — CC's 30-day default silently applies. */
+  | "cc_default"
+  /** An explicit positive day count. */
+  | "explicit"
+  /** `cleanupPeriodDays: 0` — persistence disabled entirely. */
+  | "persistence_disabled"
+  /** Negative value; invalidates CC's settings schema. */
+  | "invalid";
+
+export interface RetentionState {
+  mode: RetentionMode;
+  configured_days: number | null;
+  /** What CC will actually enforce. For `invalid`, the conservative
+   *  CC default rather than a value we'd be trusting to protect. */
+  effective_days: number;
+  is_cc_default: boolean;
+  /** CC is skipping cleanup entirely because the settings file fails
+   *  validation while explicitly containing the key. An invalid value
+   *  therefore *protects* transcripts — so the fix is to correct the
+   *  value, never to "restore the default", which would re-arm
+   *  deletion. */
+  cleanup_suppressed: boolean;
+}
+
+export interface TranscriptRisk {
+  /** Top-level `projects/<slug>/*.jsonl|*.cast` — all CC will unlink. */
+  total_transcripts: number;
+  /** Past the cutoff already: deleted on CC's next launch. */
+  already_deletable: number;
+  /** Crosses the cutoff within `horizon_days` (excludes the above). */
+  at_risk_within_horizon: number;
+  oldest_ms: number | null;
+  /** Files under session dirs that cleanup never walks. These are why
+   *  the folder grows while history is destroyed. */
+  nested_immortal: number;
+  horizon_days: number;
+  /** Part of the tree could not be read. The counts are a floor, not a
+   *  total — never render reassurance while this is true. */
+  scan_incomplete: boolean;
+}
+
+export interface RetentionReport {
+  state: RetentionState;
+  risk: TranscriptRisk;
+  /** Raising the window buys time; it does not make the corpus
+   *  durable. Always false until the archive contract ships. */
+  is_durable_archive: boolean;
+}
+
+export const ccRetentionApi = {
+  retentionReport: (horizonDays?: number) =>
+    invoke<RetentionReport>("retention_report", {
+      horizonDays: horizonDays ?? null,
+    }),
+
+  /** Positive day counts only — the backend rejects 0 and negatives. */
+  retentionSet: (days: number) =>
+    invoke<RetentionReport>("retention_set", { days }),
+
+  /** Removes the key, re-arming CC's 30-day deletion. Confirm first. */
+  retentionClear: () => invoke<RetentionReport>("retention_clear"),
+
+  /** Writes 0: CC stops saving transcripts and deletes existing ones.
+   *  Destructive; must sit behind a ConfirmDialog. */
+  retentionDisablePersistence: () =>
+    invoke<RetentionReport>("retention_disable_persistence"),
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -19,6 +19,7 @@ import { availableModelsApi } from "./availableModels";
 import { fastModeApi } from "./fastMode";
 import { thinkingApi } from "./thinking";
 import { autoDreamApi } from "./auto-dream";
+import { ccRetentionApi } from "./cc-retention";
 import { attributionApi } from "./attribution";
 import { memoryHealthApi } from "./memory-health";
 import { memoryApi } from "./memory";
@@ -57,6 +58,7 @@ export const api = {
   ...fastModeApi,
   ...thinkingApi,
   ...autoDreamApi,
+  ...ccRetentionApi,
   ...attributionApi,
   ...memoryHealthApi,
   ...memoryApi,

--- a/src/lib/notifications/__fixtures__/categories.fixture.json
+++ b/src/lib/notifications/__fixtures__/categories.fixture.json
@@ -186,6 +186,12 @@
       "group": "Background",
       "id": "updateAvailable",
       "priority": "p3Ambient"
+    },
+    {
+      "defaultEnabled": true,
+      "group": "Live work",
+      "id": "transcriptsExpiring",
+      "priority": "p1Stalled"
     }
   ]
 }

--- a/src/lib/notifications/types.test.ts
+++ b/src/lib/notifications/types.test.ts
@@ -20,11 +20,11 @@ import {
 // category's priority agrees with `priorityForCategory`.
 
 describe("notification category mirror", () => {
-  it("CATEGORY_NAMES contains 31 entries (matches Rust Category::all())", () => {
+  it("CATEGORY_NAMES contains 32 entries (matches Rust Category::all())", () => {
     // If you add or remove a Rust variant, update this number and
     // the CATEGORY_NAMES array. The Rust side has a corresponding
     // EXPECTED counter that fails compile when the lockstep breaks.
-    expect(CATEGORY_NAMES.length).toBe(31);
+    expect(CATEGORY_NAMES.length).toBe(32);
   });
 
   it("every CATEGORY_NAMES entry has a priority binding", () => {

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -52,6 +52,7 @@ export type Category =
   | "rotationSuggested"
   | "usageThreshold"
   | "updateInstallReady"
+  | "transcriptsExpiring"
   // P2 — Acknowledge
   | "accountVerified"
   | "accountSwitched"
@@ -93,6 +94,7 @@ export const CATEGORY_NAMES: readonly Category[] = [
   "rotationSuggested",
   "usageThreshold",
   "updateInstallReady",
+  "transcriptsExpiring",
   "accountVerified",
   "accountSwitched",
   "projectRenamed",
@@ -274,6 +276,7 @@ export function priorityForCategory(category: Category): Priority {
     case "rotationSuggested":
     case "usageThreshold":
     case "updateInstallReady":
+    case "transcriptsExpiring":
       return "p1Stalled";
     case "accountVerified":
     case "accountSwitched":

--- a/src/sections/SettingsSection.tsx
+++ b/src/sections/SettingsSection.tsx
@@ -40,6 +40,7 @@ import { McpInstallerPane } from "./settings/McpInstallerPane";
 import { NetworkPane } from "./settings/NetworkPane";
 import { ProtectedPathsPane } from "./settings/ProtectedPathsPane";
 import { RotationPane } from "./settings/RotationPane";
+import { RetentionPane } from "./settings/RetentionPane";
 import { CleanupPane } from "./sessions/CleanupPane";
 import { ArtifactLifecyclePane } from "./settings/ArtifactLifecyclePane";
 import { CompanionArtifactToggle } from "./settings/CompanionArtifactToggle";
@@ -62,6 +63,7 @@ type Tab =
   | "notifications"
   | "network"
   | "rotation"
+  | "retention"
   | "health"
   | "mcp"
   | "cleanup"
@@ -88,6 +90,11 @@ const TAB_DEFS: ReadonlyArray<{
   { id: "notifications", label: "Notifications", glyph: NF.bell,     group: "core" },
   { id: "network",     label: "Network",        glyph: NF.globe,    group: "core" },
   { id: "rotation",    label: "Rotation",       glyph: NF.refresh,  group: "core" },
+  // Retention = CC's `cleanupPeriodDays`, the only CC setting that
+  // destroys user data. "core", not "advanced": a control that exists
+  // to prevent silent data loss is worthless if the user has to go
+  // looking for it, and CC's own UI never mentions the setting at all.
+  { id: "retention",   label: "Retention",      glyph: NF.archive,  group: "core" },
   // Health = CC self-diagnostic (scrapes `claude doctor`). Sits in
   // "core" because the pill in WindowChrome points here directly;
   // hiding it under Advanced would make the deep-link surface
@@ -175,6 +182,7 @@ export function SettingsSection() {
           {tab === "notifications" && <NotificationsPane pushToast={pushToast} />}
           {tab === "network" && <NetworkPane pushToast={pushToast} />}
           {tab === "rotation" && <RotationPane pushToast={pushToast} />}
+          {tab === "retention" && <RetentionPane pushToast={pushToast} />}
           {tab === "health" && <HealthPane pushToast={pushToast} />}
           {tab === "mcp" && <McpInstallerPane pushToast={pushToast} />}
           {tab === "cleanup" && <CleanupTabPane pushToast={pushToast} />}

--- a/src/sections/settings/RetentionPane.test.tsx
+++ b/src/sections/settings/RetentionPane.test.tsx
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { RetentionReport } from "../../api/cc-retention";
+
+const retentionReportMock = vi.fn();
+const retentionSetMock = vi.fn();
+const retentionClearMock = vi.fn();
+const retentionDisableMock = vi.fn();
+
+vi.mock("../../api", () => ({
+  api: {
+    retentionReport: (...a: unknown[]) => retentionReportMock(...a),
+    retentionSet: (...a: unknown[]) => retentionSetMock(...a),
+    retentionClear: (...a: unknown[]) => retentionClearMock(...a),
+    retentionDisablePersistence: (...a: unknown[]) => retentionDisableMock(...a),
+  },
+}));
+
+import { RetentionPane } from "./RetentionPane";
+
+function report(over: {
+  state?: Partial<RetentionReport["state"]>;
+  risk?: Partial<RetentionReport["risk"]>;
+} = {}): RetentionReport {
+  return {
+    state: {
+      mode: "cc_default",
+      configured_days: null,
+      effective_days: 30,
+      is_cc_default: true,
+      cleanup_suppressed: false,
+      ...over.state,
+    },
+    risk: {
+      total_transcripts: 460,
+      already_deletable: 0,
+      at_risk_within_horizon: 0,
+      oldest_ms: Date.UTC(2026, 5, 6),
+      nested_immortal: 0,
+      horizon_days: 7,
+      scan_incomplete: false,
+      ...over.risk,
+    },
+    is_durable_archive: false,
+  };
+}
+
+describe("RetentionPane", () => {
+  beforeEach(() => {
+    retentionReportMock.mockReset();
+    retentionSetMock.mockReset();
+    retentionClearMock.mockReset();
+    retentionDisableMock.mockReset();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  const toast = () => vi.fn();
+
+  it("names the default as something the user did not choose", async () => {
+    retentionReportMock.mockResolvedValue(report());
+    render(<RetentionPane pushToast={toast()} />);
+    expect(
+      await screen.findByText(/not a choice you made/i),
+    ).toBeInTheDocument();
+  });
+
+  it("leads with the count that will actually be deleted", async () => {
+    retentionReportMock.mockResolvedValue(
+      report({ risk: { already_deletable: 1247, at_risk_within_horizon: 30 } }),
+    );
+    render(<RetentionPane pushToast={toast()} />);
+    expect(
+      await screen.findByText(/1,247 transcripts will be deleted/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/30 more cross the cutoff/i)).toBeInTheDocument();
+  });
+
+  // design.md render-if-nonzero: a quiet state must not show "0 will be
+  // deleted · 0 at risk".
+  it("collapses to a single line when nothing is at risk", async () => {
+    retentionReportMock.mockResolvedValue(
+      report({ state: { mode: "explicit", configured_days: 3650, effective_days: 3650, is_cc_default: false } }),
+    );
+    render(<RetentionPane pushToast={toast()} />);
+    expect(
+      await screen.findByText(/Nothing is scheduled for deletion/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/will be deleted the next time/i)).toBeNull();
+    expect(screen.queryByText(/cross the cutoff/i)).toBeNull();
+  });
+
+  it("explains why disk usage cannot reveal the loss", async () => {
+    retentionReportMock.mockResolvedValue(
+      report({ risk: { nested_immortal: 9291 } }),
+    );
+    render(<RetentionPane pushToast={toast()} />);
+    expect(
+      await screen.findByText(/disk usage cannot reveal this loss/i),
+    ).toBeInTheDocument();
+  });
+
+  it("says a longer window is not a backup", async () => {
+    retentionReportMock.mockResolvedValue(report());
+    render(<RetentionPane pushToast={toast()} />);
+    expect(await screen.findByText(/is not a backup/i)).toBeInTheDocument();
+  });
+
+  it("writes the chosen preset", async () => {
+    retentionReportMock.mockResolvedValue(report());
+    retentionSetMock.mockResolvedValue(
+      report({ state: { mode: "explicit", configured_days: 365, effective_days: 365, is_cc_default: false } }),
+    );
+    const push = vi.fn();
+    render(<RetentionPane pushToast={push} />);
+    await userEvent.setup().click(await screen.findByRole("button", { name: "1 year" }));
+    await waitFor(() => expect(retentionSetMock).toHaveBeenCalledWith(365));
+    expect(push).toHaveBeenCalledWith("info", expect.stringMatching(/1 year/i));
+  });
+
+  // The core rule: 0 is never a stop on the duration scale.
+  it("offers no preset that would disable persistence", async () => {
+    retentionReportMock.mockResolvedValue(report());
+    render(<RetentionPane pushToast={toast()} />);
+    await screen.findByRole("button", { name: "30 days" });
+    for (const label of ["0", "0 days", "Off", "Never", "Disabled"]) {
+      expect(screen.queryByRole("button", { name: label })).toBeNull();
+    }
+  });
+
+  it("gates disabling persistence behind a type-to-confirm", async () => {
+    retentionReportMock.mockResolvedValue(report());
+    render(<RetentionPane pushToast={toast()} />);
+    const user = userEvent.setup();
+    await user.click(
+      await screen.findByRole("button", { name: /stop saving transcripts entirely/i }),
+    );
+    // Dialog is up, but the destructive call must not fire until the
+    // phrase is typed.
+    const confirm = await screen.findByRole("button", {
+      name: /stop saving and delete/i,
+    });
+    await user.click(confirm);
+    expect(retentionDisableMock).not.toHaveBeenCalled();
+
+    await user.type(screen.getByRole("textbox"), "delete my transcripts");
+    await user.click(screen.getByRole("button", { name: /stop saving and delete/i }));
+    await waitFor(() => expect(retentionDisableMock).toHaveBeenCalled());
+  });
+
+  it("confirms before restoring the default that re-arms deletion", async () => {
+    retentionReportMock.mockResolvedValue(
+      report({ state: { mode: "explicit", configured_days: 3650, effective_days: 3650, is_cc_default: false } }),
+    );
+    retentionClearMock.mockResolvedValue(report());
+    const user = userEvent.setup();
+    render(<RetentionPane pushToast={toast()} />);
+    await user.click(
+      await screen.findByRole("button", { name: /restore claude code's default/i }),
+    );
+    expect(retentionClearMock).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("button", { name: /^restore default$/i }));
+    await waitFor(() => expect(retentionClearMock).toHaveBeenCalled());
+  });
+
+  it("reports an invalid configured value rather than trusting it", async () => {
+    retentionReportMock.mockResolvedValue(
+      report({ state: { mode: "invalid", configured_days: -1, effective_days: 30, is_cc_default: false } }),
+    );
+    render(<RetentionPane pushToast={toast()} />);
+    expect(await screen.findByText(/Invalid value/i)).toBeInTheDocument();
+  });
+
+  // The worst failure mode: an unreadable tree rendering as "all clear".
+  it("never reassures when the scan was incomplete", async () => {
+    retentionReportMock.mockResolvedValue(
+      report({ risk: { scan_incomplete: true } }),
+    );
+    render(<RetentionPane pushToast={toast()} />);
+    expect(await screen.findByText(/counts are a floor, not a total/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Nothing is scheduled for deletion/i)).toBeNull();
+  });
+
+  // render-if-nonzero — "0 transcripts on this machine" must not ship.
+  it("omits the transcript count when there are none", async () => {
+    retentionReportMock.mockResolvedValue(
+      report({ risk: { total_transcripts: 0 } }),
+    );
+    render(<RetentionPane pushToast={toast()} />);
+    expect(await screen.findByText(/Nothing is scheduled for deletion/i)).toBeInTheDocument();
+    expect(screen.queryByText(/0 transcripts on this machine/i)).toBeNull();
+  });
+
+  // Restoring the default here would clear the validation error and
+  // re-arm deletion — the pane must say "fix the value" instead.
+  it("warns not to restore the default when cleanup is suppressed", async () => {
+    retentionReportMock.mockResolvedValue(
+      report({
+        state: {
+          mode: "invalid",
+          configured_days: -1,
+          is_cc_default: false,
+          cleanup_suppressed: true,
+        },
+      }),
+    );
+    render(<RetentionPane pushToast={toast()} />);
+    expect(
+      await screen.findByText(/correct the value rather than restoring the default/i),
+    ).toBeInTheDocument();
+  });
+
+  it("offers a retry instead of hanging on Loading when the load fails", async () => {
+    retentionReportMock.mockRejectedValueOnce(new Error("nope"));
+    const push = vi.fn();
+    render(<RetentionPane pushToast={push} />);
+    const retry = await screen.findByRole("button", { name: /try again/i });
+    expect(screen.queryByText(/^Loading…$/)).toBeNull();
+    retentionReportMock.mockResolvedValue(report());
+    await userEvent.setup().click(retry);
+    await waitFor(() =>
+      expect(screen.getByText(/not a choice you made/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("toasts and keeps state when a write fails", async () => {
+    retentionReportMock.mockResolvedValue(report());
+    retentionSetMock.mockRejectedValue(new Error("boom"));
+    const push = vi.fn();
+    render(<RetentionPane pushToast={push} />);
+    await userEvent.setup().click(await screen.findByRole("button", { name: "90 days" }));
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith("error", expect.stringContaining("boom")),
+    );
+  });
+});

--- a/src/sections/settings/RetentionPane.tsx
+++ b/src/sections/settings/RetentionPane.tsx
@@ -1,0 +1,401 @@
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../../api";
+import type { RetentionReport } from "../../api/cc-retention";
+import { Button } from "../../components/primitives/Button";
+import { SectionLabel } from "../../components/primitives/SectionLabel";
+import { ConfirmDialog } from "../../components/ConfirmDialog";
+import { ConfirmDangerousAction } from "../../components/ConfirmDangerousAction";
+import { toastError } from "../../lib/toastError";
+
+// Settings → Retention.
+//
+// Claude Code deletes transcripts older than `cleanupPeriodDays`
+// (default 30) on every launch, and says nothing: the cleanup routine
+// computes an exact count of what it unlinked and its caller discards
+// the number. Nothing in CC's UI mentions the setting. This pane is the
+// only place a user can find out their history is on a timer.
+//
+// Three design rules carried from the plan (P0b):
+//
+//  1. Lead with the consequence on THIS machine, not the policy.
+//     Documentation loses to ignorance; a count that ticks does not.
+//  2. `0` is never a stop on the duration scale. It means "delete
+//     everything and stop persisting", so it lives behind a
+//     type-to-confirm gate and is worded as what it does.
+//  3. A long window is a BUFFER, not durability — the files still sit
+//     in CC's cache directory under CC's rules. Say so, or a big
+//     number reads as "solved".
+
+/** Stops on the scale. `0` is deliberately absent — see rule 2. */
+const PRESETS: { days: number; label: string }[] = [
+  { days: 30, label: "30 days" },
+  { days: 90, label: "90 days" },
+  { days: 365, label: "1 year" },
+  { days: 3650, label: "10 years" },
+];
+
+function fmtDate(ms: number | null): string | null {
+  if (ms == null) return null;
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+export function RetentionPane({
+  pushToast,
+}: {
+  pushToast: (kind: "info" | "error", text: string) => void;
+}) {
+  const [report, setReport] = useState<RetentionReport | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [confirmClear, setConfirmClear] = useState(false);
+  const [confirmDisable, setConfirmDisable] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      setReport(await api.retentionReport());
+      setLoadError(null);
+    } catch (e) {
+      // A pane that sits on "Loading…" forever after a failed toast
+      // reads as "still working", which in this pane specifically
+      // implies "still safe". Fail visibly instead.
+      setLoadError(e instanceof Error ? e.message : String(e));
+      toastError(pushToast, "Retention load failed", e);
+    }
+  }, [pushToast]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const run = async (fn: () => Promise<RetentionReport>, msg: string) => {
+    setBusy(true);
+    try {
+      setReport(await fn());
+      pushToast("info", msg);
+    } catch (e) {
+      toastError(pushToast, "Change retention", e);
+    } finally {
+      setBusy(false);
+      setConfirmClear(false);
+      setConfirmDisable(false);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <div style={{ display: "grid", gap: "var(--sp-12)", justifyItems: "start" }}>
+        <div style={{ color: "var(--danger)", fontSize: "var(--fs-sm)" }}>
+          Couldn&rsquo;t read Claude Code&rsquo;s retention setting, so this
+          pane cannot tell you what is scheduled for deletion.
+        </div>
+        <div style={{ color: "var(--fg-faint)", fontSize: "var(--fs-xs)" }}>
+          {loadError}
+        </div>
+        <Button variant="outline" onClick={() => void refresh()}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  if (!report) {
+    return <div style={{ color: "var(--fg-faint)" }}>Loading…</div>;
+  }
+
+  const { state, risk, is_durable_archive } = report;
+  const atRiskTotal = risk.already_deletable + risk.at_risk_within_horizon;
+  const oldest = fmtDate(risk.oldest_ms);
+
+  // Headline severity: anything already past the cutoff is live loss.
+  const severity =
+    state.mode === "persistence_disabled" || risk.already_deletable > 0
+      ? "var(--danger)"
+      : atRiskTotal > 0
+        ? "var(--warn)"
+        : "var(--fg-muted)";
+
+  const modeLine =
+    state.mode === "cc_default"
+      ? `${state.effective_days} days — Claude Code's default, not a choice you made`
+      : state.mode === "persistence_disabled"
+        ? "Transcripts are not being saved at all"
+        : state.mode === "invalid"
+          ? `Invalid value (${state.configured_days}) — Claude Code's settings schema rejects it`
+          : `${state.effective_days} days`;
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: "var(--sp-24)",
+        // tokens.css is the only place sizes are declared (design.md).
+        maxWidth: "var(--content-cap-lg)",
+      }}
+    >
+      <div>
+        <SectionLabel>Transcript retention</SectionLabel>
+        <div
+          style={{
+            fontSize: "var(--fs-md)",
+            color: severity,
+            marginTop: "var(--sp-6)",
+          }}
+        >
+          {modeLine}
+        </div>
+
+        {/* Consequence first. Render-if-nonzero: when nothing is at
+            risk this collapses to the single reassuring line below. */}
+        <div
+          style={{
+            marginTop: "var(--sp-8)",
+            fontSize: "var(--fs-sm)",
+            color: "var(--fg-muted)",
+            lineHeight: "var(--lh-body)",
+          }}
+        >
+          {risk.already_deletable > 0 && (
+            <div style={{ color: "var(--danger)" }}>
+              {risk.already_deletable.toLocaleString()} transcript
+              {risk.already_deletable === 1 ? "" : "s"} will be deleted the
+              next time Claude Code starts.
+            </div>
+          )}
+          {risk.at_risk_within_horizon > 0 && (
+            <div style={{ color: "var(--warn)" }}>
+              {risk.at_risk_within_horizon.toLocaleString()} more cross the
+              cutoff within {risk.horizon_days} days.
+            </div>
+          )}
+          {/* Never reassure on an incomplete scan — a permissions
+              failure must not read as "all clear". */}
+          {risk.scan_incomplete && (
+            <div style={{ color: "var(--warn)" }}>
+              Part of Claude Code&rsquo;s transcript folder couldn&rsquo;t be
+              read, so these counts are a floor, not a total.
+            </div>
+          )}
+          {atRiskTotal === 0 &&
+            !risk.scan_incomplete &&
+            state.mode !== "persistence_disabled" && (
+              <div>
+                Nothing is scheduled for deletion.
+                {/* render-if-nonzero: never ship "0 transcripts". */}
+                {risk.total_transcripts > 0 && (
+                  <> {risk.total_transcripts.toLocaleString()} transcripts on this machine.</>
+                )}
+              </div>
+            )}
+          {state.cleanup_suppressed && (
+            <div style={{ color: "var(--warn)" }}>
+              Claude Code is skipping cleanup entirely because this value
+              makes its settings file invalid. That is protecting your
+              transcripts by accident — correct the value rather than
+              restoring the default, which would re-arm deletion.
+            </div>
+          )}
+          {oldest && (
+            <div style={{ marginTop: "var(--sp-3)" }}>
+              Oldest surviving conversation: {oldest}.
+            </div>
+          )}
+          <div style={{ marginTop: "var(--sp-3)", color: "var(--fg-faint)" }}>
+            Claude Code does this silently — it never reports what it
+            deleted.
+          </div>
+        </div>
+      </div>
+
+      {/* Why the folder keeps growing while history shrinks. Only shown
+          when there is actually a nested pile to explain. */}
+      {risk.nested_immortal > 0 && (
+        <div
+          style={{
+            fontSize: "var(--fs-xs)",
+            color: "var(--fg-faint)",
+            lineHeight: "var(--lh-body)",
+          }}
+        >
+          Cleanup only removes the {risk.total_transcripts.toLocaleString()}{" "}
+          top-level session transcripts.{" "}
+          {risk.nested_immortal.toLocaleString()} nested files (subagent
+          runs, tool results) are never removed, so the folder keeps
+          growing while conversations are deleted — disk usage cannot
+          reveal this loss.
+        </div>
+      )}
+
+      <div>
+        <SectionLabel>Keep transcripts for</SectionLabel>
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--sp-8)",
+            flexWrap: "wrap",
+            marginTop: "var(--sp-8)",
+          }}
+        >
+          {PRESETS.map((p) => {
+            const active =
+              state.mode === "explicit" && state.configured_days === p.days;
+            return (
+              <Button
+                key={p.days}
+                variant={active ? "solid" : "outline"}
+                disabled={busy}
+                aria-pressed={active}
+                onClick={() =>
+                  void run(
+                    () => api.retentionSet(p.days),
+                    `Claude Code will keep transcripts for ${p.label}.`,
+                  )
+                }
+              >
+                {p.label}
+              </Button>
+            );
+          })}
+        </div>
+        {/* design.md: a disabled control states its reason inline,
+            next to the button — not in a tooltip. */}
+        {busy && (
+          <div
+            role="status"
+            aria-live="polite"
+            style={{
+              marginTop: "var(--sp-6)",
+              fontSize: "var(--fs-xs)",
+              color: "var(--fg-muted)",
+            }}
+          >
+            Saving retention…
+          </div>
+        )}
+        {!is_durable_archive && (
+          <div
+            style={{
+              marginTop: "var(--sp-8)",
+              fontSize: "var(--fs-xs)",
+              color: "var(--fg-faint)",
+              lineHeight: "var(--lh-body)",
+            }}
+          >
+            A longer window buys time; it is not a backup. These files
+            still live in Claude Code's cache directory under Claude
+            Code's rules, and they grow by roughly a gigabyte a week on
+            heavy use.
+          </div>
+        )}
+      </div>
+
+      <div>
+        <SectionLabel>Danger zone</SectionLabel>
+        <div
+          style={{
+            display: "flex",
+            gap: "var(--sp-8)",
+            flexWrap: "wrap",
+            marginTop: "var(--sp-8)",
+          }}
+        >
+          {state.mode !== "cc_default" && (
+            <Button
+              variant="outline"
+              disabled={busy}
+              onClick={() => setConfirmClear(true)}
+            >
+              Restore Claude Code's default
+            </Button>
+          )}
+          {state.mode !== "persistence_disabled" && (
+            <Button
+              variant="outline"
+              danger
+              disabled={busy}
+              onClick={() => setConfirmDisable(true)}
+            >
+              Stop saving transcripts entirely
+            </Button>
+          )}
+        </div>
+        <div
+          style={{
+            marginTop: "var(--sp-6)",
+            fontSize: "var(--fs-xs)",
+            color: "var(--fg-faint)",
+          }}
+        >
+          Both re-enable deletion. Neither can be undone for transcripts
+          already removed.
+        </div>
+      </div>
+
+      {confirmClear && (
+        <ConfirmDialog
+          title="Restore Claude Code's default retention?"
+          body={
+            <>
+              Retention returns to <strong>30 days</strong>. Claude Code
+              will delete every transcript older than that the next time
+              it starts
+              {risk.total_transcripts > 0 && (
+                <>
+                  {" "}
+                  — {risk.total_transcripts.toLocaleString()} transcripts
+                  are currently kept
+                </>
+              )}
+              . This cannot be undone.
+            </>
+          }
+          confirmLabel="Restore default"
+          confirmDanger
+          onCancel={() => setConfirmClear(false)}
+          onConfirm={() =>
+            void run(
+              () => api.retentionClear(),
+              "Retention restored to Claude Code's 30-day default.",
+            )
+          }
+        />
+      )}
+
+      {confirmDisable && (
+        <ConfirmDangerousAction
+          title="Stop saving transcripts entirely?"
+          consequences={
+            <>
+              <p>
+                This writes <code>cleanupPeriodDays: 0</code>, which does
+                two things:
+              </p>
+              <ul>
+                <li>Claude Code stops writing transcripts for new sessions.</li>
+                <li>
+                  Every existing transcript
+                  {risk.total_transcripts > 0 && (
+                    <> ({risk.total_transcripts.toLocaleString()} on this machine)</>
+                  )}{" "}
+                  is deleted the next time Claude Code starts.
+                </li>
+              </ul>
+              <p>
+                Session resume, search, and every Claudepot surface built
+                on transcripts stop working. This cannot be undone.
+              </p>
+            </>
+          }
+          confirmLabel="Stop saving and delete"
+          typeToConfirm="delete my transcripts"
+          onCancel={() => setConfirmDisable(false)}
+          onConfirm={() =>
+            void run(
+              () => api.retentionDisablePersistence(),
+              "Transcript persistence disabled.",
+            )
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(reader)/app/features/memory/page.mdx
+++ b/web/src/app/(reader)/app/features/memory/page.mdx
@@ -1,7 +1,7 @@
 export const metadata = {
   title: "Memory",
   description:
-    "Cross-harness shared memory and indexed transcript search across Claude Code and Codex, with an MCP server so the harness itself can query the same store.",
+    "Cross-harness shared memory and indexed transcript search across Claude Code and Codex, a cross-machine corpus with free deterministic candidate detection, and an MCP server so the harness itself can query the same store.",
 };
 
 # Memory
@@ -19,7 +19,54 @@ harness that wrote the transcripts can read them back.
 The result: ask Claude "what did I decide about authentication last
 week?" and it can answer, because it can search.
 
-## Three tabs
+## Beyond this machine
+
+Your conversations are not all in one place. If you use Claude Code on
+a laptop and a desktop, each holds a different slice — and Claude Code
+prunes each of them independently, on its own thirty-day clock.
+
+`claudepot corpus index` builds a single searchable corpus across all
+of them: the live `~/.claude/projects` plus any archived per-machine
+trees you have collected. Conversations that exist on several machines
+are recognised as one conversation, and the most complete copy wins —
+a machine that synced mid-session holds a truncated version, and taking
+that one would quietly shorten the record.
+
+```bash
+claudepot corpus index     # incremental; unchanged files are skipped
+claudepot corpus status    # per-machine coverage and staleness
+claudepot corpus detect    # candidates, free — see below
+```
+
+It lives in its own database on purpose. The session index is a
+*cache* of this machine and removes rows whose file is gone, so
+importing another machine's archive into it would be mutually
+destructive with the ordinary refresh.
+
+## Finding what's worth keeping
+
+A decade of conversations is not a knowledge base. Somewhere in it are
+the things you learned, buried in the things you typed.
+
+`claudepot corpus detect` looks for three shapes, and **calls no model
+and costs nothing**:
+
+- **Failure, then recovery** — something broke and a later attempt of
+  the same command worked. The one shape strong enough to justify a
+  rule, because the fix was observed rather than inferred.
+- **Corrections you made** — a marker like "no, do it this way", but
+  only when something corroborates it: a failure just before, or the
+  same request asked again. A marker on its own is noise; "no errors"
+  is not a correction.
+- **Requests you repeat** — the same ask, across days and projects.
+  Not a lesson. A sign that something wants automating.
+
+It reports what it found so you can decide whether distilling is worth
+paying for. A failure with no observed fix is reported as *unresolved*,
+never as "abandoned" — a conversation that simply ends tells you
+nothing about why.
+
+## The four tabs
 
 ### Search
 
@@ -105,10 +152,17 @@ gets smarter and you want every old rollout re-read.
 
 - `~/.claudepot/sessions.db` &mdash; SQLite store, FTS5-indexed.
   Schema v4 (atomic migration on first launch; older databases are
-  upgraded in place).
+  upgraded in place). This is the index of *this* machine, plus the
+  durable memories and decisions you accept.
+- `~/.claudepot/corpus.db` &mdash; the cross-machine analysis corpus,
+  built by `claudepot corpus index`. Derived data: safe to delete, one
+  pass to rebuild. Kept separate from the session index because that
+  one prunes to match this machine's disk, which would make importing
+  another machine's history destructive.
 - Pure-Rust pipeline; no remote service, no telemetry, no upload.
   The MCP server is a local subprocess that Claude / Codex talk to
-  over stdio.
+  over stdio. Detection is local too &mdash; `corpus detect` is
+  arithmetic over your own files.
 
 ## Common patterns
 

--- a/web/src/app/(reader)/app/features/settings/page.mdx
+++ b/web/src/app/(reader)/app/features/settings/page.mdx
@@ -1,7 +1,7 @@
 export const metadata = {
   title: "Settings",
   description:
-    "Thirteen sub-panes covering preferences, appearance, notifications, network, auto-rotation, health, MCP installer, cleanup, protected paths, GitHub PAT, lock-recovery, diagnostics, and About.",
+    "Fourteen sub-panes covering preferences, appearance, notifications, network, auto-rotation, transcript retention, health, MCP installer, cleanup, protected paths, GitHub PAT, lock-recovery, diagnostics, and About.",
 };
 
 # Settings
@@ -9,7 +9,7 @@ export const metadata = {
 ![ClauDepot — settings tab](/screenshots/settings.png)
 
 ClauDepot's preference surface and the operational controls that
-don't belong to any single tab. Thirteen sub-panes, grouped into
+don't belong to any single tab. Fourteen sub-panes, grouped into
 *Core* (everyday prefs) and *Advanced* (less-touched, ending at
 About).
 
@@ -73,6 +73,41 @@ evaluator in `claudepot-core::rotation::eval` is fully unit-tested,
 including cycle-boundary regressions. See
 [`dev-docs/auto-rotation.md`](https://github.com/xiaolai/claudepot-app/blob/main/dev-docs/auto-rotation.md)
 for the design.
+
+## Retention
+
+Claude Code deletes your saved conversations. Not once — on **every
+launch**, anything older than thirty days. It counts exactly what it
+removed, then throws the number away, and nothing anywhere in its
+interface mentions the setting that controls it.
+
+This pane is the only place you find out.
+
+It opens with the consequence on *your* machine, not the policy:
+
+> **Retention — 30 days**, Claude Code's default, not a choice you made
+> 1,247 transcripts will be deleted the next time Claude Code starts.
+> Oldest surviving conversation: 2026-06-06.
+
+Pick a longer window — 90 days, a year, ten years — and that line goes
+quiet on its own.
+
+**Why the folder size never warned you.** Cleanup removes the small,
+valuable session transcripts and never touches the nested subagent
+files underneath them. Those are the bulk. So the directory keeps
+growing while the conversations inside it disappear, and no amount of
+watching disk usage would ever have told you.
+
+**Zero is not "off".** It is the most destructive value the setting
+has: *write no transcripts at all, and delete the existing ones at
+startup*. So it isn't on the duration scale. Reaching it takes a
+separate, clearly-labelled action behind a type-to-confirm prompt,
+worded as what it does rather than what it disables.
+
+**A longer window buys time; it is not a backup.** Those files still
+live in Claude Code's cache directory under Claude Code's rules. If
+what you want is a durable archive, that is
+[`claudepot corpus`](/app/features/memory).
 
 ## Health
 


### PR DESCRIPTION
Five atomic commits; each compiles standalone.

## Two fixes

**`has_error` was looking in the wrong place.** It tested a top-level
`isError` field Claude Code never writes on transcript lines. CC records
a failed tool call as a nested `tool_result` block. The column read
false for every session ever indexed — 154 of 460 on a reference
machine contained a failing tool call and none were flagged.

**Harvests re-billed for finding nothing.** "Already harvested" was
inferred from having produced a memory, so a transcript the distiller
read correctly and which honestly held no lesson looked unharvested
forever. `harvest_ledger` records outcomes, including "found nothing",
which is a result rather than an absence. Existing work is backfilled so
upgrading doesn't re-pay for it.

## Two features

**Settings → Retention.** Claude Code deletes transcripts older than 30
days on every launch, counts exactly what it removed, and discards the
number. Nothing in its UI mentions the setting. This pane leads with the
consequence on *your* machine, keeps `0` off the duration scale (it
means "delete everything", not "off"), and explains why disk usage can
never reveal the loss.

**`claudepot corpus`.** Index transcripts across every machine into a
separate database — separate because the session index prunes to match
one machine's disk, which would make importing another's archive
destructive. `corpus detect` finds failure→recovery incidents,
corroborated corrections and repeated requests with **no model calls**.

## Docs + a gate

Six stale facts across README/AGENTS.md/web, most predating this branch.
`cargo xtask verify-docs` now fails the build on the mechanical half.

## Verification

`fmt` clean · `clippy -D warnings` 0 (core+cli+xtask) · `verify-cc-parity`
12/12 · `verify-docs` ok · **3,222** core tests · 8 CLI suites · 3 xtask ·
**986** frontend · web tsc + 8 tests.

Screenshot `assets/screenshots/settings.png` still predates the
Retention tab — needs the app running, not done here.