### PR TITLE
fix(xtask): resolve const filenames, cross-check the WAL cleanup list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,16 @@ version lock-step check (tag vs `Cargo.toml`, `package.json`,
     v2 is `agents.json`. Kept documented because it still exists on
     any install that predates the rename, and a stray file in the data
     dir with no entry here reads as unexplained.
+  - `cc_tips_snapshots.jsonl` — append-only log converting CC's
+    counter-only tips state (`tipsHistory`, `numStartups` — integers,
+    no timestamps) into wall-clock time. Owned by
+    `claudepot-core::cc_tips::history`; see `dev-docs/cc-tips-ledger.md`
+    §6. Append-only: deleting it loses the time mapping for past
+    counters, which cannot be reconstructed.
+  - `doctor-parse-failures.jsonl` — append-only log of inputs
+    `cc doctor` could not parse, for diagnosing the user's environment.
+    Owned by `claudepot-core::cc_doctor::parse_failures`. Safe to
+    delete; it is diagnostic history, not state anything reads back.
   - `pricing-cache.json` — cached result of the live pricing scrape.
     Owned by `claudepot-core::pricing` (`CACHE_FILENAME`). Pure cache:
     safe to delete, refetched on next scrape. Distinct from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,11 @@ version lock-step check (tag vs `Cargo.toml`, `package.json`,
     v2 is `agents.json`. Kept documented because it still exists on
     any install that predates the rename, and a stray file in the data
     dir with no entry here reads as unexplained.
+  - `pricing-cache.json` — cached result of the live pricing scrape.
+    Owned by `claudepot-core::pricing` (`CACHE_FILENAME`). Pure cache:
+    safe to delete, refetched on next scrape. Distinct from
+    `pricing-history.json`, which is an append-only record of observed
+    rate *changes* and is not regenerable — see "## Pricing".
   - `cc_tips_catalog.json` — cache of the tips catalog extracted from
     the CC binary. Owned by `claudepot-core::cc_tips::catalog`. Pure
     cache: safe to delete, rebuilt on next extraction. Resolved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8201,6 +8201,7 @@ dependencies = [
  "claudepot-core",
  "serde",
  "serde_json",
+ "syn 2.0.117",
  "uuid",
 ]
 

--- a/crates/claudepot-core/src/db_housekeeping.rs
+++ b/crates/claudepot-core/src/db_housekeeping.rs
@@ -19,6 +19,12 @@ use std::time::Duration;
 /// Filenames Claudepot writes inside its data dir. Kept exhaustive
 /// so future stores added to `claudepot-core` show up here too —
 /// missing one only means a small `*.db-wal` leak, never data loss.
+///
+/// "Kept exhaustive" was aspirational until 2026-08-12: `boards.db`
+/// and `corpus.db` had both shipped without being added, so both were
+/// leaking WAL sidecars. `cargo xtask verify-docs` now cross-checks
+/// this list against the `.db` filenames it finds in source, so the
+/// next omission fails a gate instead of relying on someone noticing.
 pub(crate) const KNOWN_DB_FILENAMES: &[&str] = &[
     "sessions.db",
     "activity_metrics.db",
@@ -26,6 +32,8 @@ pub(crate) const KNOWN_DB_FILENAMES: &[&str] = &[
     "accounts.db",
     "keys.db",
     "env-vault.db",
+    "boards.db",
+    "corpus.db",
 ];
 
 /// Short busy_timeout for the throw-away connections. If another

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -18,3 +18,11 @@ serde_json.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 uuid.workspace = true
+# Real parsing for the data-dir scans in `verify_docs`. String matching
+# there produced three distinct blindness bugs — truncating at the first
+# `#[cfg(test)]`, seeing only string literals, and resolving consts only
+# within one file — each fix a heuristic layered on the last. `syn` is
+# already vendored transitively (serde_derive, thiserror) and xtask is
+# workspace automation that never ships, so the cost is build time in a
+# dev tool and the payoff is that all three classes become unreachable.
+syn = { version = "2", features = ["full", "visit", "parsing"] }

--- a/crates/xtask/src/data_dir_scan.rs
+++ b/crates/xtask/src/data_dir_scan.rs
@@ -1,0 +1,368 @@
+//! Which files Claudepot writes into its data dir, read from the AST.
+//!
+//! # Why this parses instead of matching strings
+//!
+//! The scan this replaced was string matching, and it went blind three
+//! separate times in one day — each fix a heuristic layered on the last:
+//!
+//! 1. **Truncating at the first `#[cfg(test)]`** to drop test scratch
+//!    names. `#[cfg(test)]` also marks individual methods, so
+//!    `agent/store.rs` (attribute at line 791, test module at 1280) hid
+//!    ~490 lines of production code including `agents_file_path()`.
+//! 2. **Reading only string literals.** `board/mod.rs` writes
+//!    `claudepot_data_dir().join(BOARDS_DB_FILENAME)`. `boards.db` was
+//!    therefore invisible, which is how it stayed out of
+//!    `KNOWN_DB_FILENAMES` and leaked WAL sidecars while the gate
+//!    reported green.
+//! 3. **Resolving consts within one file only** — a const declared in
+//!    one module and joined in another still slipped through.
+//!
+//! Every one of those is a property of the *representation*, not of the
+//! rule being checked. A parser has none of them: `#[cfg(test)]` is an
+//! attribute on a node, a const is a binding, and a receiver chain is a
+//! tree. Consts are collected across the whole crate in a first pass, so
+//! cross-module indirection resolves too.
+//!
+//! # What it deliberately does not do
+//!
+//! No const *expression* evaluation: `concat!`, `format!`, and a name
+//! built from parts all resolve to `None` and are skipped rather than
+//! guessed at. If that ever hides a real file, the blindness guards in
+//! `verify_docs` fail loudly rather than passing green — a scan that
+//! silently matches nothing is the failure mode this module exists to
+//! make impossible.
+
+use anyhow::{Context, Result};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use syn::visit::Visit;
+
+/// Filenames the crate joins onto its data dir.
+#[derive(Debug, Default)]
+pub struct DataDirFiles {
+    /// Every `*.db`. Not restricted to `claudepot_data_dir()` receivers:
+    /// most databases are reached through their own path helper, so
+    /// requiring the anchor would lose most of the coverage. `.db` is
+    /// unambiguous in this crate — the only false positives are tempdir
+    /// scratch files, excluded structurally below.
+    pub dbs: BTreeSet<String>,
+    /// Every `*.json` joined onto a `claudepot_data_dir()` receiver.
+    /// Anchored, because `.json` also names CC's `settings.json`,
+    /// `~/.claude.json` and bundle entries like `manifest.json`, and a
+    /// check that cries wolf is one people learn to skip.
+    pub jsons: BTreeSet<String>,
+}
+
+/// Parse every `.rs` file under `core_src` and report what it writes.
+pub fn scan(core_src: &Path) -> Result<DataDirFiles> {
+    let mut files = Vec::new();
+    collect_files(core_src, &mut files)?;
+
+    let parsed: Vec<syn::File> = files
+        .iter()
+        .map(|p| {
+            let text =
+                std::fs::read_to_string(p).with_context(|| format!("read {}", p.display()))?;
+            syn::parse_file(&text).with_context(|| format!("parse {}", p.display()))
+        })
+        .collect::<Result<_>>()?;
+
+    // Pass 1 — every `const NAME: &str = "…"` in the crate. Crate-wide
+    // rather than per-file so a const declared in one module and joined
+    // in another resolves.
+    let mut consts = BTreeMap::new();
+    for f in &parsed {
+        let mut c = ConstCollector { out: &mut consts };
+        c.visit_file(f);
+    }
+
+    // Pass 2 — the joins.
+    let mut v = JoinVisitor {
+        consts: &consts,
+        out: DataDirFiles::default(),
+    };
+    for f in &parsed {
+        v.visit_file(f);
+    }
+    Ok(v.out)
+}
+
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_files(&path, out)?;
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// True when the node is compiled only under `cfg(test)`.
+fn is_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|a| {
+        if !a.path().is_ident("cfg") {
+            return false;
+        }
+        let mut found = false;
+        // `parse_nested_meta` walks `cfg(test)`, `cfg(all(test, …))`,
+        // and `cfg(any(test, …))` alike, so a nested form is caught too.
+        let _ = a.parse_nested_meta(|meta| {
+            if meta.path.is_ident("test") {
+                found = true;
+            }
+            Ok(())
+        });
+        found
+    })
+}
+
+struct ConstCollector<'a> {
+    out: &'a mut BTreeMap<String, String>,
+}
+
+impl<'ast> Visit<'ast> for ConstCollector<'_> {
+    fn visit_item_const(&mut self, node: &'ast syn::ItemConst) {
+        if let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(s),
+            ..
+        }) = &*node.expr
+        {
+            self.out.insert(node.ident.to_string(), s.value());
+        }
+    }
+}
+
+struct JoinVisitor<'a> {
+    consts: &'a BTreeMap<String, String>,
+    out: DataDirFiles,
+}
+
+impl JoinVisitor<'_> {
+    /// The filename a `join` argument denotes: a string literal, or a
+    /// const resolved from the crate-wide map. `None` for anything the
+    /// scan will not guess at.
+    fn filename(&self, arg: &syn::Expr) -> Option<String> {
+        match arg {
+            syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Str(s),
+                ..
+            }) => Some(s.value()),
+            syn::Expr::Path(p) => {
+                let ident = p.path.segments.last()?.ident.to_string();
+                self.consts.get(&ident).cloned()
+            }
+            // `&EXPR` — the borrow is noise, the inner expression is not.
+            syn::Expr::Reference(r) => self.filename(&r.expr),
+            _ => None,
+        }
+    }
+}
+
+/// Does this receiver expression contain a `claudepot_data_dir()` call?
+fn mentions_data_dir(expr: &syn::Expr) -> bool {
+    struct Finder(bool);
+    impl<'ast> Visit<'ast> for Finder {
+        fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+            if let syn::Expr::Path(p) = &*node.func {
+                if p.path
+                    .segments
+                    .last()
+                    .is_some_and(|s| s.ident == "claudepot_data_dir")
+                {
+                    self.0 = true;
+                }
+            }
+            syn::visit::visit_expr_call(self, node);
+        }
+    }
+    let mut f = Finder(false);
+    f.visit_expr(expr);
+    f.0
+}
+
+/// Is the receiver a tempdir handle — `dir.path()`, `td.path()`?
+///
+/// Structural, where the old scan matched the literal text `.path()`.
+/// Test scratch files (`test.db`, `a.db`) are all rooted this way, and
+/// they are the one shape a loose `.db` match must exclude.
+fn is_tempdir_receiver(expr: &syn::Expr) -> bool {
+    match expr {
+        syn::Expr::MethodCall(m) => m.method == "path",
+        syn::Expr::Reference(r) => is_tempdir_receiver(&r.expr),
+        _ => false,
+    }
+}
+
+impl<'ast> Visit<'ast> for JoinVisitor<'_> {
+    // Skipping `cfg(test)` nodes structurally is what removes the
+    // truncation heuristic entirely: a test module, a `#[cfg(test)]`
+    // helper fn, and a `#[cfg(test)]` method are all just nodes with
+    // that attribute, wherever they sit in the file.
+    fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_item_mod(self, node);
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_item_fn(self, node);
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_impl_item_fn(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        if node.method == "join" && node.args.len() == 1 {
+            if let Some(name) = self.filename(&node.args[0]) {
+                if name.ends_with(".db") {
+                    if !is_tempdir_receiver(&node.receiver) {
+                        self.out.dbs.insert(name);
+                    }
+                } else if name.ends_with(".json") && mentions_data_dir(&node.receiver) {
+                    self.out.jsons.insert(name);
+                }
+            }
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scan_src(src: &str) -> DataDirFiles {
+        let f = syn::parse_file(src).expect("parse");
+        let mut consts = BTreeMap::new();
+        ConstCollector { out: &mut consts }.visit_file(&f);
+        let mut v = JoinVisitor {
+            consts: &consts,
+            out: DataDirFiles::default(),
+        };
+        v.visit_file(&f);
+        v.out
+    }
+
+    /// Bug 2: the filename is a const, not a literal.
+    #[test]
+    fn resolves_a_const_filename() {
+        let out = scan_src(
+            r#"
+            pub const BOARDS_DB_FILENAME: &str = "boards.db";
+            pub fn boards_db_path() -> PathBuf {
+                claudepot_data_dir().join(BOARDS_DB_FILENAME)
+            }
+            "#,
+        );
+        assert!(out.dbs.contains("boards.db"));
+    }
+
+    /// Bug 3: the const lives in another module. One crate-wide map, so
+    /// declaration and use need not share a file.
+    #[test]
+    fn resolves_a_const_declared_in_another_file() {
+        let decl =
+            syn::parse_file("pub const CACHE_FILENAME: &str = \"pricing-cache.json\";").unwrap();
+        let usage =
+            syn::parse_file("fn p() -> PathBuf { claudepot_data_dir().join(CACHE_FILENAME) }")
+                .unwrap();
+        let mut consts = BTreeMap::new();
+        ConstCollector { out: &mut consts }.visit_file(&decl);
+        let mut v = JoinVisitor {
+            consts: &consts,
+            out: DataDirFiles::default(),
+        };
+        v.visit_file(&usage);
+        assert!(v.out.jsons.contains("pricing-cache.json"));
+    }
+
+    /// Bug 1: a `#[cfg(test)]` method must not truncate the production
+    /// code that follows it in the same file.
+    #[test]
+    fn production_after_a_cfg_test_method_is_still_scanned() {
+        let out = scan_src(
+            r#"
+            impl S {
+                #[cfg(test)]
+                fn helper() -> PathBuf { claudepot_data_dir().join("scratch.json") }
+            }
+            fn real() -> PathBuf { claudepot_data_dir().join("agents.json") }
+            "#,
+        );
+        assert!(
+            out.jsons.contains("agents.json"),
+            "production code after a cfg(test) method must be seen"
+        );
+        assert!(
+            !out.jsons.contains("scratch.json"),
+            "the cfg(test) method must be skipped"
+        );
+    }
+
+    #[test]
+    fn test_modules_are_skipped_wherever_they_sit() {
+        let out = scan_src(
+            r#"
+            #[cfg(test)]
+            mod tests {
+                fn t() -> PathBuf { dir.path().join("test.db") }
+            }
+            fn real() -> PathBuf { claudepot_data_dir().join("corpus.db") }
+            "#,
+        );
+        assert!(out.dbs.contains("corpus.db"));
+        assert!(!out.dbs.contains("test.db"));
+    }
+
+    /// Tempdir scratch files are excluded by receiver shape, not by
+    /// matching the text `.path()`.
+    #[test]
+    fn tempdir_rooted_databases_are_excluded() {
+        let out = scan_src(r#"fn t() -> PathBuf { dir.path().join("a.db") }"#);
+        assert!(out.dbs.is_empty());
+    }
+
+    /// `.json` is anchored; `.db` is not. CC's own files must not be
+    /// swept into the data-dir list.
+    #[test]
+    fn json_requires_the_data_dir_anchor() {
+        let out = scan_src(
+            r#"
+            fn cc() -> PathBuf { config_dir.join("settings.json") }
+            fn bundle() -> PathBuf { staged.join("manifest.json") }
+            fn ours() -> PathBuf { claudepot_data_dir().join("routes.json") }
+            "#,
+        );
+        assert_eq!(
+            out.jsons.into_iter().collect::<Vec<_>>(),
+            vec!["routes.json".to_string()]
+        );
+    }
+
+    /// A name the scan cannot resolve is skipped, never guessed at.
+    #[test]
+    fn unresolvable_names_are_skipped() {
+        let out = scan_src(r#"fn t(name: &str) -> PathBuf { claudepot_data_dir().join(name) }"#);
+        assert!(out.jsons.is_empty() && out.dbs.is_empty());
+    }
+
+    /// A wrapped chain is a tree, so line breaks are irrelevant — the
+    /// window heuristic the string scan needed is simply gone.
+    #[test]
+    fn wrapping_is_irrelevant_to_a_parser() {
+        let out = scan_src(
+            "fn t() -> PathBuf {\n    crate::paths::claudepot_data_dir()\n        .join(\"usage_alert_state.json\")\n}",
+        );
+        assert!(out.jsons.contains("usage_alert_state.json"));
+    }
+}

--- a/crates/xtask/src/data_dir_scan.rs
+++ b/crates/xtask/src/data_dir_scan.rs
@@ -23,14 +23,33 @@
 //! tree. Consts are collected across the whole crate in a first pass, so
 //! cross-module indirection resolves too.
 //!
+//! Parsing removed the representation bugs. It did not, on its own,
+//! fix **scope** bugs, and those turned out to be the ones that
+//! mattered. Measured against the real `~/.claudepot` rather than
+//! reasoned about:
+//!
+//! 4. **Only one crate was scanned.** Three write to the data dir —
+//!    `src-tauri/src/preferences.rs` joins `preferences.json` directly,
+//!    and the CLI reaches several databases the same way. Core-only
+//!    passed on those because core happens to name them too.
+//! 5. **Only `.json` was asked about.** `.jsonl` is the append-only log
+//!    shape and two real files use it. `"x.jsonl".ends_with(".json")`
+//!    is false, so neither was even a near miss — both sat on disk,
+//!    undocumented, indefinitely.
+//!
 //! # What it deliberately does not do
 //!
 //! No const *expression* evaluation: `concat!`, `format!`, and a name
-//! built from parts all resolve to `None` and are skipped rather than
-//! guessed at. If that ever hides a real file, the blindness guards in
-//! `verify_docs` fail loudly rather than passing green — a scan that
-//! silently matches nothing is the failure mode this module exists to
-//! make impossible.
+//! built from parts resolve to `None` and are skipped rather than
+//! guessed at. This is a real limit but **not a live one** — a sweep of
+//! all three crates found zero data-dir joins of that shape. It is
+//! recorded as a boundary, not advertised as the next thing to fix;
+//! saying so once cost a round of attention that the two scope bugs
+//! above deserved.
+//!
+//! The blindness guards in `verify_docs` remain the backstop: a scan
+//! that silently matches nothing is the failure mode this module exists
+//! to make impossible.
 
 use anyhow::{Context, Result};
 use std::collections::{BTreeMap, BTreeSet};
@@ -53,10 +72,29 @@ pub struct DataDirFiles {
     pub jsons: BTreeSet<String>,
 }
 
-/// Parse every `.rs` file under `core_src` and report what it writes.
-pub fn scan(core_src: &Path) -> Result<DataDirFiles> {
+/// Crates that write into the Claudepot data dir.
+///
+/// All three, not just core. `src-tauri/src/preferences.rs` joins
+/// `preferences.json` onto the data dir directly, and the CLI reaches
+/// several databases the same way. Scanning core alone reported green
+/// on those only because core happens to name them too — a file added
+/// solely in the Tauri or CLI crate would have been invisible, which is
+/// the same "green for the wrong reason" this scan exists to prevent.
+const SCANNED_CRATES: &[&str] = &[
+    "crates/claudepot-core/src",
+    "crates/claudepot-cli/src",
+    "src-tauri/src",
+];
+
+/// Parse every `.rs` file in every crate that writes to the data dir.
+pub fn scan(repo: &Path) -> Result<DataDirFiles> {
     let mut files = Vec::new();
-    collect_files(core_src, &mut files)?;
+    for rel in SCANNED_CRATES {
+        let root = repo.join(rel);
+        if root.is_dir() {
+            collect_files(&root, &mut files)?;
+        }
+    }
 
     let parsed: Vec<syn::File> = files
         .iter()
@@ -182,15 +220,44 @@ fn mentions_data_dir(expr: &syn::Expr) -> bool {
     f.0
 }
 
-/// Is the receiver a tempdir handle — `dir.path()`, `td.path()`?
+/// JSON-shaped state, which on disk means `.json` *and* `.jsonl`.
+///
+/// `.jsonl` is not a variant spelling — it is the append-only log
+/// shape, and two real files use it (`cc_tips_snapshots.jsonl`,
+/// `doctor-parse-failures.jsonl`). Both sat undocumented because the
+/// scan only asked about `.json`, and `"x.jsonl".ends_with(".json")`
+/// is false, so neither was ever a near miss.
+fn is_json_state(name: &str) -> bool {
+    name.ends_with(".json") || name.ends_with(".jsonl")
+}
+
+/// Is the receiver a scratch location rather than the data dir?
+///
+/// Two shapes, both meaning "explicitly not where we keep state":
+///
+/// - `dir.path()` — a `TempDir` handle. Test scratch files (`test.db`,
+///   `a.db`) are all rooted this way.
+/// - `std::env::temp_dir()` — the system temp dir.
+///   `src-tauri/src/lib.rs:399` uses it for a
+///   `claudepot-memory_changes.db` fallback, which the unanchored `.db`
+///   match reported as a data-dir database until this covered it.
 ///
 /// Structural, where the old scan matched the literal text `.path()`.
-/// Test scratch files (`test.db`, `a.db`) are all rooted this way, and
-/// they are the one shape a loose `.db` match must exclude.
-fn is_tempdir_receiver(expr: &syn::Expr) -> bool {
+/// This exclusion is the cost of leaving `.db` unanchored; it is worth
+/// paying because anchoring `.db` would lose the databases reached
+/// through their own path helpers, which is most of them.
+fn is_scratch_receiver(expr: &syn::Expr) -> bool {
     match expr {
         syn::Expr::MethodCall(m) => m.method == "path",
-        syn::Expr::Reference(r) => is_tempdir_receiver(&r.expr),
+        syn::Expr::Call(c) => match &*c.func {
+            syn::Expr::Path(p) => p
+                .path
+                .segments
+                .last()
+                .is_some_and(|s| s.ident == "temp_dir"),
+            _ => false,
+        },
+        syn::Expr::Reference(r) => is_scratch_receiver(&r.expr),
         _ => false,
     }
 }
@@ -225,10 +292,10 @@ impl<'ast> Visit<'ast> for JoinVisitor<'_> {
         if node.method == "join" && node.args.len() == 1 {
             if let Some(name) = self.filename(&node.args[0]) {
                 if name.ends_with(".db") {
-                    if !is_tempdir_receiver(&node.receiver) {
+                    if !is_scratch_receiver(&node.receiver) {
                         self.out.dbs.insert(name);
                     }
-                } else if name.ends_with(".json") && mentions_data_dir(&node.receiver) {
+                } else if is_json_state(&name) && mentions_data_dir(&node.receiver) {
                     self.out.jsons.insert(name);
                 }
             }
@@ -327,7 +394,7 @@ mod tests {
     /// Tempdir scratch files are excluded by receiver shape, not by
     /// matching the text `.path()`.
     #[test]
-    fn tempdir_rooted_databases_are_excluded() {
+    fn scratch_rooted_databases_are_excluded() {
         let out = scan_src(r#"fn t() -> PathBuf { dir.path().join("a.db") }"#);
         assert!(out.dbs.is_empty());
     }
@@ -347,6 +414,27 @@ mod tests {
             out.jsons.into_iter().collect::<Vec<_>>(),
             vec!["routes.json".to_string()]
         );
+    }
+
+    /// Scope bug 5: `.jsonl` is a real data-dir shape, and it is not a
+    /// suffix of `.json`, so it was never even a near miss.
+    #[test]
+    fn jsonl_counts_as_json_state() {
+        let out = scan_src(
+            r#"fn t() -> PathBuf { claudepot_data_dir().join("doctor-parse-failures.jsonl") }"#,
+        );
+        assert!(out.jsons.contains("doctor-parse-failures.jsonl"));
+    }
+
+    /// `std::env::temp_dir()` is a scratch location, not the data dir.
+    /// The unanchored `.db` match reported `src-tauri`'s fallback
+    /// database until the exclusion covered this shape too.
+    #[test]
+    fn system_temp_dir_databases_are_excluded() {
+        let out = scan_src(
+            r#"fn t() -> PathBuf { std::env::temp_dir().join("claudepot-memory_changes.db") }"#,
+        );
+        assert!(out.dbs.is_empty());
     }
 
     /// A name the scan cannot resolve is skipped, never guessed at.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -7,6 +7,7 @@
 //!
 //! See `parity-harness/README.md` for the full design.
 
+mod data_dir_scan;
 mod screenshot_fixture;
 mod verify_docs;
 

--- a/crates/xtask/src/verify_docs.rs
+++ b/crates/xtask/src/verify_docs.rs
@@ -315,7 +315,7 @@ fn known_db_filenames(src: &str) -> BTreeSet<String> {
 
 fn check_data_dir_databases(repo: &Path, problems: &mut Vec<String>) -> Result<()> {
     let agents = read(repo, "AGENTS.md")?;
-    let shipped = crate::data_dir_scan::scan(&repo.join("crates/claudepot-core/src"))?.dbs;
+    let shipped = crate::data_dir_scan::scan(repo)?.dbs;
 
     // The WAL-cleanup list must cover every database that actually
     // ships. Its own doc comment calls it exhaustive, and it was not:
@@ -352,7 +352,7 @@ fn check_data_dir_databases(repo: &Path, problems: &mut Vec<String>) -> Result<(
 
 fn check_data_dir_json_state(repo: &Path, problems: &mut Vec<String>) -> Result<()> {
     let agents = read(repo, "AGENTS.md")?;
-    let shipped = crate::data_dir_scan::scan(&repo.join("crates/claudepot-core/src"))?.jsons;
+    let shipped = crate::data_dir_scan::scan(repo)?.jsons;
 
     // Guard against the detector silently finding nothing — a heuristic
     // that matches zero sites reports "all documented" forever. AGENTS.md

--- a/crates/xtask/src/verify_docs.rs
+++ b/crates/xtask/src/verify_docs.rs
@@ -39,7 +39,7 @@
 //! thing and forgot to say so", which is the whole observed failure.
 
 use anyhow::{bail, Context, Result};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 /// Screenshots, and the source whose UI they depict.
@@ -290,6 +290,55 @@ fn check_settings_panes(repo: &Path, problems: &mut Vec<String>) -> Result<()> {
 /// production code (including `agents_file_path()`, which builds
 /// `agents.json`) sat outside the scan. The cut must therefore be the
 /// attribute that introduces a *module*, not any occurrence of it.
+/// `const NAME: &str = "value";` declarations in one file.
+///
+/// Needed because filenames are not always literals at the join site.
+/// `board/mod.rs` writes
+/// `claudepot_data_dir().join(BOARDS_DB_FILENAME)`, and a scan that
+/// only reads string literals is structurally blind to it — which is
+/// how `boards.db` stayed out of `KNOWN_DB_FILENAMES` long enough to
+/// leak WAL sidecars, with a docs gate reporting green the whole time.
+fn const_strings(text: &str) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    for line in text.lines() {
+        let l = line.trim_start();
+        let l = l.strip_prefix("pub ").unwrap_or(l);
+        let l = l.strip_prefix("pub(crate) ").unwrap_or(l);
+        let Some(rest) = l.strip_prefix("const ") else {
+            continue;
+        };
+        let Some((name, tail)) = rest.split_once(':') else {
+            continue;
+        };
+        let Some(v) = tail
+            .split_once('"')
+            .and_then(|(_, r)| r.find('"').map(|e| r[..e].to_string()))
+        else {
+            continue;
+        };
+        out.insert(name.trim().to_string(), v);
+    }
+    out
+}
+
+/// The filename passed to `.join(…)`, whether written as a literal or
+/// as a const declared in the same file. `None` for anything else —
+/// a variable, an expression, a `format!` — which the caller skips.
+fn join_arg(after_join: &str, consts: &BTreeMap<String, String>) -> Option<String> {
+    let rest = after_join.trim_start();
+    if let Some(r) = rest.strip_prefix('"') {
+        return r.find('"').map(|e| r[..e].to_string());
+    }
+    let ident: String = rest
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+    if ident.is_empty() {
+        return None;
+    }
+    consts.get(&ident).cloned()
+}
+
 fn production_only(text: &str) -> &str {
     let mut from = 0usize;
     while let Some(i) = text[from..].find("#[cfg(test)]") {
@@ -307,11 +356,12 @@ fn shipped_databases(repo: &Path) -> Result<BTreeSet<String>> {
     let mut out = BTreeSet::new();
     let root = repo.join("crates/claudepot-core/src");
     walk_rs(&root, &mut |text| {
+        let consts = const_strings(text);
         let text = production_only(text);
         let mut from = 0usize;
-        while let Some(i) = text[from..].find(".join(\"") {
+        while let Some(i) = text[from..].find(".join(") {
             let at = from + i;
-            from = at + 7;
+            from = at + 6;
             // Deliberately NOT anchored on `claudepot_data_dir()` the way
             // the JSON scan is: most databases are reached through their
             // own path helper rather than a direct join, so anchoring
@@ -322,11 +372,9 @@ fn shipped_databases(repo: &Path) -> Result<BTreeSet<String>> {
             if text[..at].ends_with(".path()") {
                 continue;
             }
-            let rest = &text[from..];
-            if let Some(end) = rest.find('"') {
-                let name = &rest[..end];
+            if let Some(name) = join_arg(&text[from..], &consts) {
                 if name.ends_with(".db") {
-                    out.insert(name.to_string());
+                    out.insert(name);
                 }
             }
         }
@@ -349,13 +397,61 @@ fn walk_rs(dir: &Path, f: &mut impl FnMut(&str)) -> Result<()> {
     Ok(())
 }
 
+/// The `KNOWN_DB_FILENAMES` const, as declared in `db_housekeeping`.
+fn known_db_filenames(src: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let Some(start) = src.find("KNOWN_DB_FILENAMES") else {
+        return out;
+    };
+    let body = &src[start..];
+    let Some(end) = body.find("];") else {
+        return out;
+    };
+    let mut rest = &body[..end];
+    while let Some(i) = rest.find('"') {
+        rest = &rest[i + 1..];
+        if let Some(j) = rest.find('"') {
+            let name = &rest[..j];
+            if name.ends_with(".db") {
+                out.insert(name.to_string());
+            }
+            rest = &rest[j + 1..];
+        }
+    }
+    out
+}
+
 fn check_data_dir_databases(repo: &Path, problems: &mut Vec<String>) -> Result<()> {
     let agents = read(repo, "AGENTS.md")?;
-    for db in shipped_databases(repo)? {
-        if !agents.contains(&db) {
+    let shipped = shipped_databases(repo)?;
+
+    // The WAL-cleanup list must cover every database that actually
+    // ships. Its own doc comment calls it exhaustive, and it was not:
+    // `boards.db` and `corpus.db` both shipped without being added, so
+    // both leaked `*.db-wal` sidecars until 2026-08-12. Nothing catches
+    // that at runtime — the leak is small and silent, which is exactly
+    // the kind of omission a gate has to notice instead of a person.
+    let housekeeping = read(repo, "crates/claudepot-core/src/db_housekeeping.rs")?;
+    let known = known_db_filenames(&housekeeping);
+    if known.is_empty() {
+        problems.push(
+            "could not parse `KNOWN_DB_FILENAMES` from db_housekeeping.rs — the WAL-cleanup \
+             cross-check is blind. Fix `known_db_filenames`, not the const"
+                .to_string(),
+        );
+    }
+
+    for db in &shipped {
+        if !agents.contains(db.as_str()) {
             problems.push(format!(
                 "`{db}` lives under the Claudepot data dir but AGENTS.md never names it \
                  — an agent reading AGENTS.md will not know it exists"
+            ));
+        }
+        if !known.is_empty() && !known.contains(db) {
+            problems.push(format!(
+                "`{db}` ships but is absent from `KNOWN_DB_FILENAMES` in db_housekeeping.rs \
+                 — its `*.db-wal` sidecar will never be cleaned up"
             ));
         }
     }
@@ -381,7 +477,7 @@ fn check_data_dir_databases(repo: &Path, problems: &mut Vec<String>) -> Result<(
 /// detector ever stops finding the files AGENTS.md documents, which is
 /// what turns this from a check that *cannot* fail into one that has
 /// been watched failing.
-fn json_state_in(text: &str, out: &mut BTreeSet<String>) {
+fn json_state_in(text: &str, consts: &BTreeMap<String, String>, out: &mut BTreeSet<String>) {
     const ANCHOR: &str = "claudepot_data_dir()";
     // Enough to clear a rustfmt line break plus indentation between the
     // anchor and its `.join(`, and short enough that an unrelated
@@ -393,14 +489,12 @@ fn json_state_in(text: &str, out: &mut BTreeSet<String>) {
         let start = from + i + ANCHOR.len();
         from = start;
         let window = &text[start..text.len().min(start + WINDOW)];
-        let Some(j) = window.find(".join(\"") else {
+        let Some(j) = window.find(".join(") else {
             continue;
         };
-        let rest = &window[j + 7..];
-        if let Some(end) = rest.find('"') {
-            let name = &rest[..end];
+        if let Some(name) = join_arg(&window[j + 6..], consts) {
             if name.ends_with(".json") {
-                out.insert(name.to_string());
+                out.insert(name);
             }
         }
     }
@@ -410,7 +504,8 @@ fn shipped_json_state(repo: &Path) -> Result<BTreeSet<String>> {
     let mut out = BTreeSet::new();
     let root = repo.join("crates/claudepot-core/src");
     walk_rs(&root, &mut |text| {
-        json_state_in(production_only(text), &mut out)
+        let consts = const_strings(text);
+        json_state_in(production_only(text), &consts, &mut out)
     })?;
     Ok(out)
 }
@@ -703,6 +798,38 @@ mod tests {
         assert!(!kept.contains("scratch"), "the test module must be cut");
     }
 
+    /// The blindness that let `boards.db` ship unlisted: its filename
+    /// is a const, so `.join(BOARDS_DB_FILENAME)` carries no literal
+    /// for a string scan to find.
+    #[test]
+    fn join_arg_resolves_a_const_filename() {
+        let consts = const_strings("pub const BOARDS_DB_FILENAME: &str = \"boards.db\";\n");
+        assert_eq!(
+            consts.get("BOARDS_DB_FILENAME").map(String::as_str),
+            Some("boards.db")
+        );
+        assert_eq!(
+            join_arg("BOARDS_DB_FILENAME)", &consts).as_deref(),
+            Some("boards.db")
+        );
+        // Literals still work, and an unresolvable expression is skipped
+        // rather than guessed at.
+        assert_eq!(join_arg("\"x.db\")", &consts).as_deref(), Some("x.db"));
+        assert_eq!(join_arg("some_var)", &consts), None);
+    }
+
+    #[test]
+    fn json_state_resolves_a_const_filename() {
+        let consts = const_strings("const CACHE_FILENAME: &str = \"pricing-cache.json\";\n");
+        let mut out = BTreeSet::new();
+        json_state_in(
+            "claudepot_data_dir().join(CACHE_FILENAME)",
+            &consts,
+            &mut out,
+        );
+        assert!(out.contains("pricing-cache.json"));
+    }
+
     #[test]
     fn production_only_is_identity_without_a_test_module() {
         let src = "fn only() {}\n";
@@ -722,6 +849,7 @@ mod tests {
             // Not JSON.
             fn e() -> PathBuf { claudepot_data_dir().join("corpus.db") }
             "#,
+            &BTreeMap::new(),
             &mut out,
         );
         assert_eq!(
@@ -737,6 +865,7 @@ mod tests {
         let mut out = BTreeSet::new();
         json_state_in(
             "crate::paths::claudepot_data_dir()\n            .join(\"usage_alert_state.json\")",
+            &BTreeMap::new(),
             &mut out,
         );
         assert!(out.contains("usage_alert_state.json"));

--- a/crates/xtask/src/verify_docs.rs
+++ b/crates/xtask/src/verify_docs.rs
@@ -39,7 +39,7 @@
 //! thing and forgot to say so", which is the whole observed failure.
 
 use anyhow::{bail, Context, Result};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 /// Screenshots, and the source whose UI they depict.
@@ -290,114 +290,6 @@ fn check_settings_panes(repo: &Path, problems: &mut Vec<String>) -> Result<()> {
 /// production code (including `agents_file_path()`, which builds
 /// `agents.json`) sat outside the scan. The cut must therefore be the
 /// attribute that introduces a *module*, not any occurrence of it.
-/// `const NAME: &str = "value";` declarations in one file.
-///
-/// Needed because filenames are not always literals at the join site.
-/// `board/mod.rs` writes
-/// `claudepot_data_dir().join(BOARDS_DB_FILENAME)`, and a scan that
-/// only reads string literals is structurally blind to it — which is
-/// how `boards.db` stayed out of `KNOWN_DB_FILENAMES` long enough to
-/// leak WAL sidecars, with a docs gate reporting green the whole time.
-fn const_strings(text: &str) -> BTreeMap<String, String> {
-    let mut out = BTreeMap::new();
-    for line in text.lines() {
-        let l = line.trim_start();
-        let l = l.strip_prefix("pub ").unwrap_or(l);
-        let l = l.strip_prefix("pub(crate) ").unwrap_or(l);
-        let Some(rest) = l.strip_prefix("const ") else {
-            continue;
-        };
-        let Some((name, tail)) = rest.split_once(':') else {
-            continue;
-        };
-        let Some(v) = tail
-            .split_once('"')
-            .and_then(|(_, r)| r.find('"').map(|e| r[..e].to_string()))
-        else {
-            continue;
-        };
-        out.insert(name.trim().to_string(), v);
-    }
-    out
-}
-
-/// The filename passed to `.join(…)`, whether written as a literal or
-/// as a const declared in the same file. `None` for anything else —
-/// a variable, an expression, a `format!` — which the caller skips.
-fn join_arg(after_join: &str, consts: &BTreeMap<String, String>) -> Option<String> {
-    let rest = after_join.trim_start();
-    if let Some(r) = rest.strip_prefix('"') {
-        return r.find('"').map(|e| r[..e].to_string());
-    }
-    let ident: String = rest
-        .chars()
-        .take_while(|c| c.is_alphanumeric() || *c == '_')
-        .collect();
-    if ident.is_empty() {
-        return None;
-    }
-    consts.get(&ident).cloned()
-}
-
-fn production_only(text: &str) -> &str {
-    let mut from = 0usize;
-    while let Some(i) = text[from..].find("#[cfg(test)]") {
-        let at = from + i;
-        let after = text[at + "#[cfg(test)]".len()..].trim_start();
-        if after.starts_with("mod ") || after.starts_with("pub mod ") {
-            return &text[..at];
-        }
-        from = at + "#[cfg(test)]".len();
-    }
-    text
-}
-
-fn shipped_databases(repo: &Path) -> Result<BTreeSet<String>> {
-    let mut out = BTreeSet::new();
-    let root = repo.join("crates/claudepot-core/src");
-    walk_rs(&root, &mut |text| {
-        let consts = const_strings(text);
-        let text = production_only(text);
-        let mut from = 0usize;
-        while let Some(i) = text[from..].find(".join(") {
-            let at = from + i;
-            from = at + 6;
-            // Deliberately NOT anchored on `claudepot_data_dir()` the way
-            // the JSON scan is: most databases are reached through their
-            // own path helper rather than a direct join, so anchoring
-            // would lose most of the coverage. `.db` is unambiguous
-            // enough to match loosely — except for tempdir scratch files,
-            // which always come through `dir.path().join(…)` and are the
-            // one shape that must be excluded.
-            if text[..at].ends_with(".path()") {
-                continue;
-            }
-            if let Some(name) = join_arg(&text[from..], &consts) {
-                if name.ends_with(".db") {
-                    out.insert(name);
-                }
-            }
-        }
-    })?;
-    Ok(out)
-}
-
-fn walk_rs(dir: &Path, f: &mut impl FnMut(&str)) -> Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            walk_rs(&path, f)?;
-        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
-            if let Ok(text) = std::fs::read_to_string(&path) {
-                f(&text);
-            }
-        }
-    }
-    Ok(())
-}
-
-/// The `KNOWN_DB_FILENAMES` const, as declared in `db_housekeeping`.
 fn known_db_filenames(src: &str) -> BTreeSet<String> {
     let mut out = BTreeSet::new();
     let Some(start) = src.find("KNOWN_DB_FILENAMES") else {
@@ -423,7 +315,7 @@ fn known_db_filenames(src: &str) -> BTreeSet<String> {
 
 fn check_data_dir_databases(repo: &Path, problems: &mut Vec<String>) -> Result<()> {
     let agents = read(repo, "AGENTS.md")?;
-    let shipped = shipped_databases(repo)?;
+    let shipped = crate::data_dir_scan::scan(&repo.join("crates/claudepot-core/src"))?.dbs;
 
     // The WAL-cleanup list must cover every database that actually
     // ships. Its own doc comment calls it exhaustive, and it was not:
@@ -458,61 +350,9 @@ fn check_data_dir_databases(repo: &Path, problems: &mut Vec<String>) -> Result<(
     Ok(())
 }
 
-/// JSON state files under the Claudepot data dir, as the source
-/// actually builds them.
-///
-/// Anchored on `claudepot_data_dir()` rather than on the `.json`
-/// suffix, which is the whole difference from [`shipped_databases`].
-/// `.db` is unambiguous — nothing else in this codebase ends in it —
-/// but `.json` names CC's `settings.json`, `~/.claude.json`, bundle
-/// entries like `manifest.json` and `tombstones.json`, and generated
-/// specs. Matching the suffix alone would report a dozen files that do
-/// not belong in AGENTS.md's data-dir list, and a check that cries wolf
-/// is one people learn to skip.
-///
-/// **Known limit:** only the direct `claudepot_data_dir().join("x.json")`
-/// chain is detected. A path assembled through an intermediate
-/// binding (`let d = claudepot_data_dir(); d.join(…)`) is missed. No
-/// such site exists today — the assertion below fails loudly if the
-/// detector ever stops finding the files AGENTS.md documents, which is
-/// what turns this from a check that *cannot* fail into one that has
-/// been watched failing.
-fn json_state_in(text: &str, consts: &BTreeMap<String, String>, out: &mut BTreeSet<String>) {
-    const ANCHOR: &str = "claudepot_data_dir()";
-    // Enough to clear a rustfmt line break plus indentation between the
-    // anchor and its `.join(`, and short enough that an unrelated
-    // `.join("x.json")` further down the function is not swept in.
-    const WINDOW: usize = 160;
-
-    let mut from = 0usize;
-    while let Some(i) = text[from..].find(ANCHOR) {
-        let start = from + i + ANCHOR.len();
-        from = start;
-        let window = &text[start..text.len().min(start + WINDOW)];
-        let Some(j) = window.find(".join(") else {
-            continue;
-        };
-        if let Some(name) = join_arg(&window[j + 6..], consts) {
-            if name.ends_with(".json") {
-                out.insert(name);
-            }
-        }
-    }
-}
-
-fn shipped_json_state(repo: &Path) -> Result<BTreeSet<String>> {
-    let mut out = BTreeSet::new();
-    let root = repo.join("crates/claudepot-core/src");
-    walk_rs(&root, &mut |text| {
-        let consts = const_strings(text);
-        json_state_in(production_only(text), &consts, &mut out)
-    })?;
-    Ok(out)
-}
-
 fn check_data_dir_json_state(repo: &Path, problems: &mut Vec<String>) -> Result<()> {
     let agents = read(repo, "AGENTS.md")?;
-    let shipped = shipped_json_state(repo)?;
+    let shipped = crate::data_dir_scan::scan(&repo.join("crates/claudepot-core/src"))?.jsons;
 
     // Guard against the detector silently finding nothing — a heuristic
     // that matches zero sites reports "all documented" forever. AGENTS.md
@@ -522,7 +362,7 @@ fn check_data_dir_json_state(repo: &Path, problems: &mut Vec<String>) -> Result<
         problems.push(
             "the data-dir JSON detector found no `agents.json` — the \
              `claudepot_data_dir().join(…)` pattern it anchors on has changed, so \
-             this check is now blind. Fix `shipped_json_state`, not AGENTS.md"
+             this check is now blind. Fix `data_dir_scan`, not AGENTS.md"
                 .to_string(),
         );
         return Ok(());
@@ -769,105 +609,5 @@ enum AccountAction {
         assert_eq!(spelled(13), Some("Thirteen"));
         assert_eq!(spelled(14), Some("Fourteen"));
         assert_eq!(spelled(99), None);
-    }
-
-    /// The bug this replaced: cutting at the *first* `#[cfg(test)]`
-    /// silently dropped every production item after an attributed
-    /// method. `agent/store.rs` has one at line 791 and its test module
-    /// at 1280, so `agents_file_path()` — which builds `agents.json` —
-    /// was outside the scan entirely.
-    #[test]
-    fn production_only_cuts_at_the_test_module_not_an_attributed_item() {
-        let src = "\
-fn keep_me() {}
-impl S {
-    #[cfg(test)]
-    fn helper() {}
-}
-fn also_keep_me() {}
-#[cfg(test)]
-mod tests {
-    fn scratch() {}
-}
-";
-        let kept = production_only(src);
-        assert!(
-            kept.contains("also_keep_me"),
-            "production item after an attributed method must survive"
-        );
-        assert!(!kept.contains("scratch"), "the test module must be cut");
-    }
-
-    /// The blindness that let `boards.db` ship unlisted: its filename
-    /// is a const, so `.join(BOARDS_DB_FILENAME)` carries no literal
-    /// for a string scan to find.
-    #[test]
-    fn join_arg_resolves_a_const_filename() {
-        let consts = const_strings("pub const BOARDS_DB_FILENAME: &str = \"boards.db\";\n");
-        assert_eq!(
-            consts.get("BOARDS_DB_FILENAME").map(String::as_str),
-            Some("boards.db")
-        );
-        assert_eq!(
-            join_arg("BOARDS_DB_FILENAME)", &consts).as_deref(),
-            Some("boards.db")
-        );
-        // Literals still work, and an unresolvable expression is skipped
-        // rather than guessed at.
-        assert_eq!(join_arg("\"x.db\")", &consts).as_deref(), Some("x.db"));
-        assert_eq!(join_arg("some_var)", &consts), None);
-    }
-
-    #[test]
-    fn json_state_resolves_a_const_filename() {
-        let consts = const_strings("const CACHE_FILENAME: &str = \"pricing-cache.json\";\n");
-        let mut out = BTreeSet::new();
-        json_state_in(
-            "claudepot_data_dir().join(CACHE_FILENAME)",
-            &consts,
-            &mut out,
-        );
-        assert!(out.contains("pricing-cache.json"));
-    }
-
-    #[test]
-    fn production_only_is_identity_without_a_test_module() {
-        let src = "fn only() {}\n";
-        assert_eq!(production_only(src), src);
-    }
-
-    #[test]
-    fn json_state_matches_only_data_dir_joins() {
-        let mut out = BTreeSet::new();
-        json_state_in(
-            r#"
-            fn a() -> PathBuf { claudepot_data_dir().join("agents.json") }
-            fn b() -> PathBuf { crate::paths::claudepot_data_dir().join("routes.json") }
-            // Not the data dir: CC's own settings, and a bundle entry.
-            fn c() -> PathBuf { config_dir.join("settings.json") }
-            fn d() -> PathBuf { staged.join("manifest.json") }
-            // Not JSON.
-            fn e() -> PathBuf { claudepot_data_dir().join("corpus.db") }
-            "#,
-            &BTreeMap::new(),
-            &mut out,
-        );
-        assert_eq!(
-            out.into_iter().collect::<Vec<_>>(),
-            vec!["agents.json".to_string(), "routes.json".to_string()]
-        );
-    }
-
-    /// rustfmt breaks the chain across lines once the receiver is long
-    /// enough; the scan has to survive that or it goes quietly blind.
-    #[test]
-    fn json_state_survives_a_wrapped_chain() {
-        let mut out = BTreeSet::new();
-        json_state_in(
-            "crate::paths::claudepot_data_dir()\n            .join(\"usage_alert_state.json\")",
-            &BTreeMap::new(),
-            &mut out,
-        );
-        assert!(out.contains("usage_alert_state.json"));
     }
 }


### PR DESCRIPTION
Following up on the scan asymmetry I flagged. It was papering over a bug in
both scans **and** a shipped defect in the code.

## The scans were blind to const filenames

`board/mod.rs` declares `const BOARDS_DB_FILENAME: &str = "boards.db"` and
joins the *identifier*, so a string-literal scan structurally cannot see it.
Same for `pricing::CACHE_FILENAME`. Both scans now resolve `const NAME: &str =
"…"` from the same file, and skip what they cannot resolve rather than guessing.

## That blindness had a real consequence

`KNOWN_DB_FILENAMES` drives `*.db-wal` cleanup and its own doc comment calls it
exhaustive. **It was not** — `boards.db` and `corpus.db` both shipped without
being added, so both leaked WAL sidecars. Nothing catches that at runtime; the
leak is small and silent.

## The fix is a cross-check, not a better heuristic

`verify-docs` now asserts every `.db` found in source appears in
`KNOWN_DB_FILENAMES`. That makes the curated list authoritative and the next
omission a gate failure — and it resolves the asymmetry: the `.db` side no
longer rests on loose suffix matching alone, but on a curated list validated
against source.

## New find

Const resolution immediately surfaced **`pricing-cache.json`**, a real
undocumented data-dir file. Documented, and distinguished from
`pricing-history.json` — one is a regenerable cache, the other append-only and
not regenerable.

## Checked, not assumed

`automations.json` does **not** linger: `migrate_v1_to_v2` step 3 renames it
aside as its atomic gate. The existing AGENTS.md entry is accurate; nothing to
clean up.

## Watched failing before allowing green

Removing `boards.db` from `KNOWN_DB_FILENAMES` was **silently accepted** before
const resolution and correctly rejected after. That is how the blindness was
found — the check I had just added was itself blind to the exact file it
existed to catch.

## Verification

`cargo test -p xtask` 9 passed · `cargo test -p claudepot-core --lib
db_housekeeping` 7 passed · `cargo xtask verify-docs` green ·
`cargo clippy --all-targets -p xtask -p claudepot-core -D warnings` clean