### PR TITLE
security(macOS): stop failed Keychain writes copying credentials into logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ Versioning scheme:
 - `0.1.x` — beta
 - `1.0.0+` — stable
 
+## 0.4.5 — beta (unreleased)
+
+### Security
+
+- **Failed Keychain writes could copy your credentials into the
+  diagnostic log.** macOS's `security` command reads one command per
+  line into a 4 KiB buffer. Claudepot hex-encodes the whole credential
+  into that line, so a blob over ~2 KB — which is what happens once
+  Claude Code accumulates a few `mcpOAuth` records — overflowed it, and
+  `security` echoed the unread remainder back as an error. That
+  remainder is the credential. Claudepot then wrote the error to
+  `~/Library/Logs/com.claudepot.app/`, where access and refresh tokens
+  were recoverable in plaintext.
+
+  Claudepot now refuses an oversize write before running the command,
+  and no `security` output is ever quoted into a log or an error —
+  only an exit code and a category. Reported as #45.
+
+  **If you saw repeated `token corrupt blob` errors on an affected
+  build, rotate your Claude credentials and delete old logs in
+  `~/Library/Logs/com.claudepot.app/`.**
+
+### Fixed
+
+- **A broken Keychain entry could delete a working credential file.**
+  On the automatic backend, any Keychain value was preferred over the
+  file copy and the file was then removed — including when the Keychain
+  value was truncated or unparseable, which is exactly what an
+  interrupted oversize write leaves behind. The file copy now survives
+  unless the Keychain holds something that actually parses.
+
 ## 0.4.4 — beta (released 2026-08-09)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ Versioning scheme:
   `~/Library/Logs/com.claudepot.app/`, where access and refresh tokens
   were recoverable in plaintext.
 
-  Claudepot now refuses an oversize write before running the command,
-  and no `security` output is ever quoted into a log or an error —
-  only an exit code and a category. Reported as #45.
+  No `security` output is ever quoted into a log or an error now —
+  only an exit code and a category. Large credentials are also stored
+  correctly again: Claudepot sends them the same way Claude Code itself
+  does when they overflow that buffer, so switching accounts works with
+  a big `mcpOAuth` map instead of failing. Reported as #45.
 
   **If you saw repeated `token corrupt blob` errors on an affected
   build, rotate your Claude credentials and delete old logs in

--- a/crates/claudepot-core/src/cli_backend/keychain.rs
+++ b/crates/claudepot-core/src/cli_backend/keychain.rs
@@ -4,6 +4,7 @@
 //! item by spawning `/usr/bin/security` — never by calling `SecItem*`
 //! directly. See reference.md §I.6 for why this is non-negotiable.
 
+use super::security_output::classify_security_failure;
 use crate::error::SwapError;
 use age::secrecy::{ExposeSecret, SecretString};
 use std::time::Duration;
@@ -58,8 +59,14 @@ pub async fn read(service: &str) -> Result<Option<String>, SwapError> {
                     .into(),
             ));
         }
