### PR TITLE
chore(release): 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,38 @@ Versioning scheme:
 - `0.1.x` — beta
 - `1.0.0+` — stable
 
-## 0.4.6 — beta (unreleased)
+## 0.4.7 — beta (unreleased)
+
+### Fixed
+
+- **`boards.db` and `corpus.db` were leaking WAL sidecars.** Neither
+  was in `KNOWN_DB_FILENAMES`, the list that drives `*.db-wal` cleanup,
+  despite its doc comment calling itself exhaustive. Both sidecars are
+  present on disk on a real install, so this was live rather than
+  theoretical.
+- **Every Vercel Preview deployment had failed for 16 days.**
+  `NEON_DATABASE_URL` is scoped to Development and Production only, and
+  three routes queried the database at build time. `sitemap.ts` and
+  `api/rss` now render per request — they are feeds over changing
+  content, so prerendering both froze them at deploy time and made the
+  database a hard build dependency. That also removes a production
+  hazard: a Neon cold start could fail the production build outright.
+- All 32 Dependabot advisories cleared across both lockfiles. Several
+  had runtime reach in `web/` — `ip-address` under `express-rate-limit`,
+  `js-yaml` as a direct dependency, `undici` via `@vercel/blob`.
+
+### Changed
+
+- `cargo xtask verify-docs` now parses the source instead of matching
+  strings, and covers all three crates that write to the data dir plus
+  `.jsonl` alongside `.json`. The previous scan went blind five distinct
+  ways; every one was a scope or representation limit rather than a
+  logic error. Four undocumented data-dir files were found and
+  documented in the process.
+- A commit touching nothing under `web/` no longer triggers a Next.js
+  build on Vercel.
+
+## 0.4.6 — beta (released 2026-08-11)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudepot-cli"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-core"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-tauri"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 # Floor set by std file_lock (File::{lock,try_lock,unlock}, 1.89) —
 # the cross-process advisory locks in claudepot-core depend on it.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you use Claude Code or Claude Desktop daily, you've probably hit at least one
 
 ### Install
 
-> **Status: beta** (`0.4.6`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
+> **Status: beta** (`0.4.7`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
 
 You'll need a recent **Rust toolchain** ([rustup.rs](https://rustup.rs)) and **Node 20+** with **pnpm** ([pnpm.io](https://pnpm.io)). No other system dependencies.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claudepot",
   "private": true,
-  "version": "0.4.6",
+  "version": "0.4.7",
   "license": "ISC",
   "type": "module",
   "engines": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claudepot",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "identifier": "com.claudepot.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/web/src/app/(reader)/app/install/page.mdx
+++ b/web/src/app/(reader)/app/install/page.mdx
@@ -5,7 +5,7 @@ export const metadata = {
 
 # Install
 
-> **Status: beta (`0.4.6`).** Daily-driven on macOS. Linux and
+> **Status: beta (`0.4.7`).** Daily-driven on macOS. Linux and
 > Windows builds are green but less seasoned.
 
 Two paths: grab a signed installer from the latest release (fast,


### PR DESCRIPTION
Version bump across all five lock-step sites plus `Cargo.lock`, and the
CHANGELOG section for what shipped since 0.4.6.

## What's in 0.4.7

**Fixed**

- `boards.db` and `corpus.db` were leaking WAL sidecars — neither was in
  `KNOWN_DB_FILENAMES` despite its doc comment claiming exhaustiveness. Both
  sidecars are present on disk on a real install, so this was live.
- Every Vercel Preview deployment had failed for 16 days. `sitemap.ts` and
  `api/rss` now render per request, which also removes a production hazard: a
  Neon cold start could fail the production build outright.
- All 32 Dependabot advisories cleared in both lockfiles.

**Changed**

- `verify-docs` parses instead of string-matching, covers all three crates that
  write to the data dir, and includes `.jsonl`. Four undocumented data-dir files
  were found and documented along the way.
- Commits touching nothing under `web/` no longer trigger a Next.js build.

## Verification

`cargo check --workspace` green · `pnpm test` 1244 passed · `web pnpm build`
green · `cargo xtask verify-docs` green

One note for the record: an initial `pnpm test` run exited non-zero with **no
failing test** and no reproducible cause. Two subsequent full runs are clean at
exit 0 with identical counts (134 files / 1244 tests). Recorded rather than
ignored — if it recurs it is worth chasing as flaky harness behaviour.