### PR TITLE
Release 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versioning scheme:
 - `0.1.x` — beta
 - `1.0.0+` — stable
 
-## 0.4.4 — beta (unreleased)
+## 0.4.4 — beta (released 2026-08-09)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudepot-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-tauri"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 # Floor set by std file_lock (File::{lock,try_lock,unlock}, 1.89) —
 # the cross-process advisory locks in claudepot-core depend on it.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you use Claude Code or Claude Desktop daily, you've probably hit at least one
 
 ### Install
 
-> **Status: beta** (`0.4.3`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
+> **Status: beta** (`0.4.4`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
 
 You'll need a recent **Rust toolchain** ([rustup.rs](https://rustup.rs)) and **Node 20+** with **pnpm** ([pnpm.io](https://pnpm.io)). No other system dependencies.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claudepot",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "license": "ISC",
   "type": "module",
   "engines": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claudepot",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "identifier": "com.claudepot.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/web/src/app/(reader)/app/install/page.mdx
+++ b/web/src/app/(reader)/app/install/page.mdx
@@ -5,7 +5,7 @@ export const metadata = {
 
 # Install
 
-> **Status: beta (`0.4.3`).** Daily-driven on macOS. Linux and
+> **Status: beta (`0.4.4`).** Daily-driven on macOS. Linux and
 > Windows builds are green but less seasoned.
 
 Two paths: grab a signed installer from the latest release (fast,


### PR DESCRIPTION
Version lock-step for `v0.4.4` across the five sites the release
workflow's preflight checks, plus `Cargo.lock`.

Ships one fix, already on `main`:

- **A progress dialog claimed work was pending that had already
  finished.** Long operations start before their dialog opens, so the
  earliest phases reported to nobody and sat on "pending" for the whole
  run. `RunningOps` now records what each phase reported and the dialog
  seeds from it on mount; a live event still beats that catch-up, so a
  phase never walks backwards.

The 0.4.4 heading is dated in this commit rather than after the tag —
0.4.2 shipped with its section still reading "unreleased" and needed a
follow-up correction.

Lock-step verified locally with the workflow's own logic: all five
sites agree with `0.4.4`.