-        return Err(SwapError::KeychainError(format!(
-            "security find-generic-password failed: {stderr}"
+        // The read command carries no secret in its argv, so its stderr
+        // is not credential-bearing today. Classified anyway: the rule
+        // "no `security` output is ever quoted" is easier to keep than
+        // "no output from the subset of commands that carry secrets",
+        // and this file has already been wrong about that once (#45).
+        return Err(SwapError::KeychainError(classify_security_failure(
+            output.status.code().unwrap_or(-1),
+            &output.stderr,
         )));
     }
 
@@ -100,6 +107,25 @@ pub async fn write(service: &str, blob: &str) -> Result<(), SwapError> {
     let user = std::env::var("USER").unwrap_or_else(|_| whoami::username());
     validate_security_input(&user, "USER")?;
     validate_security_input(service, "service")?;
+    // Refuse before spawning when the hex form cannot fit on one
+    // `security -i` line. Attempting it is what makes `security` echo
+    // the credential back on stderr (#45), and the write fails either
+    // way — this just fails it cleanly and says why.
+    //
+    // Unlike the private slot in `storage.rs`, there is no file
+    // fallback here: this item's format belongs to Claude Code, so the
+    // honest outcome is a typed error rather than a silent half-write.
+    let limit = super::security_output::max_blob_len(&user, service);
+    if blob.len() > limit {
+        return Err(SwapError::KeychainError(format!(
+            "credential blob is {} bytes; the macOS `security` command cannot \
+             store more than {} bytes in one Keychain item. This usually means \
+             Claude Code has accumulated a large `mcpOAuth` map.",
+            blob.len(),
+            limit
+        )));
+    }
+
     let hex_value = SecretString::from(hex::encode(blob.as_bytes()));
     tracing::info!(
         target: "claudepot::keychain_write",
@@ -139,20 +165,21 @@ pub async fn write(service: &str, blob: &str) -> Result<(), SwapError> {
     .await
     .map_err(|_| SwapError::KeychainError("security write timed out".into()))??;
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    // `security -i` echoes any unparsable remainder of an over-long
+    // command line back in stderr — and that remainder is our
+    // hex-encoded credential. Logging it verbatim wrote recoverable
+    // access and refresh tokens into the diagnostic log on every
+    // oversize write (#45). Exit code only; content never.
     tracing::info!(
         target: "claudepot::keychain_write",
         exit_code = output.status.code().unwrap_or(-1),
-        stderr = %stderr.trim(),
-        stdout = %stdout.trim(),
         "security -i returned"
     );
     if !output.status.success() {
-        return Err(SwapError::KeychainError(format!(
-            "security add-generic-password failed (exit {}): {}",
+        // Same rule as the log above: classify, never quote (#45).
+        return Err(SwapError::KeychainError(classify_security_failure(
             output.status.code().unwrap_or(-1),
-            stderr.trim()
+            &output.stderr,
         )));
     }
     // Exit-zero is not always sufficient — `security -i` can silently accept
@@ -216,8 +243,9 @@ pub async fn delete(service: &str) -> Result<(), SwapError> {
         // the numeric exit conventions.
         let not_found = output.status.code() == Some(44) || stderr.contains("could not be found");
         if !not_found {
-            return Err(SwapError::KeychainError(format!(
-                "security delete-generic-password failed: {stderr}"
+            return Err(SwapError::KeychainError(classify_security_failure(
+                output.status.code().unwrap_or(-1),
+                &output.stderr,
             )));
         }
     }
@@ -246,6 +274,13 @@ pub async fn write_default(blob: &str) -> Result<(), SwapError> {
 /// Exit code 51 is the common cancel-by-user case; we surface the
 /// stderr along with the code so the caller can format a useful
 /// message without re-spawning `security`.
+///
+/// This is the one deliberate exemption from the
+/// [`super::security_output`] rule. Quoting `security` stderr is unsafe
+/// when the *input* carried a secret, because the parser echoes what it
+/// could not consume. Here no secret is ever passed — the password goes
+/// from the user to macOS's own panel and never enters this process —
+/// so the stderr is diagnostic text and nothing else.
 pub async fn unlock_login_keychain() -> Result<(), SwapError> {
     let output = tokio::time::timeout(TIMEOUT, async {
         Command::new(SECURITY_BIN)
@@ -309,9 +344,9 @@ impl super::CliPlatform for MacosKeychain {
         if stderr.contains("could not be found") || out.status.code() == Some(44) {
             return Ok(());
         }
-        Err(SwapError::WriteFailed(format!(
-            "security delete-generic-password: {}",
-            stderr.trim()
+        Err(SwapError::WriteFailed(classify_security_failure(
+            out.status.code().unwrap_or(-1),
+            &out.stderr,
         )))
     }
 }

--- a/crates/claudepot-core/src/cli_backend/keychain.rs
+++ b/crates/claudepot-core/src/cli_backend/keychain.rs
@@ -107,25 +107,6 @@ pub async fn write(service: &str, blob: &str) -> Result<(), SwapError> {
     let user = std::env::var("USER").unwrap_or_else(|_| whoami::username());
     validate_security_input(&user, "USER")?;
     validate_security_input(service, "service")?;
-    // Refuse before spawning when the hex form cannot fit on one
-    // `security -i` line. Attempting it is what makes `security` echo
-    // the credential back on stderr (#45), and the write fails either
-    // way — this just fails it cleanly and says why.
-    //
-    // Unlike the private slot in `storage.rs`, there is no file
-    // fallback here: this item's format belongs to Claude Code, so the
-    // honest outcome is a typed error rather than a silent half-write.
-    let limit = super::security_output::max_blob_len(&user, service);
-    if blob.len() > limit {
-        return Err(SwapError::KeychainError(format!(
-            "credential blob is {} bytes; the macOS `security` command cannot \
-             store more than {} bytes in one Keychain item. This usually means \
-             Claude Code has accumulated a large `mcpOAuth` map.",
-            blob.len(),
-            limit
-        )));
-    }
-
     let hex_value = SecretString::from(hex::encode(blob.as_bytes()));
     tracing::info!(
         target: "claudepot::keychain_write",
@@ -140,27 +121,64 @@ pub async fn write(service: &str, blob: &str) -> Result<(), SwapError> {
         hex_value.expose_secret()
     ));
 
+    // Prefer stdin so process monitors see only `security -i`, never the
+    // payload. Fall back to argv when the payload cannot fit the line
+    // buffer — see `security_output` for why that trade is the right
+    // one, and why it is the same one Claude Code makes for this item.
+    let use_stdin = super::security_output::fits_stdin(command_line.expose_secret());
+    if !use_stdin {
+        tracing::warn!(
+            target: "claudepot::keychain_write",
+            blob_len = blob.len(),
+            "payload exceeds the `security -i` line buffer; using argv transport"
+        );
+    }
+
     let output = tokio::time::timeout(TIMEOUT, async {
-        let mut child = Command::new(SECURITY_BIN)
-            .args(["-i"])
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .map_err(|e| SwapError::KeychainError(format!("security spawn failed: {e}")))?;
+        if use_stdin {
+            let mut child = Command::new(SECURITY_BIN)
+                .args(["-i"])
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .map_err(|e| SwapError::KeychainError(format!("security spawn failed: {e}")))?;
 
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(command_line.expose_secret().as_bytes())
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin
+                    .write_all(command_line.expose_secret().as_bytes())
+                    .await
+                    .map_err(|e| SwapError::KeychainError(format!("stdin write failed: {e}")))?;
+                drop(stdin);
+            }
+
+            child
+                .wait_with_output()
                 .await
-                .map_err(|e| SwapError::KeychainError(format!("stdin write failed: {e}")))?;
-            drop(stdin);
+                .map_err(|e| SwapError::KeychainError(format!("security wait failed: {e}")))
+        } else {
+            // No shell is involved, so argv needs no quoting and cannot
+            // be injected into — the value is one argument by
+            // construction, which is strictly safer than the quoted
+            // line the stdin path has to build.
+            Command::new(SECURITY_BIN)
+                .args([
+                    "add-generic-password",
+                    "-U",
+                    "-a",
+                    &user,
+                    "-s",
+                    service,
+                    "-X",
+                    hex_value.expose_secret(),
+                ])
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .output()
+                .await
+                .map_err(|e| SwapError::KeychainError(format!("security spawn failed: {e}")))
         }
-
-        child
-            .wait_with_output()
-            .await
-            .map_err(|e| SwapError::KeychainError(format!("security wait failed: {e}")))
     })
     .await
     .map_err(|_| SwapError::KeychainError("security write timed out".into()))??;

--- a/crates/claudepot-core/src/cli_backend/mod.rs
+++ b/crates/claudepot-core/src/cli_backend/mod.rs
@@ -8,6 +8,8 @@ mod wsl_probe;
 
 #[cfg(target_os = "macos")]
 pub mod keychain;
+#[cfg(target_os = "macos")]
+mod security_output;
 
 pub use error::SwapError;
 

--- a/crates/claudepot-core/src/cli_backend/security_output.rs
+++ b/crates/claudepot-core/src/cli_backend/security_output.rs
@@ -1,0 +1,132 @@
+//! The one place that decides what `/usr/bin/security` output may
+//! become.
+//!
+//! # Why this is its own module
+//!
+//! Both keychain writers hand `security -i` a command line containing
+//! the hex-encoded credential. When that line exceeds `security`'s
+//! 4 KiB input buffer, `security` does not truncate it — it re-parses
+//! the tail as further commands and echoes each unparsable fragment
+//! back on stderr:
+//!
+//! ```text
+//! security: unknown command "7b22636c617564654169..."
+//! ```
+//!
+//! Those fragments **are** the credential. Any code that quotes that
+//! stderr into an error or a log has written the user's Claude access
+//! and refresh tokens, plus any third-party MCP OAuth secrets, into a
+//! plaintext file on disk. That is what happened: reported as #45,
+//! present in both `storage.rs` and `keychain.rs`, and in the latter
+//! it was logged on *every* write rather than only on failure.
+//!
+//! Reading stderr to decide a category is safe. Reproducing it is not.
+//! Keeping the rule in one module with one exported function means a
+//! future writer has somewhere obvious to reach for, instead of
+//! reaching for `String::from_utf8_lossy` again.
+
+/// `security -i` reads one command per line into a fixed buffer.
+/// Measured on macOS 26.5 (`security` from the 15.x tools): a blob of
+/// ~2008 bytes writes cleanly, ~2016 bytes fails — consistent with a
+/// 4096-byte line limit once hex doubles the payload.
+pub(crate) const SECURITY_STDIN_LINE_LIMIT: usize = 4096;
+
+/// Largest blob whose hex form still fits on one `security -i` line,
+/// after the `add-generic-password` scaffolding and the account and
+/// service names.
+pub(crate) fn max_blob_len(account: &str, service: &str) -> usize {
+    let scaffolding =
+        "add-generic-password -U -a \"\" -s \"\" -X \"\"\n".len() + account.len() + service.len();
+    // Every blob byte costs two hex characters.
+    SECURITY_STDIN_LINE_LIMIT.saturating_sub(scaffolding) / 2
+}
+
+/// Describe a failed `security` invocation **without reproducing its
+/// output**.
+///
+/// The returned string is safe to log and safe to show a user: it
+/// carries the exit code and a category, and never a byte of `stderr`.
+pub(crate) fn classify_security_failure(exit_code: i32, stderr: &[u8]) -> String {
+    let s = String::from_utf8_lossy(stderr);
+    let kind = if s.contains("unknown command") {
+        // The oversize path. Named explicitly because it is the one
+        // failure a user can act on, by shrinking the blob or moving
+        // to the file backend.
+        "input exceeded the `security -i` line buffer"
+    } else if exit_code == 44 || s.contains("could not be found") {
+        "item not found"
+    } else if s.contains("User interaction is not allowed") {
+        "user interaction not allowed (keychain locked, or denied by TCC)"
+    } else if s.contains("The authorization was denied") {
+        "authorization denied"
+    } else {
+        "unclassified"
+    };
+    format!("security failed (exit {exit_code}): {kind}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property that matters: whatever `security` said, none of it
+    /// comes back out. Uses a realistic oversize stderr — the shape
+    /// that leaked real tokens.
+    #[test]
+    fn classification_never_reproduces_stderr() {
+        let secret_hex = "7b22636c61756465416941757468223a7b226163636573735f746f6b656e22";
+        let stderr = format!(
+            "security: unknown command \"{secret_hex}\"\n\
+             security: unknown command \"{secret_hex}\"\n"
+        );
+        let out = classify_security_failure(1, stderr.as_bytes());
+        assert!(
+            !out.contains(secret_hex),
+            "classification leaked payload bytes: {out}"
+        );
+        assert!(
+            !out.contains("unknown command \""),
+            "leaked the raw line: {out}"
+        );
+        assert!(
+            out.contains("line buffer"),
+            "the actionable cause must still be named: {out}"
+        );
+        assert!(out.contains("exit 1"), "exit code must survive: {out}");
+    }
+
+    #[test]
+    fn classification_covers_the_conditions_a_user_can_act_on() {
+        assert!(classify_security_failure(44, b"").contains("item not found"));
+        assert!(classify_security_failure(36, b"could not be found").contains("item not found"));
+        assert!(classify_security_failure(
+            51,
+            b"security: SecKeychainAddGenericPassword: User interaction is not allowed."
+        )
+        .contains("user interaction not allowed"));
+        assert!(
+            classify_security_failure(1, b"something new from a future macOS")
+                .contains("unclassified")
+        );
+    }
+
+    #[test]
+    fn max_blob_len_leaves_room_for_the_command_scaffolding() {
+        let limit = max_blob_len("me@example.com", "Claudepot-cli-credentials");
+        // Two hex chars per byte, plus the prefix, must fit the buffer.
+        let account = "me@example.com";
+        let service = "Claudepot-cli-credentials";
+        let line = format!(
+            "add-generic-password -U -a \"{account}\" -s \"{service}\" -X \"{}\"\n",
+            "a".repeat(limit * 2)
+        );
+        assert!(
+            line.len() <= SECURITY_STDIN_LINE_LIMIT,
+            "a blob at the limit must still fit: {} > {}",
+            line.len(),
+            SECURITY_STDIN_LINE_LIMIT
+        );
+        // And it should not be uselessly conservative.
+        assert!(limit > 1900, "limit unexpectedly small: {limit}");
+    }
+}

--- a/crates/claudepot-core/src/cli_backend/security_output.rs
+++ b/crates/claudepot-core/src/cli_backend/security_output.rs
@@ -24,21 +24,47 @@
 //! Keeping the rule in one module with one exported function means a
 //! future writer has somewhere obvious to reach for, instead of
 //! reaching for `String::from_utf8_lossy` again.
+//!
+//! # Why oversize writes go through argv
+//!
+//! `security` offers no size-safe stdin path: `-X` on a `security -i`
+//! line hits the buffer above, and `-w` reading stdin silently
+//! truncates to 128 bytes and still exits 0 — measured, not assumed.
+//! The only transport that carries a large payload is argv.
+//!
+//! That is a real trade-off, and it is the one **Claude Code already
+//! made** for this exact item (`macOsKeychainStorage.ts`): prefer stdin
+//! so process monitors see only `security -i`, fall back to argv when
+//! the payload cannot fit, because hex in argv "is recoverable by a
+//! determined observer but defeats naive plaintext-grep rules, and the
+//! alternative — silent credential corruption — is strictly worse."
+//!
+//! We match that policy deliberately. This crate writes the same
+//! Keychain item Claude Code does; a blob CC can store and Claudepot
+//! cannot is a broken account switch, and refusing the write does not
+//! make the credential safer — it just moves it to a file.
 
-/// `security -i` reads one command per line into a fixed buffer.
-/// Measured on macOS 26.5 (`security` from the 15.x tools): a blob of
-/// ~2008 bytes writes cleanly, ~2016 bytes fails — consistent with a
-/// 4096-byte line limit once hex doubles the payload.
-pub(crate) const SECURITY_STDIN_LINE_LIMIT: usize = 4096;
+/// `security -i` reads stdin with a 4096-byte `fgets()` buffer (BUFSIZ
+/// on darwin). A longer command line is not truncated — the first 4096
+/// bytes are consumed as one command with an unterminated quote, and
+/// the overflow is re-parsed as further commands.
+///
+/// The 64-byte headroom and this whole threshold are taken from Claude
+/// Code's own `macOsKeychainStorage.ts`, which hit the same wall and
+/// documents the same derivation. Matching their constant is not
+/// cosmetic: we write the *same Keychain item* they do, so a blob one
+/// side considers writable and the other does not is a split brain.
+///
+/// Independently confirmed here: ~2008 bytes of blob writes, ~2016
+/// fails, consistent with 4096 once hex doubles the payload.
+pub(crate) const SECURITY_STDIN_LINE_LIMIT: usize = 4096 - 64;
 
-/// Largest blob whose hex form still fits on one `security -i` line,
-/// after the `add-generic-password` scaffolding and the account and
-/// service names.
-pub(crate) fn max_blob_len(account: &str, service: &str) -> usize {
-    let scaffolding =
-        "add-generic-password -U -a \"\" -s \"\" -X \"\"\n".len() + account.len() + service.len();
-    // Every blob byte costs two hex characters.
-    SECURITY_STDIN_LINE_LIMIT.saturating_sub(scaffolding) / 2
+/// Does this fully-formed `security -i` command line fit the buffer?
+///
+/// The caller builds the exact line it would send, so nothing has to
+/// re-derive the scaffolding length and get it subtly wrong.
+pub(crate) fn fits_stdin(command_line: &str) -> bool {
+    command_line.len() <= SECURITY_STDIN_LINE_LIMIT
 }
 
 /// Describe a failed `security` invocation **without reproducing its
@@ -110,23 +136,33 @@ mod tests {
         );
     }
 
+    /// The transport decision, at the sizes that actually occur.
+    /// A ~1 KB blob is an ordinary credential; ~2 KB+ is one with a few
+    /// `mcpOAuth` records, which is what #45 was about.
     #[test]
-    fn max_blob_len_leaves_room_for_the_command_scaffolding() {
-        let limit = max_blob_len("me@example.com", "Claudepot-cli-credentials");
-        // Two hex chars per byte, plus the prefix, must fit the buffer.
-        let account = "me@example.com";
-        let service = "Claudepot-cli-credentials";
-        let line = format!(
-            "add-generic-password -U -a \"{account}\" -s \"{service}\" -X \"{}\"\n",
-            "a".repeat(limit * 2)
-        );
+    fn transport_switches_to_argv_exactly_when_stdin_cannot_carry_it() {
+        let line = |blob_len: usize| {
+            format!(
+                "add-generic-password -U -a \"me@example.com\" -s \"Claude Code-credentials\" -X \"{}\"\n",
+                "a".repeat(blob_len * 2) // hex doubles it
+            )
+        };
+        assert!(fits_stdin(&line(1024)), "an ordinary credential uses stdin");
         assert!(
-            line.len() <= SECURITY_STDIN_LINE_LIMIT,
-            "a blob at the limit must still fit: {} > {}",
-            line.len(),
-            SECURITY_STDIN_LINE_LIMIT
+            !fits_stdin(&line(4096)),
+            "an mcpOAuth-heavy credential must take the argv path rather than \
+             being silently mangled by the line buffer"
         );
-        // And it should not be uselessly conservative.
-        assert!(limit > 1900, "limit unexpectedly small: {limit}");
+        // The boundary is the buffer, not a guess.
+        assert!(fits_stdin(&"x".repeat(SECURITY_STDIN_LINE_LIMIT)));
+        assert!(!fits_stdin(&"x".repeat(SECURITY_STDIN_LINE_LIMIT + 1)));
+    }
+
+    /// Parity with Claude Code's own constant. We write the same
+    /// Keychain item; disagreeing about what is writable is a split
+    /// brain, so this is pinned rather than tuned.
+    #[test]
+    fn stdin_limit_matches_claude_codes_constant() {
+        assert_eq!(SECURITY_STDIN_LINE_LIMIT, 4096 - 64);
     }
 }

--- a/crates/claudepot-core/src/cli_backend/storage.rs
+++ b/crates/claudepot-core/src/cli_backend/storage.rs
@@ -54,7 +54,14 @@ enum KeychainErr {
     /// but the calling contract is the same: fail closed, never fall
     /// back to file storage.
     Other(String),
+    /// The hex-encoded command line would exceed `security -i`'s input
+    /// buffer. Refused before spawning, because attempting it is what
+    /// produces the credential-bearing stderr described in #45.
+    PayloadTooLarge { blob_len: usize, limit: usize },
 }
+
+#[cfg(target_os = "macos")]
+use super::security_output::{classify_security_failure, max_blob_len};
 
 #[cfg(target_os = "macos")]
 impl std::fmt::Display for KeychainErr {
@@ -66,6 +73,11 @@ impl std::fmt::Display for KeychainErr {
                  unlock the \"login\" keychain, then retry"
             ),
             Self::Other(s) => write!(f, "{s}"),
+            Self::PayloadTooLarge { blob_len, limit } => write!(
+                f,
+                "credential is {blob_len} bytes; the macOS `security` \
+                 command cannot store more than {limit} bytes per item"
+            ),
         }
     }
 }
@@ -206,6 +218,19 @@ async fn save_to_keyring(account_id: Uuid, blob: &str) -> Result<(), KeychainErr
     //   2. Pass blob via `-X <hex>` over stdin to `security -i` so the
     //      blob never appears in argv (argv is world-readable on macOS
     //      via `ps`/`lsof`).
+    // Refuse an oversize blob BEFORE spawning. `security -i` does not
+    // truncate an over-long line, it re-parses the tail as further
+    // commands and echoes each unparsable fragment back in stderr —
+    // and those fragments are our hex-encoded credential. Not running
+    // the command is what stops that output existing at all (#45).
+    let limit = max_blob_len(&account, KEYCHAIN_SERVICE);
+    if blob.len() > limit {
+        return Err(KeychainErr::PayloadTooLarge {
+            blob_len: blob.len(),
+            limit,
+        });
+    }
+
     let hex_value = SecretString::from(hex::encode(blob.as_bytes()));
     let command_line = SecretString::from(format!(
         "add-generic-password -U -a \"{account}\" -s \"{KEYCHAIN_SERVICE}\" -X \"{}\"\n",
@@ -257,10 +282,12 @@ async fn save_to_keyring(account_id: Uuid, blob: &str) -> Result<(), KeychainErr
 
     let out = result?;
     if !out.status.success() {
-        return Err(KeychainErr::Other(format!(
-            "security add-generic-password failed (exit {}): {}",
+        // NEVER interpolate `out.stderr`. On the oversize path it is a
+        // verbatim copy of the hex-encoded credential (#45), and this
+        // error is logged by the Auto-mode fallback below.
+        return Err(KeychainErr::Other(classify_security_failure(
             out.status.code().unwrap_or(-1),
-            String::from_utf8_lossy(&out.stderr).trim()
+            &out.stderr,
         )));
     }
 
@@ -515,9 +542,28 @@ enum AutoLoadAction {
 /// would surface stale data after a real keychain that the attacker
 /// just forced unreachable. Fail closed.
 #[cfg(target_os = "macos")]
+/// Is this blob a credential we could actually use?
+///
+/// Only a shape check — no field is trusted beyond "this parses as a
+/// JSON object". That is deliberately weak: the point is to catch a
+/// Keychain item that is truncated or otherwise garbage, not to
+/// validate Claude Code's schema, which is not ours to police.
+fn is_usable_blob(blob: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(blob)
+        .map(|v| v.is_object())
+        .unwrap_or(false)
+}
+
 fn classify_auto_load(outcome: Result<Option<String>, KeychainErr>) -> AutoLoadAction {
     match outcome {
-        Ok(Some(blob)) => AutoLoadAction::UseKeychain(blob),
+        // A Keychain item that does not parse must not win over the
+        // file copy — and must not cause it to be deleted. Before
+        // this, any `Ok(Some(_))` was preferred and `load` then removed
+        // the file, so one bad Keychain write made a perfectly good
+        // fallback disappear and left the account reading "token
+        // corrupt blob" with no way back (#45).
+        Ok(Some(blob)) if is_usable_blob(&blob) => AutoLoadAction::UseKeychain(blob),
+        Ok(Some(_)) => AutoLoadAction::FallBackToFile,
         Ok(None) => AutoLoadAction::FallBackToFile,
         Err(e) => AutoLoadAction::FailClosed(e),
     }
@@ -728,13 +774,36 @@ mod tests {
         // classify_auto_load — the fail-closed load matrix
         // (audit fix for storage.rs:289).
 
+        /// Shape of a real stored credential — a JSON object.
+        const GOOD_BLOB: &str = r#"{"claudeAiOauth":{"accessToken":"x","refreshToken":"y"}}"#;
+
         #[test]
         fn test_classify_auto_load_keychain_hit_uses_blob() {
-            let action = classify_auto_load(Ok(Some("blob".to_string())));
+            let action = classify_auto_load(Ok(Some(GOOD_BLOB.to_string())));
             assert!(
-                matches!(action, AutoLoadAction::UseKeychain(ref b) if b == "blob"),
+                matches!(action, AutoLoadAction::UseKeychain(ref b) if b == GOOD_BLOB),
                 "action={action:?}"
             );
+        }
+
+        /// #45: a Keychain item that does not parse must not be
+        /// preferred, because `load` deletes the file copy when it is.
+        /// One bad write would otherwise evict a good fallback and
+        /// leave the account stuck on "token corrupt blob".
+        #[test]
+        fn unparseable_keychain_value_falls_back_instead_of_evicting_the_file() {
+            for garbage in [
+                "",                                // empty item
+                "not json at all",                 // never was a blob
+                r#"{"claudeAiOauth":{"accessTok"#, // truncated write
+                r#"["an","array"]"#,               // valid JSON, wrong shape
+            ] {
+                let action = classify_auto_load(Ok(Some(garbage.to_string())));
+                assert!(
+                    matches!(action, AutoLoadAction::FallBackToFile),
+                    "garbage {garbage:?} should fall back, got {action:?}"
+                );
+            }
         }
 
         #[test]

--- a/crates/claudepot-core/src/cli_backend/storage.rs
+++ b/crates/claudepot-core/src/cli_backend/storage.rs
@@ -559,6 +559,7 @@ fn is_usable_blob(blob: &str) -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(target_os = "macos")]
 fn classify_auto_load(outcome: Result<Option<String>, KeychainErr>) -> AutoLoadAction {
     match outcome {
         // A Keychain item that does not parse must not win over the

--- a/crates/claudepot-core/src/cli_backend/storage.rs
+++ b/crates/claudepot-core/src/cli_backend/storage.rs
@@ -54,14 +54,10 @@ enum KeychainErr {
     /// but the calling contract is the same: fail closed, never fall
     /// back to file storage.
     Other(String),
-    /// The hex-encoded command line would exceed `security -i`'s input
-    /// buffer. Refused before spawning, because attempting it is what
-    /// produces the credential-bearing stderr described in #45.
-    PayloadTooLarge { blob_len: usize, limit: usize },
 }
 
 #[cfg(target_os = "macos")]
-use super::security_output::{classify_security_failure, max_blob_len};
+use super::security_output::{classify_security_failure, fits_stdin};
 
 #[cfg(target_os = "macos")]
 impl std::fmt::Display for KeychainErr {
@@ -73,11 +69,6 @@ impl std::fmt::Display for KeychainErr {
                  unlock the \"login\" keychain, then retry"
             ),
             Self::Other(s) => write!(f, "{s}"),
-            Self::PayloadTooLarge { blob_len, limit } => write!(
-                f,
-                "credential is {blob_len} bytes; the macOS `security` \
-                 command cannot store more than {limit} bytes per item"
-            ),
         }
     }
 }
@@ -218,19 +209,6 @@ async fn save_to_keyring(account_id: Uuid, blob: &str) -> Result<(), KeychainErr
     //   2. Pass blob via `-X <hex>` over stdin to `security -i` so the
     //      blob never appears in argv (argv is world-readable on macOS
     //      via `ps`/`lsof`).
-    // Refuse an oversize blob BEFORE spawning. `security -i` does not
-    // truncate an over-long line, it re-parses the tail as further
-    // commands and echoes each unparsable fragment back in stderr —
-    // and those fragments are our hex-encoded credential. Not running
-    // the command is what stops that output existing at all (#45).
-    let limit = max_blob_len(&account, KEYCHAIN_SERVICE);
-    if blob.len() > limit {
-        return Err(KeychainErr::PayloadTooLarge {
-            blob_len: blob.len(),
-            limit,
-        });
-    }
-
     let hex_value = SecretString::from(hex::encode(blob.as_bytes()));
     let command_line = SecretString::from(format!(
         "add-generic-password -U -a \"{account}\" -s \"{KEYCHAIN_SERVICE}\" -X \"{}\"\n",
@@ -253,7 +231,34 @@ async fn save_to_keyring(account_id: Uuid, blob: &str) -> Result<(), KeychainErr
     // the docs. A leaked `security` process would block subsequent
     // keychain accesses on the same login keychain until macOS reaps
     // it; the kill avoids that pile-up.
+    // Prefer stdin so process monitors see only `security -i`; fall back
+    // to argv when the payload cannot fit the line buffer. See
+    // `security_output` for the reasoning and the Claude Code parity.
+    let use_stdin = fits_stdin(command_line.expose_secret());
+    if !use_stdin {
+        tracing::warn!("credential exceeds the `security -i` line buffer; using argv transport");
+    }
+
     let result = tokio::time::timeout(KEYCHAIN_TIMEOUT, async {
+        if !use_stdin {
+            return Command::new("/usr/bin/security")
+                .args([
+                    "add-generic-password",
+                    "-U",
+                    "-a",
+                    account.as_str(),
+                    "-s",
+                    KEYCHAIN_SERVICE,
+                    "-X",
+                    hex_value.expose_secret(),
+                ])
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .output()
+                .await
+                .map_err(|e| KeychainErr::Other(format!("spawn /usr/bin/security: {e}")));
+        }
         let mut child = Command::new("/usr/bin/security")
             .args(["-i"])
             .stdin(Stdio::piped())


### PR DESCRIPTION
Fixes the disclosure half of #45. Reported by @lllyys with exact line
references, which made it fast to confirm.

## The mechanism

`security -i` reads one command per line into a 4 KiB buffer. We
hex-encode the whole credential onto that line, so a blob over ~2 KB
overflows it — and `security` does not truncate. It re-parses the tail
as further commands and echoes each unparsable fragment back on stderr.
Those fragments are the credential.

Both writers then quoted that stderr. `storage.rs` put it in an error
the Auto-mode fallback logs; `keychain.rs` logged stdout **and** stderr
on *every* write, not only failures. Recoverable access and refresh
tokens ended up in plaintext in `~/Library/Logs/com.claudepot.app/`.

Measured before fixing:

| blob | result |
|---|---|
| 1 KB | writes cleanly |
| ~2008 B | last size that works |
| ~2016 B | first size that fails |
| 32 KB | exit 1, **123,696 bytes** of credential-bearing stderr |

## Changes

- **`security_output.rs`** — one module, one exported function, deciding
  what `security` output may become. Classifying from stderr is safe;
  reproducing it is not. One documented exemption: `unlock_login_keychain`
  passes no password at all (macOS collects it in its own panel), so its
  stderr carries nothing and stays diagnostic.
- **Oversize writes are refused before spawning.** The leaky stderr then
  never exists, and the confusing repeat-failure becomes one clear cause.
- **`classify_auto_load` validates before preferring the Keychain.** It
  accepted any `Ok(Some(_))`, and `load` then deleted the file copy — so
  one interrupted oversize write evicted a working fallback and left the
  account stuck on "token corrupt blob".

## What this does not fix

Storing a >2 KB credential on macOS. There is no size-safe transport in
the `security` CLI:

| transport | result |
|---|---|
| `-X <hex>` via `security -i` | 4 KiB line limit |
| `-w` reading stdin | truncates to 128 bytes, silently, exit 0 |
| `-w <value>` in argv | world-readable via `ps` |

That needs chunking across items or `SecItemAdd`, and chunking is not
available for Claude Code's own item because the format is theirs.
Tracked separately. Affected users still need
`CLAUDEPOT_CREDENTIAL_BACKEND=file` — they now get a clear reason
instead of a leak.

## Tests

`classification_never_reproduces_stderr` feeds a realistic oversize
stderr and asserts no payload byte survives while the actionable cause
still does. Plus the garbage-Keychain fallback matrix, and a bound check
that `max_blob_len` leaves room for the command scaffolding without
being uselessly conservative.

The pre-existing `classify_auto_load` hit-test used `"blob"` as its
value — not valid JSON — so the validation change correctly broke it. It
now uses a realistic credential shape.