### PR TITLE
fix(macOS): bring the window back when the Dock icon is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ Versioning scheme:
 
 ### Fixed
 
+- **Closing the window with the red ✕ left no way back.** The ✕ hides
+  Claudepot rather than quitting it, so that a stray click never
+  discards what you were doing — but nothing was listening for the Dock
+  icon being clicked afterwards, so the window never came back. The only
+  routes back were the menu bar icon, or the View menu, which is
+  reachable only while Claudepot is still frontmost. Minimize was never
+  affected, because macOS restores a minimized window itself. Reported
+  as #43.
 - **A broken Keychain entry could delete a working credential file.**
   On the automatic backend, any Keychain value was preferred over the
   file copy and the file was then removed — including when the Keychain

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1371,9 +1371,46 @@ pub fn run() {
             commands::shared_memory::shared_memory_snippet_body,
             commands::shared_memory::shared_memory_mcp_health,
         ])
-        .run(tauri::generate_context!())
+        .build(tauri::generate_context!())
         .unwrap_or_else(|e| {
             eprintln!("fatal: tauri application failed to start: {e}");
             std::process::exit(1);
+        })
+        .run(|app, event| {
+            // Dock-icon click with no visible window (#43).
+            //
+            // The red ✕ does not close this app, it hides the window —
+            // see the `CloseRequested` handler above, which calls
+            // `prevent_close()` so quitting stays deliberate. macOS then
+            // sends `applicationShouldHandleReopen:` when the Dock icon
+            // is clicked, and with nothing listening for it the click
+            // did nothing: the window was hidden, the app was running,
+            // and the only ways back were the tray or the View menu —
+            // and the menu bar is only reachable while Claudepot is
+            // still frontmost, which it stops being the moment you
+            // click anything else.
+            //
+            // Minimize was never affected, because AppKit restores a
+            // miniaturized window itself. Only the app-managed hidden
+            // state needed an owner.
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen {
+                has_visible_windows,
+                ..
+            } = event
+            {
+                if !has_visible_windows {
+                    use tauri::Manager;
+                    if let Some(w) = app.get_webview_window("main") {
+                        let _ = w.show();
+                        let _ = w.unminimize();
+                        let _ = w.set_focus();
+                    }
+                }
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = (app, event);
+            }
         });
 }


### PR DESCRIPTION
Fixes #43.

## Cause

The red ✕ does not quit Claudepot — `CloseRequested` calls
`prevent_close()` and hides the window, so a stray click never discards
what you were doing. macOS then sends `applicationShouldHandleReopen:`
when the Dock icon is clicked, and **nothing in the crate was listening
for it**. Window hidden, app running, no way back except the menu bar
icon or the View menu — and the menu bar is only reachable while
Claudepot is still frontmost, which it stops being the moment you click
anything else.

@Zibo-Sun's two observations pin it exactly:

- **Minimize was fine** — AppKit restores a miniaturized window itself.
- **The View menu worked** — so `show()` / `set_focus()` were never the
  problem.

Only the app-managed hidden state had no owner. Handling
`RunEvent::Reopen` required moving from `.run(context)` to
`.build(context)?.run(callback)`.

## Verification is incomplete

Stating this up front rather than burying it. The root cause is
confirmed by reading the code, and the handler compiles and is the
documented API for this event — but I could not drive a real Dock click
end to end.

A non-bundled debug binary is not registered with LaunchServices, so
`tell application id "com.claudepot.app" to reopen` resolved to the
*installed* app and launched it. My "still hidden" reading was measuring
the wrong process entirely. What I did confirm on the debug build is the
first half:

```
1. launched     : alive=yes windows=1
2. after red X  : alive=yes windows=0    ← hidden, not quit
```

Confirming the second half needs a bundled build. @Zibo-Sun — if you're
willing, the release after this merges would be the real test.