### PR TITLE
feat(migrate): merge mode, CC state fragments, delta export (0.4.6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ version lock-step check (tag vs `Cargo.toml`, `package.json`,
   authoritative). Stores backed by `claudepot-core::json_store` (the
   six below plus `agent-events.json`) move a corrupt file aside to a
   timestamped `<name>.corrupt.<unix-ts>` and start empty — never
-  fatal at boot. Six carry behavior worth documenting here:
+  fatal at boot. Seven carry behavior worth documenting here:
   - `notifications.json` — ≤ 500 dispatched toast + OS-banner entries
     surfaced by the WindowChrome bell-icon popover. Owned by
     `claudepot-core::notification_log`. Capture sites: `pushToast` in
@@ -162,6 +162,18 @@ version lock-step check (tag vs `Cargo.toml`, `package.json`,
     `claudepot-core::pricing::history`. Empty file = no change ever
     observed, and the bundled rate history stands alone. See
     "## Pricing".
+  - `migrate-peers.json` — per-`(peer, project)` file fingerprints
+    for delta export (`claudepot export --since-peer <id>`).
+    `{schema_version, peers: {peer_id: {projects: {cwd: [...]}}}}`.
+    Owned by `claudepot-core::migrate::peer`. **Transport state, not
+    cache**: it must survive a `sessions.db` rebuild, because
+    rebuilding a cache would silently re-send every file to every
+    peer — which is why it is its own file rather than a table in
+    `sessions.db`, whose documented remedy is "delete and rebuild".
+    Empty file = every export is full. Fingerprints are
+    `(size, mtime_ns)` rather than a high-water mark, because
+    `session slim` rewrites transcripts *smaller* in place and
+    retention deletes them outright; a watermark skips both.
 
 ## Pricing (Activities → Cost, and every "on API" figure)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versioning scheme:
 - `0.1.x` — beta
 - `1.0.0+` — stable
 
-## Unreleased
+## 0.4.6 — beta (unreleased)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ Versioning scheme:
 - `0.1.x` — beta
 - `1.0.0+` — stable
 
+## Unreleased
+
+### Added
+
+- **`import --mode=merge` now works.** Merging into an existing project
+  unions the bundle's sessions with the target's instead of refusing.
+  Sessions only the target has are preserved — the previous
+  whole-directory rename would have destroyed them. A session id present
+  on both machines is a conflict: `--prefer-imported` or
+  `--prefer-target` resolves it, and merge refuses without one rather
+  than picking a winner (spec §6, golden #16).
+- **`~/.claude.json` and `history.jsonl` now travel** with a project
+  (spec §5.6 / §5.7). The project's `projects[<cwd>]` entry is re-keyed
+  to the target cwd with embedded paths re-anchored; history lines are
+  appended and deduped by `(sessionId, hash(prompt))`, never reordered.
+  Additive bundle entries — no schema bump, and older bundles import
+  unchanged.
+- **`export --since-peer <id>`** ships only what changed since the last
+  export to that peer. Files removed since then ride along as
+  tombstones, which the importer *reports and never acts on* — a
+  retention sweep on one machine must not delete another machine's last
+  copy.
+
+### Fixed
+
+- Session-overlap detection never fired: the importer hardcoded a
+  zero-count "no overlap", so a cross-machine session id collision was
+  undetectable.
+- `undo` could restore a half-applied `~/.claude.json` or
+  `history.jsonl`. Snapshots are named per `(bundle, target)`, so a
+  second project in the same bundle overwrote the pre-import copy with
+  already-mutated bytes. The first snapshot of a target now wins.
+- An import that failed partway through a merge left the files it had
+  already placed out of the journal, invisible to rollback.
+- The dry run ignored `--remap` and could promise an import that apply
+  then refused.
+
 ## 0.4.5 — beta (released 2026-08-10)
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudepot-cli"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-core"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-tauri"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 # Floor set by std file_lock (File::{lock,try_lock,unlock}, 1.89) —
 # the cross-process advisory locks in claudepot-core depend on it.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you use Claude Code or Claude Desktop daily, you've probably hit at least one
 
 ### Install
 
-> **Status: beta** (`0.4.5`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
+> **Status: beta** (`0.4.6`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
 
 You'll need a recent **Rust toolchain** ([rustup.rs](https://rustup.rs)) and **Node 20+** with **pnpm** ([pnpm.io](https://pnpm.io)). No other system dependencies.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ claudepot experimental board                        # durable agent-written
                                                     # is self-declared, not
                                                     # authenticated.
 claudepot export / import                           # *.claudepot.tar.zst bundles
+                    export --since-peer <id>        # ship only what changed
+                    import --mode=merge             # union into an existing
+                            --prefer-imported|-target #  project; refuses an
+                                                    #  id collision otherwise
 claudepot migrate   inspect | undo
 claudepot doctor                                    # health check
 claudepot status                                    # ground-truth auth status

--- a/crates/claudepot-cli/src/commands/project_migrate/export.rs
+++ b/crates/claudepot-cli/src/commands/project_migrate/export.rs
@@ -50,6 +50,14 @@ pub struct ExportArgs {
     /// Optional minisign signature over the manifest sha256.
     #[arg(long, value_name = "KEYFILE")]
     pub sign: Option<String>,
+    /// Export only what changed since the last export to this peer.
+    /// The id is yours to choose — any stable label for the receiving
+    /// machine (e.g. `laptop`). Omit for a full bundle.
+    ///
+    /// Files removed since that export ride along as tombstones, which
+    /// the importer reports and never acts on.
+    #[arg(long, value_name = "PEER_ID")]
+    pub since_peer: Option<String>,
 }
 
 /// `project export <project-prefix>... [opts]`
@@ -64,6 +72,7 @@ pub fn export(ctx: &AppContext, args: ExportArgs) -> Result<()> {
         no_file_history,
         encrypt,
         sign: sign_keyfile,
+        since_peer,
     } = args;
     if project_prefixes.is_empty() {
         return Err(anyhow!("at least one project-prefix is required"));
@@ -130,6 +139,7 @@ pub fn export(ctx: &AppContext, args: ExportArgs) -> Result<()> {
         encrypt_passphrase,
         sign_keyfile,
         sign_password,
+        since_peer,
         account_stubs,
     };
 

--- a/crates/claudepot-core/src/migrate/apply.rs
+++ b/crates/claudepot-core/src/migrate/apply.rs
@@ -207,6 +207,18 @@ pub fn snapshot_file(bundle_id: &str, target: &Path) -> Result<Option<PathBuf>, 
         .map(|e| format!(".{}", e.to_string_lossy()))
         .unwrap_or_default();
     let snap = dir.join(format!("{key}{suffix}"));
+    // First snapshot of this target wins, and later ones are no-ops.
+    //
+    // The name is deterministic per `(bundle_id, target)`, so a target
+    // touched twice in one import — `~/.claude.json` and
+    // `history.jsonl` are written once per project, and a bundle may
+    // carry several — would otherwise have its pre-import snapshot
+    // overwritten by mid-import bytes on the second write. Rollback
+    // restores LIFO, and every step for that target points at this one
+    // path, so the content it holds must be the *pre-import* state.
+    if snap.exists() {
+        return Ok(Some(snap));
+    }
     fs::copy(target, &snap).map_err(MigrateError::from)?;
     Ok(Some(snap))
 }

--- a/crates/claudepot-core/src/migrate/fragment.rs
+++ b/crates/claudepot-core/src/migrate/fragment.rs
@@ -1,0 +1,529 @@
+//! §5.6 / §5.7 — the two per-project fragments that carry CC state
+//! living *outside* the slug tree.
+//!
+//! See `dev-docs/archive/project-migrate-spec.md` §3.2 (layout), §5.6
+//! (`~/.claude.json`), §5.7 (`history.jsonl`), §6 (collision policy).
+//!
+//! Both are **additive** bundle entries: `SCHEMA_VERSION` is not
+//! bumped for them. The writer records them in `file_inventory`, so a
+//! newer bundle verifies on an older importer, which simply never
+//! reads them; a newer importer treats a missing fragment as "old
+//! bundle, nothing to merge". Bumping the schema instead would make
+//! every existing bundle fail hard at the `UnsupportedSchemaVersion`
+//! gate for a purely additive change.
+//!
+//! ## Locking
+//!
+//! The import holds the global import lock for P1..P8 (`mod.rs`),
+//! mutually exclusive with rename / repair / move. Do **not** acquire
+//! a second lock here — these functions are called from inside it.
+//!
+//! ## Why `project` is rewritten but not hashed
+//!
+//! A `history.jsonl` line carries an absolute `project` path, which
+//! the substitution table rewrites on import. The dedupe key is
+//! therefore `(sessionId, hash(prompt))` and never the whole line: an
+//! entry that arrived before the rewrite and the same entry after it
+//! are the same entry, and hashing the line would import a duplicate
+//! of every one of them.
+
+use crate::migrate::apply;
+use crate::migrate::bundle::BundleWriter;
+use crate::migrate::error::MigrateError;
+use crate::migrate::plan::SubstitutionTable;
+use crate::migrate::rewrite;
+use serde_json::{Map, Value};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const CLAUDE_JSON_FRAGMENT: &str = "claude-json-fragment.json";
+pub const HISTORY_FRAGMENT: &str = "history-fragment.jsonl";
+
+/// The `.claude.json` belonging to `config_dir`.
+///
+/// Deliberately derived from the passed config dir rather than via
+/// `paths::resolved_global_claude_json()`: migrate is always given an
+/// explicit config dir (a temp tree under test, a real one in
+/// production), and a global resolver would read the developer's own
+/// `~/.claude.json` during an export from a fixture.
+///
+/// Precedence mirrors CC's `getGlobalClaudeFile`: the legacy
+/// `<config>/.config.json`, then `<config>/.claude.json` (the
+/// `CLAUDE_CONFIG_DIR` layout), then the `~/.claude` sibling.
+pub fn claude_json_for(config_dir: &Path) -> Option<PathBuf> {
+    let legacy = config_dir.join(".config.json");
+    if legacy.is_file() {
+        return Some(legacy);
+    }
+    let inside = config_dir.join(".claude.json");
+    if inside.is_file() {
+        return Some(inside);
+    }
+    let sibling = config_dir.parent()?.join(".claude.json");
+    sibling.is_file().then_some(sibling)
+}
+
+/// `history.jsonl` belonging to `config_dir`.
+pub fn history_for(config_dir: &Path) -> PathBuf {
+    config_dir.join("history.jsonl")
+}
+
+// ---------------------------------------------------------------------------
+// Export side
+// ---------------------------------------------------------------------------
+
+/// Append both fragments for one project. Returns how many entries were
+/// written (0..=2) so the caller can keep its file count honest.
+///
+/// Every absence is normal, not an error: a fresh machine has no
+/// `~/.claude.json`, a project may have no entry in it, and a machine
+/// that has never used the prompt history has no `history.jsonl`.
+pub fn append_fragments(
+    writer: &mut BundleWriter,
+    project_id: &str,
+    config_dir: &Path,
+    source_cwd: &str,
+    session_ids: &[String],
+) -> Result<usize, MigrateError> {
+    let mut written = 0;
+
+    if let Some(bytes) = extract_claude_json_fragment(config_dir, source_cwd) {
+        writer.append_bytes(
+            &format!("projects/{project_id}/{CLAUDE_JSON_FRAGMENT}"),
+            &bytes,
+            0o600,
+        )?;
+        written += 1;
+    }
+
+    if let Some(bytes) = extract_history_fragment(config_dir, session_ids) {
+        writer.append_bytes(
+            &format!("projects/{project_id}/{HISTORY_FRAGMENT}"),
+            &bytes,
+            0o600,
+        )?;
+        written += 1;
+    }
+
+    Ok(written)
+}
+
+/// The source's `projects[<source_cwd>]` value, serialized. `None` when
+/// the file is absent, unparseable, or carries no such key.
+pub fn extract_claude_json_fragment(config_dir: &Path, source_cwd: &str) -> Option<Vec<u8>> {
+    let path = claude_json_for(config_dir)?;
+    let text = fs::read_to_string(&path).ok()?;
+    let root: Value = serde_json::from_str(&text).ok()?;
+    let value = root.get("projects")?.get(source_cwd)?;
+    serde_json::to_vec_pretty(value).ok()
+}
+
+/// History lines whose `sessionId` is in `session_ids`, in source
+/// order. `None` when the file is absent or nothing matches.
+pub fn extract_history_fragment(config_dir: &Path, session_ids: &[String]) -> Option<Vec<u8>> {
+    let text = fs::read_to_string(history_for(config_dir)).ok()?;
+    let wanted: HashSet<&str> = session_ids.iter().map(|s| s.as_str()).collect();
+    let mut out = String::new();
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        // A line we cannot parse is not ours to claim; leave it home.
+        let Ok(obj) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if obj
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| wanted.contains(s))
+        {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    (!out.is_empty()).then(|| out.into_bytes())
+}
+
+// ---------------------------------------------------------------------------
+// Import side
+// ---------------------------------------------------------------------------
+
+/// One applied fragment: the file touched, plus the snapshot of its
+/// prior content for `undo`.
+#[derive(Debug, Clone)]
+pub struct FragmentStep {
+    pub after: String,
+    pub snapshot_path: Option<String>,
+    /// Set for the `~/.claude.json` step: the `projects` key written.
+    pub fragment_key: Option<String>,
+}
+
+/// §5.6 — re-key the fragment onto `projects[target_cwd]`, rewriting
+/// embedded absolute paths through `table`.
+///
+/// Collision policy is §6's `merge`: shallow merge per top-level key,
+/// imported wins, keys the import does not carry survive on the target.
+pub fn apply_claude_json_fragment(
+    staged_project_root: &Path,
+    config_dir: &Path,
+    target_cwd: &str,
+    table: &SubstitutionTable,
+    bundle_id: &str,
+) -> Result<Option<FragmentStep>, MigrateError> {
+    let staged = staged_project_root.join(CLAUDE_JSON_FRAGMENT);
+    if !staged.is_file() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&staged).map_err(MigrateError::from)?;
+    let mut fragment: Value =
+        serde_json::from_slice(&bytes).map_err(|e| MigrateError::Serialize(e.to_string()))?;
+    // Rewrites `activeWorktreeSession.originalCwd`, `.worktreePath`,
+    // absolute-path `mcpServers[*].command`, and any other embedded
+    // path — the table is the same one the slug tree used.
+    rewrite::rewrite_value(&mut fragment, table);
+
+    // Target file: the `~/.claude` sibling when it doesn't exist yet.
+    let target = claude_json_for(config_dir).unwrap_or_else(|| {
+        config_dir
+            .parent()
+            .unwrap_or(config_dir)
+            .join(".claude.json")
+    });
+    let snapshot = apply::snapshot_file(bundle_id, &target)?;
+
+    let mut root: Value = match fs::read_to_string(&target) {
+        Ok(t) => serde_json::from_str(&t).unwrap_or_else(|_| Value::Object(Map::new())),
+        Err(_) => Value::Object(Map::new()),
+    };
+    if !root.is_object() {
+        root = Value::Object(Map::new());
+    }
+    let obj = root.as_object_mut().expect("object by construction");
+    let projects = obj
+        .entry("projects")
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !projects.is_object() {
+        *projects = Value::Object(Map::new());
+    }
+    let projects = projects.as_object_mut().expect("object by construction");
+
+    match (projects.get(target_cwd), fragment) {
+        // Shallow merge: imported wins per key, target keeps the rest.
+        (Some(Value::Object(existing)), Value::Object(incoming)) => {
+            let mut merged = existing.clone();
+            for (k, v) in incoming {
+                merged.insert(k, v);
+            }
+            projects.insert(target_cwd.to_string(), Value::Object(merged));
+        }
+        (_, incoming) => {
+            projects.insert(target_cwd.to_string(), incoming);
+        }
+    }
+
+    write_atomic(
+        &target,
+        &serde_json::to_vec_pretty(&root).map_err(|e| MigrateError::Serialize(e.to_string()))?,
+    )?;
+
+    Ok(Some(FragmentStep {
+        after: target.to_string_lossy().to_string(),
+        snapshot_path: snapshot.map(|p| p.to_string_lossy().to_string()),
+        fragment_key: Some(target_cwd.to_string()),
+    }))
+}
+
+/// §5.7 — append the history fragment, deduping by
+/// `(sessionId, hash(prompt))`. Existing target lines are never
+/// rewritten, reordered, or dropped; new lines land after them.
+pub fn apply_history_fragment(
+    staged_project_root: &Path,
+    config_dir: &Path,
+    table: &SubstitutionTable,
+    bundle_id: &str,
+) -> Result<Option<FragmentStep>, MigrateError> {
+    let staged = staged_project_root.join(HISTORY_FRAGMENT);
+    if !staged.is_file() {
+        return Ok(None);
+    }
+    let incoming = fs::read_to_string(&staged).map_err(MigrateError::from)?;
+    let target = history_for(config_dir);
+    let existing = fs::read_to_string(&target).unwrap_or_default();
+
+    let mut seen: HashSet<String> = existing.lines().filter_map(dedupe_key).collect();
+
+    let mut appended = String::new();
+    for line in incoming.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let (rewritten, _) = rewrite::rewrite_jsonl_line_multi(line, table);
+        match dedupe_key(rewritten.as_str()) {
+            // Unparseable or key-less lines are dropped rather than
+            // appended blind — without a key we cannot tell a genuine
+            // new entry from one already present, and re-importing
+            // would grow the file without bound.
+            None => continue,
+            Some(k) => {
+                if seen.insert(k) {
+                    appended.push_str(&rewritten);
+                    appended.push('\n');
+                }
+            }
+        }
+    }
+    if appended.is_empty() {
+        return Ok(None);
+    }
+
+    let snapshot = apply::snapshot_file(bundle_id, &target)?;
+    let mut out = existing;
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(&appended);
+    write_atomic(&target, out.as_bytes())?;
+
+    Ok(Some(FragmentStep {
+        after: target.to_string_lossy().to_string(),
+        snapshot_path: snapshot.map(|p| p.to_string_lossy().to_string()),
+        fragment_key: None,
+    }))
+}
+
+/// `(sessionId, hash(prompt))` per §5.7. `None` when the line is not
+/// JSON or carries no `sessionId`.
+fn dedupe_key(line: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(line).ok()?;
+    let sid = v.get("sessionId")?.as_str()?;
+    // CC names the prompt `display`. Absent, an empty prompt still
+    // dedupes correctly against another empty prompt in the session.
+    let prompt = v.get("display").and_then(|d| d.as_str()).unwrap_or("");
+    use sha2::Digest;
+    let mut h = sha2::Sha256::new();
+    h.update(prompt.as_bytes());
+    Some(format!("{sid}\u{0}{}", hex::encode(h.finalize())))
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), MigrateError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(MigrateError::from)?;
+    }
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(parent).map_err(MigrateError::from)?;
+    std::io::Write::write_all(&mut tmp, bytes).map_err(MigrateError::from)?;
+    tmp.persist(path).map_err(|e| MigrateError::from(e.error))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrate::plan::RuleOrigin;
+
+    fn table(from: &str, to: &str) -> SubstitutionTable {
+        let mut t = SubstitutionTable::new();
+        t.push(from, to, RuleOrigin::ProjectCwd);
+        t.finalize();
+        t
+    }
+
+    fn cfg(tmp: &Path) -> PathBuf {
+        let c = tmp.join(".claude");
+        fs::create_dir_all(&c).unwrap();
+        c
+    }
+
+    #[test]
+    fn claude_json_prefers_config_dir_over_sibling() {
+        let td = tempfile::tempdir().unwrap();
+        let c = cfg(td.path());
+        fs::write(td.path().join(".claude.json"), "{}").unwrap();
+        assert_eq!(claude_json_for(&c).unwrap(), td.path().join(".claude.json"));
+        fs::write(c.join(".claude.json"), "{}").unwrap();
+        assert_eq!(claude_json_for(&c).unwrap(), c.join(".claude.json"));
+    }
+
+    #[test]
+    fn extract_claude_json_returns_none_when_key_absent() {
+        let td = tempfile::tempdir().unwrap();
+        let c = cfg(td.path());
+        fs::write(
+            td.path().join(".claude.json"),
+            r#"{"projects":{"/other":{"a":1}}}"#,
+        )
+        .unwrap();
+        assert!(extract_claude_json_fragment(&c, "/mine").is_none());
+        assert!(extract_claude_json_fragment(&c, "/other").is_some());
+    }
+
+    #[test]
+    fn extract_history_filters_by_session_id() {
+        let td = tempfile::tempdir().unwrap();
+        let c = cfg(td.path());
+        fs::write(
+            history_for(&c),
+            "{\"sessionId\":\"a\",\"display\":\"one\"}\n\
+             {\"sessionId\":\"b\",\"display\":\"two\"}\n\
+             not json\n",
+        )
+        .unwrap();
+        let out = extract_history_fragment(&c, &["a".to_string()]).unwrap();
+        let s = String::from_utf8(out).unwrap();
+        assert!(s.contains("\"a\""));
+        assert!(!s.contains("\"b\""));
+        assert_eq!(s.lines().count(), 1);
+    }
+
+    #[test]
+    fn extract_history_none_when_nothing_matches() {
+        let td = tempfile::tempdir().unwrap();
+        let c = cfg(td.path());
+        fs::write(history_for(&c), "{\"sessionId\":\"z\"}\n").unwrap();
+        assert!(extract_history_fragment(&c, &["a".to_string()]).is_none());
+    }
+
+    #[test]
+    fn apply_claude_json_shallow_merges_imported_over_target() {
+        let td = tempfile::tempdir().unwrap();
+        let c = cfg(td.path());
+        let staged = td.path().join("staged");
+        fs::create_dir_all(&staged).unwrap();
+        fs::write(
+            staged.join(CLAUDE_JSON_FRAGMENT),
+            r#"{"allowedTools":["imported"],"newKey":1}"#,
+        )
+        .unwrap();
+        fs::write(
+            td.path().join(".claude.json"),
+            r#"{"projects":{"/tgt":{"allowedTools":["target"],"keepMe":true}},"other":9}"#,
+        )
+        .unwrap();
+
+        let step = apply_claude_json_fragment(&staged, &c, "/tgt", &table("/src", "/tgt"), "b1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(step.fragment_key.as_deref(), Some("/tgt"));
+
+        let root: Value =
+            serde_json::from_str(&fs::read_to_string(td.path().join(".claude.json")).unwrap())
+                .unwrap();
+        let p = &root["projects"]["/tgt"];
+        assert_eq!(p["allowedTools"][0], "imported", "imported wins per key");
+        assert_eq!(p["keepMe"], true, "target-only key survives");
+        assert_eq!(p["newKey"], 1);
+        assert_eq!(root["other"], 9, "unrelated top-level keys untouched");
+    }
+
+    #[test]
+    fn apply_claude_json_rewrites_embedded_paths() {
+        let td = tempfile::tempdir().unwrap();
+        let c = cfg(td.path());
+        let staged = td.path().join("staged");
+        fs::create_dir_all(&staged).unwrap();
+        fs::write(
+            staged.join(CLAUDE_JSON_FRAGMENT),
+            r#"{"activeWorktreeSession":{"originalCwd":"/src/x"}}"#,
+        )
+        .unwrap();
+
+        apply_claude_json_fragment(&staged, &c, "/tgt", &table("/src", "/tgt"), "b1").unwrap();
+
+        let root: Value =
+            serde_json::from_str(&fs::read_to_string(td.path().join(".claude.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            root["projects"]["/tgt"]["activeWorktreeSession"]["originalCwd"],
+            "/tgt/x"
+        );
+    }
+
+    #[test]
+    fn apply_history_appends_and_preserves_existing_order() {
+        let td = tempfile::tempdir().unwrap();
+        let c = cfg(td.path());
+        let staged = td.path().join("staged");
+        fs::create_dir_all(&staged).unwrap();
+        fs::write(
+            history_for(&c),
+            "{\"sessionId\":\"old\",\"display\":\"first\"}\n",
+        )
+        .unwrap();
+        fs::write(
+            staged.join(HISTORY_FRAGMENT),
+            "{\"sessionId\":\"new\",\"display\":\"second\",\"project\":\"/src\"}\n",
+        )
+        .unwrap();
+
+        apply_history_fragment(&staged, &c, &table("/src", "/tgt"), "b1").unwrap();
+
+        let out = fs::read_to_string(history_for(&c)).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("\"old\""), "existing line stays first");
+        assert!(lines[1].contains("\"new\""));
+        assert!(lines[1].contains("/tgt"), "project path rewritten");
+    }
+
+    /// Re-importing the same bundle must add nothing — the property
+    /// that makes repeated transport safe.
+    #[test]
+    fn apply_history_is_idempotent() {
+        let td = tempfile::tempdir().unwrap();
+        let c = cfg(td.path());
+        let staged = td.path().join("staged");
+        fs::create_dir_all(&staged).unwrap();
+        fs::write(
+            staged.join(HISTORY_FRAGMENT),
+            "{\"sessionId\":\"s\",\"display\":\"hello\"}\n",
+        )
+        .unwrap();
+        let t = table("/src", "/tgt");
+
+        assert!(apply_history_fragment(&staged, &c, &t, "b1")
+            .unwrap()
+            .is_some());
+        let once = fs::read_to_string(history_for(&c)).unwrap();
+        assert!(apply_history_fragment(&staged, &c, &t, "b2")
+            .unwrap()
+            .is_none());
+        assert_eq!(fs::read_to_string(history_for(&c)).unwrap(), once);
+    }
+
+    /// Same session, different prompt, is a different entry.
+    #[test]
+    fn apply_history_dedupes_on_prompt_not_session_alone() {
+        let td = tempfile::tempdir().unwrap();
+        let c = cfg(td.path());
+        let staged = td.path().join("staged");
+        fs::create_dir_all(&staged).unwrap();
+        fs::write(history_for(&c), "{\"sessionId\":\"s\",\"display\":\"a\"}\n").unwrap();
+        fs::write(
+            staged.join(HISTORY_FRAGMENT),
+            "{\"sessionId\":\"s\",\"display\":\"a\"}\n\
+             {\"sessionId\":\"s\",\"display\":\"b\"}\n",
+        )
+        .unwrap();
+
+        apply_history_fragment(&staged, &c, &table("/src", "/tgt"), "b1").unwrap();
+
+        let out = fs::read_to_string(history_for(&c)).unwrap();
+        assert_eq!(out.lines().count(), 2, "only the new prompt is appended");
+    }
+
+    #[test]
+    fn missing_fragments_are_not_an_error() {
+        let td = tempfile::tempdir().unwrap();
+        let c = cfg(td.path());
+        let staged = td.path().join("staged");
+        fs::create_dir_all(&staged).unwrap();
+        let t = table("/src", "/tgt");
+        assert!(apply_claude_json_fragment(&staged, &c, "/tgt", &t, "b1")
+            .unwrap()
+            .is_none());
+        assert!(apply_history_fragment(&staged, &c, &t, "b1")
+            .unwrap()
+            .is_none());
+    }
+}

--- a/crates/claudepot-core/src/migrate/golden_tests/cc_state.rs
+++ b/crates/claudepot-core/src/migrate/golden_tests/cc_state.rs
@@ -161,6 +161,7 @@ fn row21_round_trip_export_inspect_export_diff() {
             account_stubs: None,
             encrypt_passphrase: None,
             sign_password: None,
+            since_peer: None,
         },
     )
     .unwrap();
@@ -188,6 +189,7 @@ fn row21_round_trip_export_inspect_export_diff() {
             account_stubs: None,
             encrypt_passphrase: None,
             sign_password: None,
+            since_peer: None,
         },
     )
     .unwrap();

--- a/crates/claudepot-core/src/migrate/golden_tests/trust_gates.rs
+++ b/crates/claudepot-core/src/migrate/golden_tests/trust_gates.rs
@@ -151,6 +151,7 @@ fn row32_encrypt_returns_not_implemented_no_partial_state() {
         account_stubs: None,
         encrypt_passphrase: None,
         sign_password: None,
+        since_peer: None,
     };
     let err = crate::migrate::export_projects(&cfg, opts).unwrap_err();
     // After v1 encryption support landed, missing passphrase became a

--- a/crates/claudepot-core/src/migrate/merge.rs
+++ b/crates/claudepot-core/src/migrate/merge.rs
@@ -1,0 +1,389 @@
+//! Merge-mode apply — union a staged slug tree into an *existing*
+//! target slug tree under a uniform prefer policy.
+//!
+//! See `dev-docs/archive/project-migrate-spec.md` §6.
+//!
+//! ## Why this is a file-level union and not a content merge
+//!
+//! Spec §6 is explicit that conflict resolution is "project-level
+//! only. There is no per-session UI; the engine handles session-id
+//! collisions inside `merge` mode under a uniform policy." So a
+//! session that exists on both sides is resolved *whole*: one copy
+//! wins, the other is preserved out-of-band (snapshot, for undo).
+//! Nothing interleaves two transcripts.
+//!
+//! That is the same call CC makes when one sessionId resolves to
+//! several files — newest mtime wins, no merge
+//! (`listSessionsImpl.ts:246-261`) — and the same call the analysis
+//! corpus makes (`corpus.rs:572`, most-complete copy wins). Merging
+//! transcript *content* would need a common ancestor, which a bundle
+//! does not carry; §1 scopes that to a separate continuous-sync
+//! feature.
+//!
+//! ## Ordering contract
+//!
+//! Every replaced file is snapshotted *before* it is overwritten, so
+//! the journal's `snapshot_path` always points at recoverable bytes.
+//! A failure between snapshot and place leaves the target untouched;
+//! a failure after leaves a journal step whose rollback restores the
+//! snapshot.
+
+use crate::migrate::apply;
+use crate::migrate::conflicts::MergePreference;
+use crate::migrate::error::MigrateError;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// What happened to one file during a merge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeApplyKind {
+    /// Target had no file at this relative path; the imported copy
+    /// landed. Rollback deletes it.
+    Added,
+    /// Both sides had the file and `prefer = Imported`: the target's
+    /// copy was snapshotted, then overwritten. Rollback restores the
+    /// snapshot.
+    Replaced,
+    /// Both sides had the file and `prefer = Target`: the target's
+    /// copy stands and the imported one is dropped. Nothing to roll
+    /// back.
+    KeptTarget,
+}
+
+/// One file's disposition. Mirrors `worktree::WorktreeApplyStep`'s
+/// shape so `mod.rs` maps both into `apply::JournalStep` the same way.
+#[derive(Debug, Clone)]
+pub struct MergeStep {
+    pub kind: MergeApplyKind,
+    /// Absolute path of the file in the target tree.
+    pub after: String,
+    /// Where the target's prior content was archived. `Some` only for
+    /// `Replaced`.
+    pub snapshot_path: Option<String>,
+}
+
+/// Top-level session ids present in a CC slug directory.
+///
+/// CC names a transcript `<sessionId>.jsonl` at the top level of the
+/// slug dir; nested dirs (`subagents/`, `memory/`) are not sessions.
+/// The stem *is* the identity — CC derives it from the filename and
+/// validates it as a UUID (`listSessionsImpl.ts:183-185`), and so does
+/// Claudepot (`session/core.rs:549`). Reading the id out of the JSONL
+/// body would disagree with both.
+///
+/// Returns an empty set when `dir` is absent or unreadable — callers
+/// treat that as "no overlap", which is correct for a target slug that
+/// does not exist yet.
+pub fn session_ids_in(dir: &Path) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let Ok(rd) = fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in rd.flatten() {
+        if !entry.file_type().is_ok_and(|t| t.is_file()) {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "jsonl") {
+            if let Some(stem) = path.file_stem() {
+                out.insert(stem.to_string_lossy().to_string());
+            }
+        }
+    }
+    out
+}
+
+/// Session ids in a bundle's slug tree, read from the manifest's file
+/// inventory instead of from disk.
+///
+/// The dry run runs before extraction, so it has no staging tree to
+/// walk. This applies the *same* rule as [`session_ids_in`] —
+/// top-level `*.jsonl` stems only — so a dry run predicts the
+/// resolution apply will reach. Two different notions of "which
+/// sessions does this bundle carry" would let the plan disagree with
+/// the outcome, which is the one thing a dry run must never do.
+///
+/// `slug_prefix` is the bundle-relative directory prefix, trailing
+/// separator included.
+pub fn session_ids_in_inventory<'a>(
+    paths: impl IntoIterator<Item = &'a str>,
+    slug_prefix: &str,
+) -> BTreeSet<String> {
+    paths
+        .into_iter()
+        .filter_map(|p| p.strip_prefix(slug_prefix))
+        // Bundle paths are always `/`-joined; nested means not a session.
+        .filter(|rest| !rest.contains('/'))
+        .filter_map(|rest| rest.strip_suffix(".jsonl"))
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Union `staged_slug_root` into `target_slug_dir`, which must already
+/// exist (the caller only reaches merge when the target slug is
+/// present). Returns one step per staged file.
+///
+/// Files are placed individually rather than by directory rename: the
+/// target tree holds sessions the bundle knows nothing about, and a
+/// directory rename would erase them.
+/// `steps` is an **out-parameter, not a return value**, on purpose: a
+/// failure partway through has already moved files onto the target, and
+/// the caller must journal those before propagating. Returning
+/// `Result<Vec<MergeStep>>` discarded them on the error path, leaving
+/// placed files unjournaled — invisible to rollback, with their
+/// snapshots orphaned.
+pub fn merge_slug_tree(
+    staged_slug_root: &Path,
+    target_slug_dir: &Path,
+    prefer: MergePreference,
+    bundle_id: &str,
+    steps: &mut Vec<MergeStep>,
+) -> Result<(), MigrateError> {
+    // `collect_dir_inventory` walks recursively and yields `/`-joined
+    // paths relative to the root, on every platform.
+    for rel in apply::collect_dir_inventory(staged_slug_root) {
+        let from = join_rel(staged_slug_root, &rel);
+        let to = join_rel(target_slug_dir, &rel);
+
+        if to.exists() {
+            match prefer {
+                MergePreference::Target => {
+                    steps.push(MergeStep {
+                        kind: MergeApplyKind::KeptTarget,
+                        after: to.to_string_lossy().to_string(),
+                        snapshot_path: None,
+                    });
+                }
+                MergePreference::Imported => {
+                    // Snapshot BEFORE the overwrite — see the ordering
+                    // contract in the module docs.
+                    let snap = apply::snapshot_file(bundle_id, &to)?;
+                    place_file(&from, &to)?;
+                    steps.push(MergeStep {
+                        kind: MergeApplyKind::Replaced,
+                        after: to.to_string_lossy().to_string(),
+                        snapshot_path: snap.map(|p| p.to_string_lossy().to_string()),
+                    });
+                }
+            }
+        } else {
+            place_file(&from, &to)?;
+            steps.push(MergeStep {
+                kind: MergeApplyKind::Added,
+                after: to.to_string_lossy().to_string(),
+                snapshot_path: None,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Join a `/`-separated relative path onto `base` using native
+/// separators. `collect_dir_inventory` normalizes `\` to `/` on
+/// Windows, so this reverses that for the filesystem call.
+fn join_rel(base: &Path, rel: &str) -> PathBuf {
+    let mut p = base.to_path_buf();
+    for seg in rel.split('/').filter(|s| !s.is_empty()) {
+        p.push(seg);
+    }
+    p
+}
+
+/// Move `from` onto `to`, creating parents. Falls back to copy when the
+/// two sit on different volumes — staging lives under `~/.claudepot`
+/// and the target under `~/.claude`, which are usually but not always
+/// the same filesystem. Mirrors the EXDEV handling in `mod.rs`'s
+/// whole-tree rename.
+fn place_file(from: &Path, to: &Path) -> Result<(), MigrateError> {
+    if let Some(parent) = to.parent() {
+        fs::create_dir_all(parent).map_err(MigrateError::from)?;
+    }
+    match fs::rename(from, to) {
+        Ok(()) => Ok(()),
+        Err(e)
+            if e.kind() == std::io::ErrorKind::CrossesDevices
+                || e.raw_os_error() == Some(libc::EXDEV) =>
+        {
+            fs::copy(from, to).map_err(MigrateError::from)?;
+            let _ = fs::remove_file(from);
+            Ok(())
+        }
+        Err(e) => Err(MigrateError::from(e)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(p: &Path, body: &str) {
+        if let Some(parent) = p.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(p, body).unwrap();
+    }
+
+    #[test]
+    fn session_ids_reads_top_level_jsonl_stems_only() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path();
+        write(&root.join("aaa.jsonl"), "{}");
+        write(&root.join("bbb.jsonl"), "{}");
+        // Not sessions: wrong extension, and a nested transcript.
+        write(&root.join("notes.meta.json"), "{}");
+        write(&root.join("aaa").join("subagents").join("ccc.jsonl"), "{}");
+
+        let ids = session_ids_in(root);
+        assert_eq!(
+            ids.into_iter().collect::<Vec<_>>(),
+            vec!["aaa".to_string(), "bbb".to_string()]
+        );
+    }
+
+    #[test]
+    fn session_ids_of_missing_dir_is_empty() {
+        let td = tempfile::tempdir().unwrap();
+        assert!(session_ids_in(&td.path().join("nope")).is_empty());
+    }
+
+    #[test]
+    fn merge_adds_files_the_target_lacks() {
+        let td = tempfile::tempdir().unwrap();
+        let staged = td.path().join("staged");
+        let target = td.path().join("target");
+        write(&staged.join("new.jsonl"), "imported");
+        fs::create_dir_all(&target).unwrap();
+
+        let mut steps = Vec::new();
+        merge_slug_tree(
+            &staged,
+            &target,
+            MergePreference::Imported,
+            "b1",
+            &mut steps,
+        )
+        .unwrap();
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].kind, MergeApplyKind::Added);
+        assert_eq!(
+            fs::read_to_string(target.join("new.jsonl")).unwrap(),
+            "imported"
+        );
+    }
+
+    /// The union property: sessions the bundle never heard of must
+    /// survive. A whole-directory rename would have erased this file.
+    #[test]
+    fn merge_preserves_target_only_sessions() {
+        let td = tempfile::tempdir().unwrap();
+        let staged = td.path().join("staged");
+        let target = td.path().join("target");
+        write(&staged.join("from-peer.jsonl"), "imported");
+        write(&target.join("local-only.jsonl"), "mine");
+
+        let mut steps = Vec::new();
+        merge_slug_tree(
+            &staged,
+            &target,
+            MergePreference::Imported,
+            "b1",
+            &mut steps,
+        )
+        .unwrap();
+        let _ = &steps;
+
+        assert_eq!(
+            fs::read_to_string(target.join("local-only.jsonl")).unwrap(),
+            "mine",
+            "a session absent from the bundle must survive the merge"
+        );
+        assert_eq!(
+            fs::read_to_string(target.join("from-peer.jsonl")).unwrap(),
+            "imported"
+        );
+    }
+
+    #[test]
+    fn prefer_imported_overwrites_and_snapshots() {
+        let td = tempfile::tempdir().unwrap();
+        let staged = td.path().join("staged");
+        let target = td.path().join("target");
+        write(&staged.join("dup.jsonl"), "imported");
+        write(&target.join("dup.jsonl"), "target");
+
+        let mut steps = Vec::new();
+        merge_slug_tree(
+            &staged,
+            &target,
+            MergePreference::Imported,
+            "b-imp",
+            &mut steps,
+        )
+        .unwrap();
+
+        assert_eq!(steps[0].kind, MergeApplyKind::Replaced);
+        assert_eq!(
+            fs::read_to_string(target.join("dup.jsonl")).unwrap(),
+            "imported"
+        );
+        let snap = steps[0].snapshot_path.as_ref().expect("snapshot recorded");
+        assert_eq!(
+            fs::read_to_string(snap).unwrap(),
+            "target",
+            "the overwritten copy must be recoverable for undo"
+        );
+    }
+
+    #[test]
+    fn prefer_target_keeps_target_and_takes_no_snapshot() {
+        let td = tempfile::tempdir().unwrap();
+        let staged = td.path().join("staged");
+        let target = td.path().join("target");
+        write(&staged.join("dup.jsonl"), "imported");
+        write(&target.join("dup.jsonl"), "target");
+
+        let mut steps = Vec::new();
+        merge_slug_tree(
+            &staged,
+            &target,
+            MergePreference::Target,
+            "b-tgt",
+            &mut steps,
+        )
+        .unwrap();
+
+        assert_eq!(steps[0].kind, MergeApplyKind::KeptTarget);
+        assert!(steps[0].snapshot_path.is_none());
+        assert_eq!(
+            fs::read_to_string(target.join("dup.jsonl")).unwrap(),
+            "target"
+        );
+    }
+
+    #[test]
+    fn merge_walks_nested_dirs() {
+        let td = tempfile::tempdir().unwrap();
+        let staged = td.path().join("staged");
+        let target = td.path().join("target");
+        write(&staged.join("sid").join("subagents").join("a.jsonl"), "sub");
+        fs::create_dir_all(&target).unwrap();
+
+        let mut steps = Vec::new();
+        merge_slug_tree(
+            &staged,
+            &target,
+            MergePreference::Imported,
+            "b1",
+            &mut steps,
+        )
+        .unwrap();
+
+        assert_eq!(steps.len(), 1);
+        assert_eq!(
+            fs::read_to_string(target.join("sid").join("subagents").join("a.jsonl")).unwrap(),
+            "sub"
+        );
+    }
+}

--- a/crates/claudepot-core/src/migrate/mod.rs
+++ b/crates/claudepot-core/src/migrate/mod.rs
@@ -83,8 +83,11 @@ pub(crate) mod bundle;
 pub(crate) mod crypto;
 pub(crate) mod error;
 pub(crate) mod file_history;
+pub(crate) mod fragment;
 pub(crate) mod global;
+pub(crate) mod merge;
 pub(crate) mod nfc;
+pub mod peer;
 pub(crate) mod plan;
 pub(crate) mod quarantine;
 pub(crate) mod rewrite;
@@ -126,6 +129,11 @@ pub struct ExportOptions {
     /// `Some("")` for unprotected keys; `None` falls back to empty
     /// (no interactive prompt — see `crypto::sign_bundle`).
     pub sign_password: Option<String>,
+    /// Export only what changed since the last export to this peer id.
+    /// `None` exports everything (the one-shot migrate behavior).
+    /// See `migrate::peer` for why this is a fingerprint diff and not
+    /// a high-water mark.
+    pub since_peer: Option<String>,
     /// Optional account stubs to include when
     /// `include_claudepot_state` is true. Caller pre-builds via
     /// `state::account_stubs_from_store` (we don't take a `&AccountStore`
@@ -179,6 +187,12 @@ pub fn export_projects(
     let mut projects = Vec::new();
     let mut file_count = 0usize;
 
+    // Delta-export state. Loaded once; the new fingerprints are recorded
+    // only after the bundle finalizes, so a failed export never claims
+    // files were shipped.
+    let peer_store = opts.since_peer.as_ref().map(|_| peer::load());
+    let mut peer_updates: Vec<(String, Vec<crate::session_index::diff::IndexTuple>)> = Vec::new();
+
     for cwd in &opts.project_cwds {
         let nfc_cwd = nfc::nfc(&crate::path_utils::simplify_windows_path(cwd));
         let slug = sanitize_path(&nfc_cwd);
@@ -197,7 +211,35 @@ pub fn export_projects(
         // double-record them on the per-project manifest, so we only
         // need the count back here.
         let prefix = format!("projects/{}/claude/projects/{}", project_id, slug);
-        let project_file_count = walk_and_append(&slug_dir, &slug_dir, &prefix, &mut writer)?;
+
+        // Delta scope. `to_upsert` is new-or-changed in either
+        // direction, so a file `slim` shrank re-exports; `to_delete`
+        // becomes tombstones the importer surfaces without acting on.
+        let fs_now = peer::fingerprint_dir(&slug_dir);
+        let (only, tombstones) = match (opts.since_peer.as_deref(), peer_store.as_ref()) {
+            (Some(peer_id), Some(store)) => {
+                let plan = peer::delta(store, peer_id, &nfc_cwd, &fs_now);
+                let set: std::collections::HashSet<String> = plan.to_upsert.into_iter().collect();
+                (Some(set), plan.to_delete)
+            }
+            _ => (None, Vec::new()),
+        };
+        let project_file_count =
+            walk_and_append(&slug_dir, &slug_dir, &prefix, &mut writer, only.as_ref())?;
+
+        if !tombstones.is_empty() {
+            let bytes = serde_json::to_vec_pretty(&tombstones)
+                .map_err(|e| MigrateError::Serialize(e.to_string()))?;
+            writer.append_bytes(
+                &format!("projects/{project_id}/{}", peer::TOMBSTONES_ENTRY),
+                &bytes,
+                0o600,
+            )?;
+            file_count += 1;
+        }
+        if opts.since_peer.is_some() {
+            peer_updates.push((nfc_cwd.clone(), fs_now));
+        }
 
         // Collect sessionIds from `*.jsonl` filenames at the slug root.
         for entry in fs::read_dir(&slug_dir).map_err(MigrateError::from)? {
@@ -214,6 +256,17 @@ pub fn export_projects(
 
         let session_count = session_ids.len() as u32;
         file_count += project_file_count;
+
+        // §5.6 / §5.7 fragments — CC state for this project that lives
+        // outside the slug tree. Additive entries; absence is normal
+        // and never an error (see `fragment`'s module docs).
+        file_count += fragment::append_fragments(
+            &mut writer,
+            &project_id,
+            config_dir,
+            &nfc_cwd,
+            &session_ids,
+        )?;
 
         // Optional: tarball <cwd>/.claude/** + <cwd>/CLAUDE.md when
         // --include-worktree was set. The cwd may not exist on the
@@ -367,6 +420,24 @@ pub fn export_projects(
             std::path::Path::new(keyfile),
             opts.sign_password.clone(),
         )?;
+    }
+
+    // Record what this peer now holds — last, so an export that failed
+    // anywhere above leaves the prior state intact and the next run
+    // re-ships rather than silently skipping.
+    if let (Some(peer_id), Some(mut store)) = (opts.since_peer.as_deref(), peer_store) {
+        for (cwd, fps) in &peer_updates {
+            peer::record(&mut store, peer_id, cwd, fps);
+        }
+        if let Err(e) = peer::save(&store) {
+            // The bundle is already written and valid; failing the whole
+            // export here would be worse than re-shipping next time.
+            tracing::warn!(
+                target = "claudepot_core::migrate",
+                error = %e,
+                "delta-export state could not be saved; the next export to this peer will be full"
+            );
+        }
     }
 
     Ok(ExportReceipt {
@@ -601,6 +672,15 @@ pub struct ImportReceipt {
     /// Account stubs surface to the user as "the source had these;
     /// re-login here." Never auto-inserted (spec §16 Q2).
     pub accounts_listed: Vec<state::AccountStub>,
+    /// Slug-relative paths that left the source since its last export
+    /// to this peer (delta export only).
+    ///
+    /// **Reported, never acted on.** The source may have run a
+    /// retention sweep this machine's user does not want mirrored;
+    /// deleting their last copy of a transcript because another
+    /// machine aged it out is precisely the silent loss this design
+    /// refuses. A human decides.
+    pub tombstones: Vec<String>,
 }
 
 /// Import a bundle. v0 implements the dry-run path end-to-end and the
@@ -691,30 +771,64 @@ pub fn import_bundle(
     let mut projects_imported = Vec::new();
     let mut projects_refused = Vec::new();
     let mut accounts_listed: Vec<state::AccountStub> = Vec::new();
+    let mut tombstones: Vec<String> = Vec::new();
 
     if opts.dry_run {
         // P0+P2 only — no extraction. Caller gets the project plan
         // via `inspect`; this returns the resolution decisions.
         for pref in &manifest.projects {
-            let target_cwd = pref.source_cwd.clone(); // same-machine fallback
+            // Honor --remap here too: checking the un-remapped slug would
+            // detect a conflict against a project we are not writing to.
+            let target_cwd = opts
+                .remap_rules
+                .iter()
+                .find(|(s, _)| s == &pref.source_cwd)
+                .map(|(_, t)| t.clone())
+                .unwrap_or_else(|| pref.source_cwd.clone());
             let target_slug = plan::target_slug(&target_cwd);
             let target_slug_dir = config_dir.join("projects").join(&target_slug);
             let conflict = if target_slug_dir.exists() {
-                conflicts::ProjectConflict::PresentNoOverlap {
-                    target_slug: target_slug.clone(),
-                    target_session_count: 0,
+                // Same overlap rule as apply, sourced from the manifest
+                // inventory because nothing is extracted yet.
+                let slug_prefix =
+                    format!("projects/{}/claude/projects/{}/", pref.id, pref.source_slug);
+                let bundle_ids = merge::session_ids_in_inventory(
+                    manifest.file_inventory.iter().map(|e| e.path.as_str()),
+                    &slug_prefix,
+                );
+                let target_ids = merge::session_ids_in(&target_slug_dir);
+                let overlapping: Vec<String> =
+                    bundle_ids.intersection(&target_ids).cloned().collect();
+                if overlapping.is_empty() {
+                    conflicts::ProjectConflict::PresentNoOverlap {
+                        target_slug: target_slug.clone(),
+                        target_session_count: target_ids.len(),
+                    }
+                } else {
+                    conflicts::ProjectConflict::PresentOverlap {
+                        target_slug: target_slug.clone(),
+                        overlapping_ids: overlapping,
+                    }
                 }
             } else {
                 conflicts::ProjectConflict::None
             };
             match conflicts::resolve(&conflict, opts.mode, opts.prefer) {
-                conflicts::Resolution::Apply
-                | conflicts::Resolution::ArchiveThenApply
-                | conflicts::Resolution::Merge { .. } => {
+                conflicts::Resolution::Apply | conflicts::Resolution::Merge { .. } => {
                     projects_imported.push(pref.source_cwd.clone());
                 }
                 conflicts::Resolution::Refuse(reason) => {
                     projects_refused.push((pref.source_cwd.clone(), reason));
+                }
+                conflicts::Resolution::ArchiveThenApply => {
+                    // Mirror apply's refusal, or the plan would promise an
+                    // import the apply phase declines to perform.
+                    projects_refused.push((
+                        pref.source_cwd.clone(),
+                        "--mode=replace is not implemented; use --mode=merge with \
+                         --prefer-imported or --prefer-target"
+                            .to_string(),
+                    ));
                 }
             }
         }
@@ -725,6 +839,7 @@ pub fn import_bundle(
             journal_path,
             dry_run: true,
             accounts_listed: Vec::new(),
+            tombstones: Vec::new(),
         });
     }
 
@@ -782,82 +897,171 @@ pub fn import_bundle(
             }
             table.finalize();
 
-            // Conflict detection.
-            let target_slug = plan::target_slug(&target_cwd);
-            let target_slug_dir = config_dir.join("projects").join(&target_slug);
-            let conflict = if target_slug_dir.exists() {
-                conflicts::ProjectConflict::PresentNoOverlap {
-                    target_slug: target_slug.clone(),
-                    target_session_count: 0,
-                }
-            } else {
-                conflicts::ProjectConflict::None
-            };
-            match conflicts::resolve(&conflict, opts.mode, opts.prefer) {
-                conflicts::Resolution::Apply => {}
-                conflicts::Resolution::Refuse(reason) => {
-                    projects_refused.push((pref.source_cwd.clone(), reason));
-                    continue;
-                }
-                other => {
-                    // Merge / archive paths land in the next slice; for v0
-                    // we refuse loudly so callers know to wait.
-                    projects_refused.push((
-                        pref.source_cwd.clone(),
-                        format!("v0 only supports apply (no-conflict). got: {other:?}"),
-                    ));
-                    continue;
+            let staged_project_root = staging.join("projects").join(&pref.id);
+
+            // Delta-export tombstones: surface only. See the field docs
+            // on `ImportReceipt::tombstones` for why nothing is deleted.
+            let mut project_tombstones: Vec<String> = Vec::new();
+            let tomb_path = staged_project_root.join(peer::TOMBSTONES_ENTRY);
+            if tomb_path.is_file() {
+                if let Ok(bytes) = fs::read(&tomb_path) {
+                    if let Ok(list) = serde_json::from_slice::<Vec<String>>(&bytes) {
+                        project_tombstones = list;
+                    }
                 }
             }
 
-            // P3 rewrite + P5 apply for the slug tree.
+            // Staging path is needed before conflict detection: overlap
+            // is computed from the session ids actually present on each
+            // side, not from a count.
             let staged_slug_root = staging
                 .join("projects")
                 .join(&pref.id)
                 .join("claude")
                 .join("projects")
                 .join(&pref.source_slug);
-            rewrite_slug_tree(&staged_slug_root, &table)?;
-
-            if !staged_slug_root.exists() {
+            // A delta bundle legitimately carries no slug tree when
+            // nothing changed — the news may be only a removal, or only
+            // a fragment update. Refuse only when the project brings
+            // nothing at all.
+            let has_payload = staged_slug_root.exists();
+            if !has_payload && project_tombstones.is_empty() && !staged_project_root.exists() {
                 projects_refused.push((
                     pref.source_cwd.clone(),
                     "bundle missing expected slug tree".to_string(),
                 ));
                 continue;
             }
-            // P5: rename staged → final. Both paths are in the same volume
-            // (`~/.claudepot/imports/...` and `~/.claude/projects/...`)
-            // are typically on the same FS; if not, fall back to copy.
-            if let Some(parent) = target_slug_dir.parent() {
-                fs::create_dir_all(parent).map_err(MigrateError::from)?;
-            }
-            match fs::rename(&staged_slug_root, &target_slug_dir) {
-                Ok(()) => {}
-                Err(e)
-                    if e.kind() == std::io::ErrorKind::CrossesDevices
-                        || e.raw_os_error() == Some(libc::EXDEV) =>
-                {
-                    copy_dir_recursive(&staged_slug_root, &target_slug_dir)?;
-                    fs::remove_dir_all(&staged_slug_root).map_err(MigrateError::from)?;
-                }
-                Err(e) => return Err(MigrateError::from(e)),
-            }
 
-            // Populate dir_inventory so surgical rollback knows exactly
-            // which files we wrote — preserves user work added post-
-            // import (audit Robustness finding).
-            let dir_inventory = apply::collect_dir_inventory(&target_slug_dir);
-            journal.record(apply::JournalStep {
-                kind: apply::JournalStepKind::CreateDir,
-                before: None,
-                after: Some(target_slug_dir.to_string_lossy().to_string()),
-                snapshot_path: None,
-                after_sha256: None,
-                fragment_key: None,
-                dir_inventory,
-                timestamp_unix_secs: now_secs(),
-            });
+            if has_payload {
+                // Conflict detection (§6). A transcript's identity is its
+                // filename stem — that is how CC resolves it
+                // (`listSessionsImpl.ts:183-185`) and how Claudepot does
+                // (`session/core.rs:549`) — so an id present in both trees is
+                // one logical session recorded twice, i.e. a real overlap.
+                let target_slug = plan::target_slug(&target_cwd);
+                let target_slug_dir = config_dir.join("projects").join(&target_slug);
+                let conflict = if target_slug_dir.exists() {
+                    let target_ids = merge::session_ids_in(&target_slug_dir);
+                    let overlapping: Vec<String> = merge::session_ids_in(&staged_slug_root)
+                        .intersection(&target_ids)
+                        .cloned()
+                        .collect();
+                    if overlapping.is_empty() {
+                        conflicts::ProjectConflict::PresentNoOverlap {
+                            target_slug: target_slug.clone(),
+                            target_session_count: target_ids.len(),
+                        }
+                    } else {
+                        conflicts::ProjectConflict::PresentOverlap {
+                            target_slug: target_slug.clone(),
+                            overlapping_ids: overlapping,
+                        }
+                    }
+                } else {
+                    conflicts::ProjectConflict::None
+                };
+
+                // `Some(prefer)` selects the file-by-file merge below; `None`
+                // is the whole-tree rename onto an absent slug.
+                let merge_prefer = match conflicts::resolve(&conflict, opts.mode, opts.prefer) {
+                    conflicts::Resolution::Apply => None,
+                    conflicts::Resolution::Merge { prefer } => Some(prefer),
+                    conflicts::Resolution::Refuse(reason) => {
+                        projects_refused.push((pref.source_cwd.clone(), reason));
+                        continue;
+                    }
+                    conflicts::Resolution::ArchiveThenApply => {
+                        // `replace` needs an archive-to-trash step that does
+                        // not exist yet. Refuse loudly rather than silently
+                        // degrading to an overwrite — the mode's whole point
+                        // is that the target's copy is recoverable.
+                        projects_refused.push((
+                            pref.source_cwd.clone(),
+                            "--mode=replace is not implemented; use --mode=merge with \
+                         --prefer-imported or --prefer-target"
+                                .to_string(),
+                        ));
+                        continue;
+                    }
+                };
+
+                // P3 rewrite — precedes placement on both paths.
+                rewrite_slug_tree(&staged_slug_root, &table)?;
+
+                if let Some(prefer) = merge_prefer {
+                    // P5 (merge): place file-by-file. A whole-tree rename
+                    // would erase sessions the target has and the bundle
+                    // does not — the union in §6 is precisely about keeping
+                    // those.
+                    // Steps come back through an out-param so a failure
+                    // partway through still journals what already landed;
+                    // the error propagates after the journal is written.
+                    let mut steps = Vec::new();
+                    let merge_result = merge::merge_slug_tree(
+                        &staged_slug_root,
+                        &target_slug_dir,
+                        prefer,
+                        &bundle_id,
+                        &mut steps,
+                    );
+                    for s in steps {
+                        let kind = match s.kind {
+                            merge::MergeApplyKind::Added => apply::JournalStepKind::CreateFile,
+                            merge::MergeApplyKind::Replaced => apply::JournalStepKind::ReplaceFile,
+                            // Nothing was written; nothing to reverse.
+                            merge::MergeApplyKind::KeptTarget => continue,
+                        };
+                        let after_sha256 =
+                            apply::sha256_of_file_optional(std::path::Path::new(&s.after));
+                        journal.record(apply::JournalStep {
+                            kind,
+                            before: None,
+                            after: Some(s.after),
+                            snapshot_path: s.snapshot_path,
+                            after_sha256,
+                            fragment_key: None,
+                            dir_inventory: Vec::new(),
+                            timestamp_unix_secs: now_secs(),
+                        });
+                    }
+                    merge_result?;
+                    let _ = fs::remove_dir_all(&staged_slug_root);
+                } else {
+                    // P5 (apply): rename staged → final. `~/.claudepot/imports/…`
+                    // and `~/.claude/projects/…` are typically on the same
+                    // filesystem; if not, fall back to copy.
+                    if let Some(parent) = target_slug_dir.parent() {
+                        fs::create_dir_all(parent).map_err(MigrateError::from)?;
+                    }
+                    match fs::rename(&staged_slug_root, &target_slug_dir) {
+                        Ok(()) => {}
+                        Err(e)
+                            if e.kind() == std::io::ErrorKind::CrossesDevices
+                                || e.raw_os_error() == Some(libc::EXDEV) =>
+                        {
+                            copy_dir_recursive(&staged_slug_root, &target_slug_dir)?;
+                            fs::remove_dir_all(&staged_slug_root).map_err(MigrateError::from)?;
+                        }
+                        Err(e) => return Err(MigrateError::from(e)),
+                    }
+
+                    // Populate dir_inventory so surgical rollback knows exactly
+                    // which files we wrote — preserves user work added post-
+                    // import (audit Robustness finding).
+                    let dir_inventory = apply::collect_dir_inventory(&target_slug_dir);
+                    journal.record(apply::JournalStep {
+                        kind: apply::JournalStepKind::CreateDir,
+                        before: None,
+                        after: Some(target_slug_dir.to_string_lossy().to_string()),
+                        snapshot_path: None,
+                        after_sha256: None,
+                        fragment_key: None,
+                        dir_inventory,
+                        timestamp_unix_secs: now_secs(),
+                    });
+                }
+            } // end `if has_payload`
 
             // Worktree apply (when bundle carries it).
             if manifest.flags.include_worktree {
@@ -897,6 +1101,58 @@ pub fn import_bundle(
                     // Target cwd missing: skip silently. The slug landed
                     // either way; the user can re-apply worktree later.
                 }
+            }
+
+            tombstones.extend(project_tombstones);
+
+            // §5.6 / §5.7 — the out-of-slug CC state. Both are no-ops
+            // for a bundle exported before these entries existed.
+
+            if let Some(step) = fragment::apply_claude_json_fragment(
+                &staged_project_root,
+                config_dir,
+                &target_cwd,
+                &table,
+                &bundle_id,
+            )? {
+                let after_sha256 =
+                    apply::sha256_of_file_optional(std::path::Path::new(&step.after));
+                journal.record(apply::JournalStep {
+                    kind: apply::JournalStepKind::WriteJsonFragment,
+                    before: None,
+                    after: Some(step.after),
+                    snapshot_path: step.snapshot_path,
+                    after_sha256,
+                    fragment_key: step.fragment_key,
+                    dir_inventory: Vec::new(),
+                    timestamp_unix_secs: now_secs(),
+                });
+            }
+            if let Some(step) = fragment::apply_history_fragment(
+                &staged_project_root,
+                config_dir,
+                &table,
+                &bundle_id,
+            )? {
+                // No snapshot means the target had no `history.jsonl`,
+                // so undo deletes rather than restores.
+                let kind = if step.snapshot_path.is_some() {
+                    apply::JournalStepKind::ReplaceFile
+                } else {
+                    apply::JournalStepKind::CreateFile
+                };
+                let after_sha256 =
+                    apply::sha256_of_file_optional(std::path::Path::new(&step.after));
+                journal.record(apply::JournalStep {
+                    kind,
+                    before: None,
+                    after: Some(step.after),
+                    snapshot_path: step.snapshot_path,
+                    after_sha256,
+                    fragment_key: None,
+                    dir_inventory: Vec::new(),
+                    timestamp_unix_secs: now_secs(),
+                });
             }
 
             projects_imported.push(pref.source_cwd.clone());
@@ -1041,6 +1297,7 @@ pub fn import_bundle(
         journal_path,
         dry_run: false,
         accounts_listed,
+        tombstones,
     })
 }
 
@@ -1100,6 +1357,9 @@ fn walk_and_append(
     base: &Path,
     bundle_prefix: &str,
     writer: &mut bundle::BundleWriter,
+    // `Some` restricts the walk to these slug-relative paths (delta
+    // export). `None` appends everything.
+    only: Option<&std::collections::HashSet<String>>,
 ) -> Result<usize, MigrateError> {
     let mut count = 0usize;
     for entry in fs::read_dir(root).map_err(MigrateError::from)? {
@@ -1118,13 +1378,16 @@ fn walk_and_append(
             )));
         }
         if ft.is_dir() {
-            count += walk_and_append(&path, base, bundle_prefix, writer)?;
+            count += walk_and_append(&path, base, bundle_prefix, writer, only)?;
         } else if ft.is_file() {
             let rel = path
                 .strip_prefix(base)
                 .map_err(|e| MigrateError::Io(std::io::Error::other(format!("strip_prefix: {e}"))))?
                 .to_string_lossy()
                 .replace('\\', "/");
+            if only.is_some_and(|set| !set.contains(&rel)) {
+                continue;
+            }
             let bundle_path = format!("{bundle_prefix}/{rel}");
             writer.append_file(&bundle_path, &path, None)?;
             count += 1;
@@ -1215,6 +1478,7 @@ mod tests {
             account_stubs: None,
             encrypt_passphrase: None,
             sign_password: None,
+            since_peer: None,
         };
         let receipt = export_projects(&cfg, opts).unwrap();
         assert_eq!(receipt.project_count, 1);
@@ -1249,6 +1513,7 @@ mod tests {
             account_stubs: None,
             encrypt_passphrase: None,
             sign_password: None,
+            since_peer: None,
         };
         let err = export_projects(&cfg, opts).unwrap_err();
         // Configuration (not NotImplemented) — encryption ships;
@@ -1275,6 +1540,7 @@ mod tests {
             account_stubs: None,
             encrypt_passphrase: None,
             sign_password: None,
+            since_peer: None,
         };
         let err = export_projects(&cfg, opts).unwrap_err();
         assert!(matches!(err, MigrateError::ProjectNotInBundle(_)));
@@ -1304,6 +1570,7 @@ mod tests {
                 account_stubs: None,
                 encrypt_passphrase: None,
                 sign_password: None,
+                since_peer: None,
             },
         )
         .unwrap();
@@ -1359,6 +1626,7 @@ mod tests {
                 account_stubs: None,
                 encrypt_passphrase: None,
                 sign_password: None,
+                since_peer: None,
             },
         )
         .unwrap();
@@ -1423,6 +1691,7 @@ mod tests {
                 account_stubs: None,
                 encrypt_passphrase: None,
                 sign_password: None,
+                since_peer: None,
             },
         )
         .unwrap();
@@ -1482,6 +1751,7 @@ mod tests {
                 account_stubs: None,
                 encrypt_passphrase: None,
                 sign_password: None,
+                since_peer: None,
             },
         )
         .unwrap();
@@ -1530,6 +1800,7 @@ mod tests {
                 encrypt_passphrase: Some(pwd.clone()),
                 sign_keyfile: None,
                 sign_password: None,
+                since_peer: None,
                 account_stubs: None,
             },
         )
@@ -1588,6 +1859,7 @@ mod tests {
                 account_stubs: None,
                 encrypt_passphrase: None,
                 sign_password: None,
+                since_peer: None,
             },
         )
         .unwrap();
@@ -1634,6 +1906,7 @@ mod tests {
                 account_stubs: None,
                 encrypt_passphrase: None,
                 sign_password: None,
+                since_peer: None,
             },
         )
         .unwrap();
@@ -1684,6 +1957,7 @@ mod tests {
                 account_stubs: None,
                 encrypt_passphrase: None,
                 sign_password: None,
+                since_peer: None,
             },
         )
         .unwrap();
@@ -1716,6 +1990,632 @@ mod tests {
             }
         }
         assert!(found_jsonl, "expected at least one rewritten jsonl");
+
+        std::env::remove_var("CLAUDEPOT_DATA_DIR");
+    }
+
+    /// Seed a project carrying one session with a caller-chosen id, so
+    /// overlap tests can force a collision instead of hoping two random
+    /// UUIDv4s coincide.
+    fn seed_project_with_session(config_dir: &Path, cwd: &str, session_id: &str, body: &str) {
+        let slug = sanitize_path(&nfc::nfc(cwd));
+        let slug_dir = config_dir.join("projects").join(&slug);
+        fs::create_dir_all(&slug_dir).unwrap();
+        fs::write(slug_dir.join(format!("{session_id}.jsonl")), body).unwrap();
+    }
+
+    /// Export a single project from `cfg_src` to `bundle`, no optional
+    /// buckets. Keeps the merge tests below to their actual subject.
+    fn export_one(cfg_src: &Path, cwd: &str, bundle: &Path) {
+        export_projects(
+            cfg_src,
+            ExportOptions {
+                output: bundle.to_path_buf(),
+                project_cwds: vec![cwd.to_string()],
+                include_global: false,
+                include_worktree: false,
+                include_live: false,
+                include_claudepot_state: false,
+                include_file_history: true,
+                encrypt: false,
+                sign_keyfile: None,
+                account_stubs: None,
+                encrypt_passphrase: None,
+                sign_password: None,
+                since_peer: None,
+            },
+        )
+        .unwrap();
+    }
+
+    fn merge_opts(prefer: Option<conflicts::MergePreference>) -> ImportOptions {
+        ImportOptions {
+            mode: conflicts::ConflictMode::Merge,
+            prefer,
+            ..Default::default()
+        }
+    }
+
+    /// The union property from §6: merging into an existing slug adds the
+    /// bundle's sessions without disturbing sessions only the target has.
+    /// Before merge mode existed this path refused outright; a
+    /// whole-directory rename would have destroyed `local-only`.
+    #[test]
+    fn merge_unions_and_preserves_target_only_sessions() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("CLAUDEPOT_DATA_DIR", tmp.path().join("claudepot"));
+        let cwd = "/tmp/test-merge-union".to_string();
+
+        let cfg_src = tmp.path().join("src/.claude");
+        fs::create_dir_all(cfg_src.join("projects")).unwrap();
+        seed_project_with_session(
+            &cfg_src,
+            &cwd,
+            "11111111-1111-4111-8111-111111111111",
+            "from-peer\n",
+        );
+        let bundle = tmp.path().join("merge.tar.zst");
+        export_one(&cfg_src, &cwd, &bundle);
+
+        let cfg_target = tmp.path().join("dst/.claude");
+        fs::create_dir_all(cfg_target.join("projects")).unwrap();
+        seed_project_with_session(
+            &cfg_target,
+            &cwd,
+            "22222222-2222-4222-8222-222222222222",
+            "local-only\n",
+        );
+
+        let receipt = import_bundle(&cfg_target, &bundle, merge_opts(None)).unwrap();
+        assert_eq!(
+            receipt.projects_refused,
+            vec![],
+            "merge must no longer hit the v0 refusal arm"
+        );
+        assert_eq!(receipt.projects_imported.len(), 1);
+
+        let target_dir = cfg_target.join("projects").join(plan::target_slug(&cwd));
+        assert!(
+            target_dir
+                .join("22222222-2222-4222-8222-222222222222.jsonl")
+                .exists(),
+            "a session the bundle never carried must survive the merge"
+        );
+        assert!(
+            target_dir
+                .join("11111111-1111-4111-8111-111111111111.jsonl")
+                .exists(),
+            "the bundle's session must land"
+        );
+
+        std::env::remove_var("CLAUDEPOT_DATA_DIR");
+    }
+
+    /// Golden #16 (§11.3) — a sessionId present on both machines is a
+    /// conflict, and `merge` without a preference refuses rather than
+    /// picking a winner.
+    #[test]
+    fn golden_16_overlapping_session_id_refuses_without_preference() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("CLAUDEPOT_DATA_DIR", tmp.path().join("claudepot"));
+        let cwd = "/tmp/test-merge-overlap".to_string();
+        let shared = "33333333-3333-4333-8333-333333333333";
+
+        let cfg_src = tmp.path().join("src/.claude");
+        fs::create_dir_all(cfg_src.join("projects")).unwrap();
+        seed_project_with_session(&cfg_src, &cwd, shared, "imported-copy\n");
+        let bundle = tmp.path().join("overlap.tar.zst");
+        export_one(&cfg_src, &cwd, &bundle);
+
+        let cfg_target = tmp.path().join("dst/.claude");
+        fs::create_dir_all(cfg_target.join("projects")).unwrap();
+        seed_project_with_session(&cfg_target, &cwd, shared, "target-copy\n");
+
+        let receipt = import_bundle(&cfg_target, &bundle, merge_opts(None)).unwrap();
+
+        assert!(receipt.projects_imported.is_empty());
+        assert_eq!(receipt.projects_refused.len(), 1);
+        assert!(
+            receipt.projects_refused[0].1.contains("overlapping"),
+            "refusal must name the overlap, got: {}",
+            receipt.projects_refused[0].1
+        );
+        // The target's copy is untouched by a refused import.
+        let target_dir = cfg_target.join("projects").join(plan::target_slug(&cwd));
+        assert_eq!(
+            fs::read_to_string(target_dir.join(format!("{shared}.jsonl"))).unwrap(),
+            "target-copy\n"
+        );
+
+        std::env::remove_var("CLAUDEPOT_DATA_DIR");
+    }
+
+    /// The dry run must reach the same resolution as apply. A plan that
+    /// promises an import the apply phase refuses is worse than no plan.
+    #[test]
+    fn dry_run_predicts_the_overlap_refusal() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("CLAUDEPOT_DATA_DIR", tmp.path().join("claudepot"));
+        let cwd = "/tmp/test-merge-dryrun".to_string();
+        let shared = "44444444-4444-4444-8444-444444444444";
+
+        let cfg_src = tmp.path().join("src/.claude");
+        fs::create_dir_all(cfg_src.join("projects")).unwrap();
+        seed_project_with_session(&cfg_src, &cwd, shared, "imported\n");
+        let bundle = tmp.path().join("dry.tar.zst");
+        export_one(&cfg_src, &cwd, &bundle);
+
+        let cfg_target = tmp.path().join("dst/.claude");
+        fs::create_dir_all(cfg_target.join("projects")).unwrap();
+        seed_project_with_session(&cfg_target, &cwd, shared, "target\n");
+
+        let mut opts = merge_opts(None);
+        opts.dry_run = true;
+        let dry = import_bundle(&cfg_target, &bundle, opts).unwrap();
+        assert!(dry.dry_run);
+        assert_eq!(
+            dry.projects_refused.len(),
+            1,
+            "dry run must predict the refusal apply reaches"
+        );
+
+        std::env::remove_var("CLAUDEPOT_DATA_DIR");
+    }
+
+    /// `--prefer-target` resolves the collision by keeping what the
+    /// target already had.
+    #[test]
+    fn merge_prefer_target_keeps_the_local_copy() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("CLAUDEPOT_DATA_DIR", tmp.path().join("claudepot"));
+        let cwd = "/tmp/test-merge-prefer-target".to_string();
+        let shared = "55555555-5555-4555-8555-555555555555";
+
+        let cfg_src = tmp.path().join("src/.claude");
+        fs::create_dir_all(cfg_src.join("projects")).unwrap();
+        seed_project_with_session(&cfg_src, &cwd, shared, "imported\n");
+        let bundle = tmp.path().join("pt.tar.zst");
+        export_one(&cfg_src, &cwd, &bundle);
+
+        let cfg_target = tmp.path().join("dst/.claude");
+        fs::create_dir_all(cfg_target.join("projects")).unwrap();
+        seed_project_with_session(&cfg_target, &cwd, shared, "target\n");
+
+        let receipt = import_bundle(
+            &cfg_target,
+            &bundle,
+            merge_opts(Some(conflicts::MergePreference::Target)),
+        )
+        .unwrap();
+        assert_eq!(receipt.projects_refused, vec![]);
+
+        let target_dir = cfg_target.join("projects").join(plan::target_slug(&cwd));
+        assert_eq!(
+            fs::read_to_string(target_dir.join(format!("{shared}.jsonl"))).unwrap(),
+            "target\n",
+            "--prefer-target must not overwrite the local copy"
+        );
+
+        std::env::remove_var("CLAUDEPOT_DATA_DIR");
+    }
+
+    /// `--prefer-imported` overwrites, and the displaced copy is
+    /// recoverable — the journal step carries a snapshot so `undo`
+    /// can put it back.
+    #[test]
+    fn merge_prefer_imported_replaces_and_snapshots_for_undo() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("CLAUDEPOT_DATA_DIR", tmp.path().join("claudepot"));
+        let cwd = "/tmp/test-merge-prefer-imported".to_string();
+        let shared = "66666666-6666-4666-8666-666666666666";
+
+        let cfg_src = tmp.path().join("src/.claude");
+        fs::create_dir_all(cfg_src.join("projects")).unwrap();
+        seed_project_with_session(&cfg_src, &cwd, shared, "imported\n");
+        let bundle = tmp.path().join("pi.tar.zst");
+        export_one(&cfg_src, &cwd, &bundle);
+
+        let cfg_target = tmp.path().join("dst/.claude");
+        fs::create_dir_all(cfg_target.join("projects")).unwrap();
+        seed_project_with_session(&cfg_target, &cwd, shared, "target\n");
+
+        let receipt = import_bundle(
+            &cfg_target,
+            &bundle,
+            merge_opts(Some(conflicts::MergePreference::Imported)),
+        )
+        .unwrap();
+        assert_eq!(receipt.projects_refused, vec![]);
+
+        let target_dir = cfg_target.join("projects").join(plan::target_slug(&cwd));
+        assert_eq!(
+            fs::read_to_string(target_dir.join(format!("{shared}.jsonl"))).unwrap(),
+            "imported\n"
+        );
+
+        // The displaced bytes are recoverable.
+        let journal = apply::ImportJournal::load(&receipt.journal_path).unwrap();
+        let replaced = journal
+            .steps
+            .iter()
+            .find(|s| matches!(s.kind, apply::JournalStepKind::ReplaceFile))
+            .expect("a replaced session must be journaled as ReplaceFile");
+        let snap = replaced
+            .snapshot_path
+            .as_ref()
+            .expect("ReplaceFile must carry a snapshot");
+        assert_eq!(fs::read_to_string(snap).unwrap(), "target\n");
+
+        std::env::remove_var("CLAUDEPOT_DATA_DIR");
+    }
+
+    /// §5.6 + §5.7 end to end: both fragments leave the source, land on
+    /// the target, and have their embedded absolute paths re-anchored.
+    #[test]
+    fn fragments_round_trip_through_export_and_import() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("CLAUDEPOT_DATA_DIR", tmp.path().join("claudepot"));
+        let src_cwd = "/tmp/frag-src".to_string();
+        let dst_cwd = "/tmp/frag-dst".to_string();
+        let sid = "77777777-7777-4777-8777-777777777777";
+
+        let src_home = tmp.path().join("src");
+        let cfg_src = src_home.join(".claude");
+        fs::create_dir_all(cfg_src.join("projects")).unwrap();
+        seed_project_with_session(&cfg_src, &src_cwd, sid, "body\n");
+        fs::write(
+            src_home.join(".claude.json"),
+            format!(
+                r#"{{"projects":{{"{src_cwd}":{{"allowedTools":["Bash"],"activeWorktreeSession":{{"originalCwd":"{src_cwd}/wt"}}}}}}}}"#
+            ),
+        )
+        .unwrap();
+        fs::write(
+            cfg_src.join("history.jsonl"),
+            format!("{{\"sessionId\":\"{sid}\",\"display\":\"hi\",\"project\":\"{src_cwd}\"}}\n"),
+        )
+        .unwrap();
+
+        let bundle = tmp.path().join("frag.tar.zst");
+        export_one(&cfg_src, &src_cwd, &bundle);
+
+        let dst_home = tmp.path().join("dst");
+        let cfg_target = dst_home.join(".claude");
+        fs::create_dir_all(cfg_target.join("projects")).unwrap();
+
+        let receipt = import_bundle(
+            &cfg_target,
+            &bundle,
+            ImportOptions {
+                remap_rules: vec![(src_cwd.clone(), dst_cwd.clone())],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(receipt.projects_refused, vec![]);
+
+        // §5.6 — re-keyed to the target cwd, inner path re-anchored.
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(dst_home.join(".claude.json")).unwrap())
+                .unwrap();
+        let entry = &root["projects"][&dst_cwd];
+        assert_eq!(entry["allowedTools"][0], "Bash");
+        assert_eq!(
+            entry["activeWorktreeSession"]["originalCwd"],
+            format!("{dst_cwd}/wt")
+        );
+
+        // §5.7 — appended with the project path rewritten.
+        let hist = fs::read_to_string(cfg_target.join("history.jsonl")).unwrap();
+        assert_eq!(hist.lines().count(), 1);
+        assert!(hist.contains(&dst_cwd), "history project path re-anchored");
+
+        std::env::remove_var("CLAUDEPOT_DATA_DIR");
+    }
+
+    /// Golden #21 (§11.3) — export → import → export is stable.
+    ///
+    /// "Bit-identical except manifest timestamp + machine identity" is
+    /// asserted on content, not on raw bundle bytes: each export mints
+    /// a fresh `projects/<uuid>/` id, and the archive itself carries
+    /// mtimes. Normalizing the project id and comparing every payload's
+    /// path→sha256 is the same claim without the incidental noise.
+    #[test]
+    fn golden_21_export_import_export_round_trips() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("CLAUDEPOT_DATA_DIR", tmp.path().join("claudepot"));
+        let cwd = "/tmp/golden21".to_string();
+
+        let src_home = tmp.path().join("src");
+        let cfg_src = src_home.join(".claude");
+        fs::create_dir_all(cfg_src.join("projects")).unwrap();
+        seed_project_with_session(
+            &cfg_src,
+            &cwd,
+            "88888888-8888-4888-8888-888888888888",
+            "content\n",
+        );
+        fs::write(
+            src_home.join(".claude.json"),
+            format!(r#"{{"projects":{{"{cwd}":{{"allowedTools":["Bash"]}}}}}}"#),
+        )
+        .unwrap();
+
+        let first = tmp.path().join("first.tar.zst");
+        export_one(&cfg_src, &cwd, &first);
+
+        let dst_home = tmp.path().join("dst");
+        let cfg_target = dst_home.join(".claude");
+        fs::create_dir_all(cfg_target.join("projects")).unwrap();
+        let receipt = import_bundle(&cfg_target, &first, ImportOptions::default()).unwrap();
+        assert_eq!(receipt.projects_refused, vec![]);
+
+        let second = tmp.path().join("second.tar.zst");
+        export_one(&cfg_target, &cwd, &second);
+
+        assert_eq!(
+            normalized_inventory(&first),
+            normalized_inventory(&second),
+            "re-exporting an imported bundle must reproduce the same payloads"
+        );
+
+        // The per-project `manifest.json` is excluded above because it
+        // embeds a fresh `id` per export — the "machine identity" half
+        // of the golden's carve-out. Its meaningful fields must still
+        // agree.
+        let (a, b) = (inspect(&first).unwrap(), inspect(&second).unwrap());
+        let key = |m: &manifest::BundleManifest| -> Vec<(String, String, u32)> {
+            m.projects
+                .iter()
+                .map(|p| (p.source_cwd.clone(), p.source_slug.clone(), p.session_count))
+                .collect()
+        };
+        assert_eq!(
+            key(&a),
+            key(&b),
+            "project identity must survive a round trip"
+        );
+
+        std::env::remove_var("CLAUDEPOT_DATA_DIR");
+    }
+
+    /// path → sha256 for every payload, with the per-export project
+    /// UUID folded out so two exports of the same content compare equal.
+    ///
+    /// `manifest.json` entries are excluded: they carry that per-export
+    /// id in their *contents*, so their digests can never match. The
+    /// caller asserts their meaningful fields separately.
+    fn normalized_inventory(bundle: &Path) -> std::collections::BTreeMap<String, String> {
+        let m = inspect(bundle).unwrap();
+        let ids: Vec<String> = m.projects.iter().map(|p| p.id.clone()).collect();
+        m.file_inventory
+            .iter()
+            .filter(|e| !e.path.ends_with("manifest.json"))
+            .map(|e| {
+                let mut path = e.path.clone();
+                for id in &ids {
+                    path = path.replace(id.as_str(), "<project-id>");
+                }
+                (path, e.sha256.clone())
+            })
+            .collect()
+    }
+
+    /// `rules/paths.md` — the merge path must re-anchor all four path
+    /// shapes. Exercised through the §5.6 fragment, which is where an
+    /// absolute path actually crosses machines.
+    #[test]
+    fn merge_fragment_re_anchors_all_four_path_shapes() {
+        // The verbatim shape re-anchors to the *simplified* target:
+        // `simplify_windows_path` strips `\\?\` before the substitution
+        // table is built, because CC never writes the verbatim form into
+        // a cwd or a slug (`rules/paths.md`). Preserving it here would
+        // produce a path CC cannot match.
+        for (from, to, expected) in [
+            ("/Users/alice/proj", "/Users/bob/proj", "/Users/bob/proj"),
+            (
+                r"C:\Users\alice\proj",
+                r"C:\Users\bob\proj",
+                r"C:\Users\bob\proj",
+            ),
+            (
+                r"\\server\share\alice",
+                r"\\server\share\bob",
+                r"\\server\share\bob",
+            ),
+            (r"\\?\C:\Users\alice", r"\\?\C:\Users\bob", r"C:\Users\bob"),
+        ] {
+            let td = tempfile::tempdir().unwrap();
+            let cfg = td.path().join(".claude");
+            fs::create_dir_all(&cfg).unwrap();
+            let staged = td.path().join("staged");
+            fs::create_dir_all(&staged).unwrap();
+
+            let mut table = plan::SubstitutionTable::new();
+            table.push(from, to, plan::RuleOrigin::ProjectCwd);
+            table.finalize();
+
+            let frag = serde_json::json!({ "activeWorktreeSession": { "originalCwd": from } });
+            fs::write(
+                staged.join(fragment::CLAUDE_JSON_FRAGMENT),
+                serde_json::to_vec(&frag).unwrap(),
+            )
+            .unwrap();
+
+            fragment::apply_claude_json_fragment(&staged, &cfg, to, &table, "shapes").unwrap();
+
+            let root: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(td.path().join(".claude.json")).unwrap())
+                    .unwrap();
+            assert_eq!(
+                root["projects"][to]["activeWorktreeSession"]["originalCwd"], expected,
+                "shape {from} -> {to} was not re-anchored"
+            );
+        }
+    }
+
+    /// Transcript payloads actually carried by a bundle. `session_count`
+    /// on the manifest counts the *source project's* sessions, not the
+    /// delta, so it cannot answer "did this delta ship anything".
+    fn shipped_jsonl(bundle: &Path) -> Vec<String> {
+        let mut v: Vec<String> = inspect(bundle)
+            .unwrap()
+            .file_inventory
+            .iter()
+            .filter(|e| e.path.ends_with(".jsonl"))
+            .map(|e| e.path.rsplit('/').next().unwrap_or(&e.path).to_string())
+            .collect();
+        v.sort();
+        v
+    }
+
+    fn export_to_peer(cfg_src: &Path, cwd: &str, bundle: &Path, peer_id: &str) {
+        export_projects(
+            cfg_src,
+            ExportOptions {
+                output: bundle.to_path_buf(),
+                project_cwds: vec![cwd.to_string()],
+                include_global: false,
+                include_worktree: false,
+                include_live: false,
+                include_claudepot_state: false,
+                include_file_history: true,
+                encrypt: false,
+                sign_keyfile: None,
+                account_stubs: None,
+                encrypt_passphrase: None,
+                sign_password: None,
+                since_peer: Some(peer_id.to_string()),
+            },
+        )
+        .unwrap();
+    }
+
+    /// WI-2's headline property. A high-water mark skips a file that
+    /// `slim` made *smaller*, leaving the peer on a stale fat copy
+    /// forever; a fingerprint diff re-ships it.
+    #[test]
+    fn delta_export_reships_a_shrunk_file_and_import_lands_it() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("CLAUDEPOT_DATA_DIR", tmp.path().join("claudepot"));
+        let cwd = "/tmp/delta-shrink".to_string();
+        let sid = "99999999-9999-4999-8999-999999999999";
+
+        let cfg_src = tmp.path().join("src/.claude");
+        fs::create_dir_all(cfg_src.join("projects")).unwrap();
+        let fat = format!("{}\n", "x".repeat(500));
+        seed_project_with_session(&cfg_src, &cwd, sid, &fat);
+
+        let cfg_target = tmp.path().join("dst/.claude");
+        fs::create_dir_all(cfg_target.join("projects")).unwrap();
+
+        let b1 = tmp.path().join("d1.tar.zst");
+        export_to_peer(&cfg_src, &cwd, &b1, "laptop");
+        import_bundle(&cfg_target, &b1, ImportOptions::default()).unwrap();
+
+        let target_file = cfg_target
+            .join("projects")
+            .join(plan::target_slug(&cwd))
+            .join(format!("{sid}.jsonl"));
+        assert_eq!(fs::read_to_string(&target_file).unwrap().len(), fat.len());
+
+        // Simulate `claudepot session slim`: same path, fewer bytes.
+        let slim = "{\"slimmed\":true}\n";
+        let src_file = cfg_src
+            .join("projects")
+            .join(sanitize_path(&nfc::nfc(&cwd)))
+            .join(format!("{sid}.jsonl"));
+        fs::write(&src_file, slim).unwrap();
+
+        let b2 = tmp.path().join("d2.tar.zst");
+        export_to_peer(&cfg_src, &cwd, &b2, "laptop");
+        assert_eq!(
+            shipped_jsonl(&b2),
+            vec![format!("{sid}.jsonl")],
+            "the shrunk session must be in the delta bundle"
+        );
+
+        let receipt = import_bundle(
+            &cfg_target,
+            &b2,
+            merge_opts(Some(conflicts::MergePreference::Imported)),
+        )
+        .unwrap();
+        assert_eq!(receipt.projects_refused, vec![]);
+        assert_eq!(
+            fs::read_to_string(&target_file).unwrap(),
+            slim,
+            "the target must end up with the slimmed copy"
+        );
+
+        std::env::remove_var("CLAUDEPOT_DATA_DIR");
+    }
+
+    /// An unchanged project ships nothing the second time, and a removed
+    /// session becomes a tombstone the importer reports but never acts
+    /// on.
+    #[test]
+    fn delta_export_tombstones_a_removal_without_deleting_on_target() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("CLAUDEPOT_DATA_DIR", tmp.path().join("claudepot"));
+        let cwd = "/tmp/delta-tomb".to_string();
+        let keep = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+        let gone = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+        let cfg_src = tmp.path().join("src/.claude");
+        fs::create_dir_all(cfg_src.join("projects")).unwrap();
+        seed_project_with_session(&cfg_src, &cwd, keep, "keep\n");
+        seed_project_with_session(&cfg_src, &cwd, gone, "gone\n");
+
+        let cfg_target = tmp.path().join("dst/.claude");
+        fs::create_dir_all(cfg_target.join("projects")).unwrap();
+
+        let b1 = tmp.path().join("t1.tar.zst");
+        export_to_peer(&cfg_src, &cwd, &b1, "laptop");
+        import_bundle(&cfg_target, &b1, ImportOptions::default()).unwrap();
+
+        // Source drops one session (retention sweep, prune, whatever).
+        let src_slug = cfg_src
+            .join("projects")
+            .join(sanitize_path(&nfc::nfc(&cwd)));
+        fs::remove_file(src_slug.join(format!("{gone}.jsonl"))).unwrap();
+
+        let b2 = tmp.path().join("t2.tar.zst");
+        export_to_peer(&cfg_src, &cwd, &b2, "laptop");
+        assert!(
+            shipped_jsonl(&b2).is_empty(),
+            "nothing changed, so no session payload ships: {:?}",
+            shipped_jsonl(&b2)
+        );
+
+        let receipt = import_bundle(
+            &cfg_target,
+            &b2,
+            merge_opts(Some(conflicts::MergePreference::Imported)),
+        )
+        .unwrap();
+        assert_eq!(
+            receipt.tombstones,
+            vec![format!("{gone}.jsonl")],
+            "the removal must be reported"
+        );
+        assert!(
+            cfg_target
+                .join("projects")
+                .join(plan::target_slug(&cwd))
+                .join(format!("{gone}.jsonl"))
+                .exists(),
+            "a tombstone must never delete the target's copy"
+        );
 
         std::env::remove_var("CLAUDEPOT_DATA_DIR");
     }
