### PR TITLE
fix(web): stop the database being a hard build dependency

### DIFF
--- a/web/src/app/(reader)/c/[slug]/page.tsx
+++ b/web/src/app/(reader)/c/[slug]/page.tsx
@@ -29,7 +29,26 @@ import { decodeCursor, isCursorTime } from "@/lib/api/cursor";
 export const dynamic = "force-dynamic";
 
 export async function generateStaticParams() {
-  return (await getAllTags()).map((t) => ({ slug: t.slug }));
+  try {
+    return (await getAllTags()).map((t) => ({ slug: t.slug }));
+  } catch (err) {
+    // No reachable database at build time. Two real cases: a Preview
+    // deployment, which has no NEON_DATABASE_URL (the variable is scoped
+    // to Development and Production), and a Neon cold start racing the
+    // production build.
+    //
+    // Returning [] is safe *because of* `force-dynamic` above — these
+    // params are a prerender hint, not the route's only entry, so every
+    // slug still renders on demand and unknown ones still reach
+    // notFound(). The only thing lost is a warm cache on first hit.
+    // Throwing instead fails the whole build, which trades that warm
+    // cache for no site at all.
+    console.warn(
+      "[c/[slug]] generateStaticParams: no tags prerendered (database unreachable at build time)",
+      err,
+    );
+    return [];
+  }
 }
 
 export default async function TagPage({

--- a/web/src/app/api/rss/route.ts
+++ b/web/src/app/api/rss/route.ts
@@ -3,6 +3,11 @@ import { NextResponse } from "next/server";
 import { getSubmissionsByHot } from "@/db/queries";
 import { escapeXml as escape } from "@/lib/escape-xml";
 
+// Rendered per request, not at build — same reasoning as sitemap.ts: a
+// prerendered feed goes stale at deploy time, and building it makes the
+// database a hard build dependency.
+export const dynamic = "force-dynamic";
+
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://claudepot.com";
 
 export async function GET() {

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -2,6 +2,14 @@ import type { MetadataRoute } from "next";
 
 import { getSitemapSubmissions, getAllTags } from "@/db/queries";
 
+// Rendered per request, not at build. Two reasons, both load-bearing:
+// a build-time sitemap freezes at deploy time and goes stale as
+// submissions land, and generating it at build makes the database a
+// hard build dependency — which is how a Preview deployment (no
+// NEON_DATABASE_URL; the variable is scoped to Development and
+// Production) and a Neon cold start could each fail the whole build.
+export const dynamic = "force-dynamic";
+
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://claudepot.com";
 
 // Static product-docs routes under /app — mirrors the on-disk

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- .",
   "crons": [
     {
       "path": "/api/cron/digest-weekly",


### PR DESCRIPTION
Every Vercel **Preview** deployment has failed for 16 days — including before
the 0.4.6 work. Not a regression: `NEON_DATABASE_URL` is scoped to
**Development** and **Production** only, so a Preview build has no database,
and three routes queried one at build time. Production has the variable, which
is why production stayed green and the breakage stayed invisible.

The same shape is a live **production** hazard: a Neon cold start at the wrong
moment fails the production build outright — for content that is stale by the
time it deploys anyway.

## Changes

- **`sitemap.ts`, `api/rss/route.ts` → `force-dynamic`.** Both are feeds over
  changing content. Prerendering froze them at deploy time *and* made the
  database a build dependency; rendering per request fixes both at once.
- **`c/[slug]` `generateStaticParams` returns `[]`** when the query fails
  rather than throwing. Safe because of the `force-dynamic` already on that
  route — the params are a prerender hint, so every slug still renders on
  demand and unknown ones still reach `notFound()`. Only a warm first-hit
  cache is lost.
- **`ignoreCommand` in `web/vercel.json`** so a commit touching nothing under
  `web/` skips the build. This repo is a Tauri app with the site as a separate
  app; the 0.4.6 release triggered a full Next.js build for a one-character
  version string. `git diff --quiet` exits 0 (Vercel's skip signal) when `web/`
  is untouched, 1 when it is not. An unresolvable `HEAD^` errors with another
  code and the build runs — failing toward building.

## Verification

`NEON_DATABASE_URL=<unreachable> pnpm build` — the exact Preview condition:

- **Before:** failed at `/c/[slug]`, then at `/sitemap.xml`
- **After:** succeeds

Normal `pnpm build` green, with `/sitemap.xml` and `/api/rss` both reporting
`ƒ (Dynamic)`. `pnpm test` — 8 passed.

## Not done, deliberately

Adding `NEON_DATABASE_URL` to the Preview scope. It is the one-click fix and it
hands the production credential to every branch build.

Note this PR touches `web/`, so it will actually exercise the Preview build —
which is the point.