@@ -1762,6 +2662,7 @@ mod tests {
                 account_stubs: None,
                 encrypt_passphrase: None,
                 sign_password: None,
+                since_peer: None,
             },
         )
         .unwrap();
@@ -1826,6 +2727,7 @@ mod tests {
                 account_stubs: None,
                 encrypt_passphrase: Some(age::secrecy::SecretString::from("pw".to_string())),
                 sign_password: None,
+                since_peer: None,
             },
         )
         .unwrap();
@@ -1899,6 +2801,7 @@ mod tests {
                 account_stubs: None,
                 encrypt_passphrase: None,
                 sign_password: None,
+                since_peer: None,
             },
         )
         .unwrap();

--- a/crates/claudepot-core/src/migrate/peer.rs
+++ b/crates/claudepot-core/src/migrate/peer.rs
@@ -1,0 +1,292 @@
+//! Delta-export state — per-`(peer, project)` file fingerprints.
+//!
+//! Lets a repeated export ship only what changed since the last export
+//! to that peer, instead of a full bundle every time.
+//!
+//! ## Why a high-water mark would be wrong
+//!
+//! The obvious design — record a timestamp, export everything newer —
+//! fails on this data. `claudepot session slim` rewrites a transcript
+//! **in place**, and CC's `cleanupPeriodDays` deletes whole files on a
+//! sliding window. Neither is "after" a watermark in any useful sense:
+//! a slimmed file is *smaller* than the copy the peer holds, and a
+//! deleted file has no timestamp at all. A watermark skips both, so
+//! the peer keeps a stale fat copy forever and never learns about the
+//! deletion.
+//!
+//! Fingerprints catch both. `(size, mtime_ns)` diverging in *either*
+//! direction marks the file for re-export, and a path that was
+//! fingerprinted but is now absent becomes a tombstone.
+//!
+//! ## Why tombstones do not delete
+//!
+//! A tombstone says "this file left the source", never "remove it on
+//! the target". The source may have run a retention sweep the target's
+//! user does not want mirrored — deleting their only remaining copy of
+//! a transcript because another machine aged it out is exactly the
+//! silent data loss this whole plan exists to avoid. The importer
+//! surfaces them; a human decides.
+//!
+//! ## Storage
+//!
+//! `~/.claudepot/migrate-peers.json`, via `json_store` (so a corrupt
+//! file moves aside and starts empty rather than being fatal at boot).
+//! This is **transport state, not cache**: it must survive a
+//! `sessions.db` rebuild, because rebuilding a cache would otherwise
+//! silently re-send every file to every peer. That is why it is its
+//! own file and not a table in `sessions.db`, whose documented remedy
+//! is "delete and rebuild".
+
+use crate::json_store;
+use crate::session_index::diff::{self, DiffPlan, IndexTuple};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Bundle entry listing paths that left the source since the last
+/// export to this peer.
+pub const TOMBSTONES_ENTRY: &str = "tombstones.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileFingerprint {
+    /// Slug-relative, `/`-joined.
+    pub path: String,
+    pub size: u64,
+    pub mtime_ns: i64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PeerRecord {
+    /// Keyed by source cwd.
+    #[serde(default)]
+    pub projects: BTreeMap<String, Vec<FileFingerprint>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PeerStore {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub peers: BTreeMap<String, PeerRecord>,
+}
+
+impl Default for PeerStore {
+    fn default() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            peers: BTreeMap::new(),
+        }
+    }
+}
+
+/// A schema this build cannot read. Treated as corruption by
+/// `json_store`, which moves the file aside and starts empty — the
+/// safe direction: worst case is one full re-export to each peer.
+#[derive(Debug)]
+pub struct PeerStoreInvalid(String);
+
+impl std::fmt::Display for PeerStoreInvalid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl json_store::Validate for PeerStore {
+    type Error = PeerStoreInvalid;
+
+    fn validate(&self) -> Result<(), Self::Error> {
+        if self.schema_version == 0 || self.schema_version > SCHEMA_VERSION {
+            return Err(PeerStoreInvalid(format!(
+                "unsupported schema_version {} (this build reads <= {SCHEMA_VERSION})",
+                self.schema_version
+            )));
+        }
+        Ok(())
+    }
+}
+
+pub fn state_path() -> PathBuf {
+    crate::paths::claudepot_data_dir().join("migrate-peers.json")
+}
+
+pub fn load() -> PeerStore {
+    json_store::load_or_default(&state_path(), "migrate_peers")
+}
+
+pub fn save(store: &PeerStore) -> std::io::Result<()> {
+    json_store::save(&state_path(), store).map_err(|e| std::io::Error::other(format!("{e:?}")))
+}
+
+/// Fingerprint every file under `slug_dir`, slug-relative.
+///
+/// `inode` is left at 0: it is meaningless across the export boundary
+/// and `diff_fs_vs_db` only compares `(size, mtime_ns)`.
+pub fn fingerprint_dir(slug_dir: &Path) -> Vec<IndexTuple> {
+    let mut out = Vec::new();
+    for rel in crate::migrate::apply::collect_dir_inventory(slug_dir) {
+        let mut abs = slug_dir.to_path_buf();
+        for seg in rel.split('/').filter(|s| !s.is_empty()) {
+            abs.push(seg);
+        }
+        let Ok(meta) = std::fs::metadata(&abs) else {
+            continue;
+        };
+        out.push(IndexTuple {
+            file_path: rel,
+            size: meta.len(),
+            mtime_ns: mtime_ns(&meta),
+            inode: 0,
+        });
+    }
+    out.sort_by(|a, b| a.file_path.cmp(&b.file_path));
+    out
+}
+
+fn mtime_ns(meta: &std::fs::Metadata) -> i64 {
+    meta.modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0)
+}
+
+/// What to ship for `(peer, project)` given the current on-disk state.
+///
+/// `to_upsert` is new-or-changed (in either direction, so a slimmed
+/// file is included); `to_delete` is the tombstone list.
+pub fn delta(
+    store: &PeerStore,
+    peer_id: &str,
+    source_cwd: &str,
+    fs_now: &[IndexTuple],
+) -> DiffPlan {
+    let recorded: Vec<IndexTuple> = store
+        .peers
+        .get(peer_id)
+        .and_then(|r| r.projects.get(source_cwd))
+        .map(|fps| {
+            fps.iter()
+                .map(|f| IndexTuple {
+                    file_path: f.path.clone(),
+                    size: f.size,
+                    mtime_ns: f.mtime_ns,
+                    inode: 0,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    diff::diff_fs_vs_db(fs_now, &recorded)
+}
+
+/// Replace the recorded fingerprints for `(peer, project)`. Call only
+/// after the bundle has been written — recording first would claim
+/// files were sent that a failed export never shipped.
+pub fn record(store: &mut PeerStore, peer_id: &str, source_cwd: &str, fs_now: &[IndexTuple]) {
+    let rec = store.peers.entry(peer_id.to_string()).or_default();
+    rec.projects.insert(
+        source_cwd.to_string(),
+        fs_now
+            .iter()
+            .map(|t| FileFingerprint {
+                path: t.file_path.clone(),
+                size: t.size,
+                mtime_ns: t.mtime_ns,
+            })
+            .collect(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tuple(path: &str, size: u64, mtime_ns: i64) -> IndexTuple {
+        IndexTuple {
+            file_path: path.to_string(),
+            size,
+            mtime_ns,
+            inode: 0,
+        }
+    }
+
+    #[test]
+    fn first_export_to_a_peer_ships_everything() {
+        let store = PeerStore::default();
+        let now = vec![tuple("a.jsonl", 10, 1), tuple("b.jsonl", 20, 2)];
+        let plan = delta(&store, "laptop", "/proj", &now);
+        assert_eq!(plan.to_upsert, vec!["a.jsonl", "b.jsonl"]);
+        assert!(plan.to_delete.is_empty());
+    }
+
+    #[test]
+    fn unchanged_files_are_not_reshipped() {
+        let mut store = PeerStore::default();
+        let now = vec![tuple("a.jsonl", 10, 1)];
+        record(&mut store, "laptop", "/proj", &now);
+        let plan = delta(&store, "laptop", "/proj", &now);
+        assert!(plan.to_upsert.is_empty());
+        assert!(plan.to_delete.is_empty());
+    }
+
+    /// The property a high-water mark gets wrong: `slim` makes a file
+    /// smaller, and it must still re-export.
+    #[test]
+    fn a_shrunk_file_is_reshipped() {
+        let mut store = PeerStore::default();
+        record(&mut store, "laptop", "/proj", &[tuple("a.jsonl", 900, 5)]);
+        // Same mtime, smaller — the shape `slim` leaves behind if the
+        // clock is coarse.
+        let plan = delta(&store, "laptop", "/proj", &[tuple("a.jsonl", 100, 5)]);
+        assert_eq!(plan.to_upsert, vec!["a.jsonl"]);
+    }
+
+    #[test]
+    fn a_removed_file_becomes_a_tombstone() {
+        let mut store = PeerStore::default();
+        record(
+            &mut store,
+            "laptop",
+            "/proj",
+            &[tuple("a.jsonl", 10, 1), tuple("gone.jsonl", 10, 1)],
+        );
+        let plan = delta(&store, "laptop", "/proj", &[tuple("a.jsonl", 10, 1)]);
+        assert!(plan.to_upsert.is_empty());
+        assert_eq!(plan.to_delete, vec!["gone.jsonl"]);
+    }
+
+    #[test]
+    fn peers_and_projects_are_tracked_independently() {
+        let mut store = PeerStore::default();
+        let now = vec![tuple("a.jsonl", 10, 1)];
+        record(&mut store, "laptop", "/proj", &now);
+        // A different peer has seen nothing.
+        assert_eq!(delta(&store, "desktop", "/proj", &now).to_upsert.len(), 1);
+        // A different project on the same peer likewise.
+        assert_eq!(delta(&store, "laptop", "/other", &now).to_upsert.len(), 1);
+    }
+
+    #[test]
+    fn fingerprint_dir_walks_nested_files() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path();
+        std::fs::write(root.join("a.jsonl"), "hello").unwrap();
+        std::fs::create_dir_all(root.join("sid/subagents")).unwrap();
+        std::fs::write(root.join("sid/subagents/b.jsonl"), "sub").unwrap();
+
+        let fps = fingerprint_dir(root);
+        let paths: Vec<&str> = fps.iter().map(|t| t.file_path.as_str()).collect();
+        assert_eq!(paths, vec!["a.jsonl", "sid/subagents/b.jsonl"]);
+        assert_eq!(fps[0].size, 5);
+    }
+
+    #[test]
+    fn store_round_trips_through_serde() {
+        let mut store = PeerStore::default();
+        record(&mut store, "laptop", "/proj", &[tuple("a.jsonl", 10, 1)]);
+        let text = serde_json::to_string(&store).unwrap();
+        let back: PeerStore = serde_json::from_str(&text).unwrap();
+        assert_eq!(back.schema_version, SCHEMA_VERSION);
+        assert_eq!(back.peers["laptop"].projects["/proj"][0].size, 10);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claudepot",
   "private": true,
-  "version": "0.4.5",
+  "version": "0.4.6",
   "license": "ISC",
   "type": "module",
   "engines": {

--- a/src-tauri/src/commands/migrate.rs
+++ b/src-tauri/src/commands/migrate.rs
@@ -117,6 +117,7 @@ pub async fn migrate_export(args: ExportArgsDto) -> Result<ExportReceiptDto, Err
         encrypt_passphrase,
         sign_keyfile: args.sign_keyfile,
         sign_password,
+        since_peer: None,
         account_stubs,
     };
     let receipt = migrate::export_projects(&config_dir, opts)?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claudepot",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "identifier": "com.claudepot.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/web/src/app/(reader)/app/install/page.mdx
+++ b/web/src/app/(reader)/app/install/page.mdx
@@ -5,7 +5,7 @@ export const metadata = {
 
 # Install
 
-> **Status: beta (`0.4.5`).** Daily-driven on macOS. Linux and
+> **Status: beta (`0.4.6`).** Daily-driven on macOS. Linux and
 > Windows builds are green but less seasoned.
 
 Two paths: grab a signed installer from the latest release (fast,


### PR DESCRIPTION
Makes `migrate` repeatable instead of one-shot, implementing the parts of
`dev-docs/archive/project-migrate-spec.md` that were specified but never built.

## What's new

- **`import --mode=merge` works.** Unions a bundle into an existing project
  instead of refusing. Sessions only the target holds are preserved — the
  previous whole-directory rename destroyed them. A session id present on both
  machines is a conflict resolved by `--prefer-imported` / `--prefer-target`,
  and refused without one rather than picking a winner (§6, golden #16).
- **`~/.claude.json` and `history.jsonl` travel with a project** (§5.6 / §5.7).
  The `projects[<cwd>]` entry is re-keyed with embedded paths re-anchored;
  history lines are appended and deduped by `(sessionId, hash(prompt))`, never
  reordered. Additive bundle entries — no schema bump, older bundles import
  unchanged.
- **`export --since-peer <id>`** ships only what changed. Fingerprints, not a
  high-water mark: `session slim` rewrites transcripts *smaller* in place and
  retention deletes them outright, and a watermark skips both. Removals ride
  along as tombstones the importer reports but never acts on.

## Fixes

- Overlap detection never fired — the importer hardcoded a zero-count "no
  overlap", so a cross-machine session id collision was undetectable and
  golden #16 could not fail under any input.
- `undo` could restore a half-applied `~/.claude.json` / `history.jsonl`:
  snapshots are named per `(bundle, target)`, so a second project in one bundle
  overwrote the pre-import copy with mutated bytes. First snapshot now wins,
  fixed at the shared helper.
- A merge failing partway left already-placed files out of the journal,
  invisible to rollback.
- A delta whose only news was a removal carried no slug tree and was refused
  before its tombstones were read.
- The dry run ignored `--remap` and could promise an import apply refused.

`--mode=replace` now refuses explicitly instead of falling through a generic
arm; its archive-to-trash step remains unimplemented.

## Verification

- `cargo test -p claudepot-core -p claudepot-cli --lib` — 3517 passed, 0 failed
- `pnpm test` — 134 files, 1244 tests passed
- `cargo clippy --all-targets -D warnings` — clean
- `cargo check --workspace`, `cargo xtask verify-docs`, `repo-invariants.sh` — clean
- `pnpm build` — green

Docs updated: AGENTS.md (`migrate-peers.json` data-dir entry), README CLI block,
CHANGELOG.