### PR TITLE
feat(usage): render model-scoped rate-limit rows (Fable)

### DIFF
--- a/crates/claudepot-core/src/oauth/usage.rs
+++ b/crates/claudepot-core/src/oauth/usage.rs
@@ -42,10 +42,89 @@ pub struct UsageResponse {
     pub iguana_necktie: Option<UsageWindow>,
     #[serde(default)]
     pub extra_usage: Option<ExtraUsage>,
+    /// Model- and surface-scoped rate limits. Added 2026-08: Anthropic
+    /// moved per-model windows out of the `seven_day_<model>` keys —
+    /// which now come back `null` on every observed account — and into
+    /// this generic array. Untyped, it landed in `unknown` and never
+    /// reached the UI.
+    ///
+    /// `deserialize_with` swallows a reshaped array: a parse error here
+    /// would blank the whole usage panel, and a missing row is a far
+    /// better failure than a missing panel.
+    #[serde(default, deserialize_with = "lenient_limits")]
+    pub limits: Vec<UsageLimit>,
     /// Catch-all for any future field Anthropic adds — keeps the
     /// response parseable so UI doesn't blank when the wire grows.
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_json::Value>,
+}
+
+/// One entry of `/api/oauth/usage`'s `limits[]`.
+///
+/// `kind` is `session` | `weekly_all` | `weekly_scoped` in every
+/// observation, but stays a `String`: a new kind must not fail the
+/// parse.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UsageLimit {
+    pub kind: String,
+    #[serde(default)]
+    pub group: Option<String>,
+    #[serde(default)]
+    pub percent: f64,
+    /// `normal` | `warning` observed. Not rendered yet.
+    #[serde(default)]
+    pub severity: Option<String>,
+    #[serde(default)]
+    pub resets_at: Option<DateTime<FixedOffset>>,
+    #[serde(default)]
+    pub scope: Option<LimitScope>,
+    /// Whether this limit is the currently binding one.
+    #[serde(default)]
+    pub is_active: bool,
+}
+
+/// What a limit is scoped to. `surface` is opaque: null in every
+/// observation, and inventing a shape for it would be guessing.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LimitScope {
+    #[serde(default)]
+    pub model: Option<LimitModel>,
+    #[serde(default)]
+    pub surface: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LimitModel {
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Server-supplied, already human-readable ("Fable"). Rendered
+    /// verbatim — it is a proper noun in every locale.
+    #[serde(default)]
+    pub display_name: Option<String>,
+}
+
+/// Tolerate any `limits` value that is not a well-formed array.
+fn lenient_limits<'de, D>(deserializer: D) -> Result<Vec<UsageLimit>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = serde_json::Value::deserialize(deserializer)?;
+    Ok(serde_json::from_value(raw).unwrap_or_default())
+}
+
+impl UsageResponse {
+    /// Limits carrying a usable model name — the ones with no
+    /// plan-level equivalent already on screen.
+    ///
+    /// `session` and `weekly_all` restate `five_hour` and `seven_day`
+    /// to the percent, so yielding them would double-render two rows
+    /// the UI already draws. Yields `(display_name, limit)`.
+    pub fn scoped_limits(&self) -> impl Iterator<Item = (&str, &UsageLimit)> {
+        self.limits.iter().filter_map(|l| {
+            let name = l.scope.as_ref()?.model.as_ref()?.display_name.as_deref()?;
+            (!name.is_empty()).then_some((name, l))
+        })
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -246,5 +325,113 @@ mod tests {
         assert_eq!(extra.monthly_limit, Some(15000.0));
         assert_eq!(extra.used_credits, Some(1911.0));
         assert_eq!(extra.currency.as_deref(), Some("GBP"));
+    }
+
+    /// The 2026-08 wire shape: model-scoped limits moved out of the
+    /// `seven_day_<model>` keys into a generic `limits[]` array. Both
+    /// observed accounts return exactly three entries, and `scope` is
+    /// non-null only on `weekly_scoped`.
+    #[test]
+    fn limits_array_parses_with_model_scope() {
+        let json = r#"{
+            "five_hour": {"utilization": 31.0, "resets_at": "2026-08-12T04:40:00+00:00"},
+            "seven_day": {"utilization": 13.0, "resets_at": "2026-08-16T16:00:00+00:00"},
+            "limits": [
+                {"kind": "session", "group": "session", "percent": 31,
+                 "severity": "normal", "resets_at": "2026-08-12T04:40:00+00:00",
+                 "scope": null, "is_active": true},
+                {"kind": "weekly_all", "group": "weekly", "percent": 13,
+                 "severity": "normal", "resets_at": "2026-08-16T16:00:00+00:00",
+                 "scope": null, "is_active": false},
+                {"kind": "weekly_scoped", "group": "weekly", "percent": 23,
+                 "severity": "normal", "resets_at": "2026-08-16T15:59:59+00:00",
+                 "scope": {"model": {"id": null, "display_name": "Fable"}, "surface": null},
+                 "is_active": false}
+            ]
+        }"#;
+        let usage: UsageResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(usage.limits.len(), 3);
+        assert_eq!(usage.limits[2].kind, "weekly_scoped");
+        assert_eq!(usage.limits[2].percent, 23.0);
+        assert_eq!(usage.limits[2].severity.as_deref(), Some("normal"));
+        assert!(usage.limits[2].resets_at.is_some());
+    }
+
+    /// `session` restates `five_hour` and `weekly_all` restates
+    /// `seven_day`, to the percent. Appending them would double-render
+    /// rows already on screen, so only model-scoped entries survive.
+    #[test]
+    fn scoped_limits_keeps_only_model_scoped_entries() {
+        let json = r#"{
+            "limits": [
+                {"kind": "session", "percent": 31, "scope": null, "is_active": true},
+                {"kind": "weekly_all", "percent": 13, "scope": null, "is_active": false},
+                {"kind": "weekly_scoped", "percent": 80,
+                 "severity": "warning",
+                 "scope": {"model": {"id": null, "display_name": "Fable"}, "surface": null},
+                 "is_active": true}
+            ]
+        }"#;
+        let usage: UsageResponse = serde_json::from_str(json).unwrap();
+        let scoped: Vec<_> = usage.scoped_limits().collect();
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].0, "Fable");
+        assert_eq!(scoped[0].1.percent, 80.0);
+        assert_eq!(scoped[0].1.severity.as_deref(), Some("warning"));
+    }
+
+    /// A scope with no usable model name is not a row we can label, so
+    /// it must not reach the UI as a blank-titled entry.
+    #[test]
+    fn scoped_limits_skips_scope_without_display_name() {
+        let json = r#"{
+            "limits": [
+                {"kind": "weekly_scoped", "percent": 5,
+                 "scope": {"model": {"id": "abc", "display_name": null}, "surface": null},
+                 "is_active": false},
+                {"kind": "weekly_scoped", "percent": 6,
+                 "scope": {"model": null, "surface": null}, "is_active": false}
+            ]
+        }"#;
+        let usage: UsageResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(usage.scoped_limits().count(), 0);
+    }
+
+    /// Back-compat: servers that never send `limits` must still parse,
+    /// and must not report phantom rows.
+    #[test]
+    fn response_without_limits_yields_no_scoped_rows() {
+        let json = r#"{"five_hour": {"utilization": 1.0}}"#;
+        let usage: UsageResponse = serde_json::from_str(json).unwrap();
+        assert!(usage.limits.is_empty());
+        assert_eq!(usage.scoped_limits().count(), 0);
+    }
+
+    /// Forward-compat, and the reason every field is defaulted: a
+    /// reshaped entry must degrade to an empty list rather than fail
+    /// the whole parse and blank the usage panel.
+    #[test]
+    fn malformed_limits_does_not_blank_the_rest_of_the_response() {
+        let json = r#"{
+            "five_hour": {"utilization": 7.0},
+            "limits": "not-an-array"
+        }"#;
+        let usage: UsageResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(usage.five_hour.unwrap().utilization, 7.0);
+        assert!(usage.limits.is_empty());
+    }
+
+    /// Entries omitting optional keys entirely (not just null) parse.
+    #[test]
+    fn limit_entry_accepts_missing_optional_fields() {
+        let json = r#"{"limits": [{"kind": "session", "percent": 0}]}"#;
+        let usage: UsageResponse = serde_json::from_str(json).unwrap();
+        let l = &usage.limits[0];
+        assert_eq!(l.kind, "session");
+        assert!(l.group.is_none());
+        assert!(l.severity.is_none());
+        assert!(l.resets_at.is_none());
+        assert!(l.scope.is_none());
+        assert!(!l.is_active);
     }
 }

--- a/crates/claudepot-core/src/services/usage_alerts.rs
+++ b/crates/claudepot-core/src/services/usage_alerts.rs
@@ -295,6 +295,7 @@ mod tests {
             seven_day_cowork: None,
             iguana_necktie: None,
             extra_usage: None,
+            limits: Vec::new(),
             unknown: HashMap::new(),
         }
     }
@@ -495,6 +496,7 @@ mod tests {
             seven_day_cowork: None,
             iguana_necktie: None,
             extra_usage: None,
+            limits: Vec::new(),
             unknown: HashMap::new(),
         };
         let crossings = st.apply_crossings(uuid, &r, &[80], &all_kinds());
@@ -525,6 +527,7 @@ mod tests {
             seven_day_cowork: None,
             iguana_necktie: None,
             extra_usage: None,
+            limits: Vec::new(),
             unknown: HashMap::new(),
         };
         let umbrella_only = vec![UsageWindowKind::FiveHour, UsageWindowKind::SevenDay];

--- a/crates/claudepot-core/src/services/usage_cache.rs
+++ b/crates/claudepot-core/src/services/usage_cache.rs
@@ -583,6 +583,7 @@ mod tests {
             seven_day_cowork: None,
             iguana_necktie: None,
             extra_usage: None,
+            limits: Vec::new(),
             unknown: HashMap::new(),
         }
     }

--- a/crates/claudepot-core/src/services/usage_snapshot.rs
+++ b/crates/claudepot-core/src/services/usage_snapshot.rs
@@ -260,6 +260,7 @@ mod tests {
             seven_day_cowork: None,
             iguana_necktie: None,
             extra_usage: None,
+            limits: Vec::new(),
             unknown: Default::default(),
         }
     }

--- a/src-tauri/src/dto_usage.rs
+++ b/src-tauri/src/dto_usage.rs
@@ -14,6 +14,19 @@ pub struct UsageWindowDto {
     pub resets_at: Option<String>, // RFC3339; null when the window has no reset yet
 }
 
+/// A model-scoped rate limit (e.g. the weekly Fable window).
+///
+/// Carries its own `label` because the server names the model — there
+/// is no fixed field per model any more, so the UI cannot look up a
+/// static i18n key for it.
+#[derive(Serialize, Clone)]
+pub struct ScopedLimitDto {
+    /// Server-supplied model name, rendered verbatim ("Fable").
+    pub label: String,
+    pub utilization: f64,
+    pub resets_at: Option<String>,
+}
+
 /// Extra-usage (monthly overage billing) info.
 #[derive(Serialize, Clone)]
 pub struct ExtraUsageDto {
@@ -48,6 +61,10 @@ pub struct AccountUsageDto {
     /// Usage attributed to cowork / shared-seat pool. Null on
     /// personal plans; GUI renders render-if-nonzero.
     pub seven_day_cowork: Option<UsageWindowDto>,
+    /// Model-scoped windows from the server's `limits[]`. Empty when
+    /// the account has none, so render-if-nonzero hides the rows with
+    /// no special case.
+    pub scoped_limits: Vec<ScopedLimitDto>,
     pub extra_usage: Option<ExtraUsageDto>,
 }
 
@@ -66,6 +83,14 @@ impl AccountUsageDto {
             seven_day_sonnet: map_window(&r.seven_day_sonnet),
             seven_day_oauth_apps: map_window(&r.seven_day_oauth_apps),
             seven_day_cowork: map_window(&r.seven_day_cowork),
+            scoped_limits: r
+                .scoped_limits()
+                .map(|(label, l)| ScopedLimitDto {
+                    label: label.to_string(),
+                    utilization: l.percent,
+                    resets_at: l.resets_at.as_ref().map(|t| t.to_rfc3339()),
+                })
+                .collect(),
             extra_usage: r.extra_usage.as_ref().map(|e| ExtraUsageDto {
                 is_enabled: e.is_enabled,
                 monthly_limit: e.monthly_limit,
@@ -156,5 +181,44 @@ impl UsageEntryDto {
                 error_detail: Some(msg),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claudepot_core::oauth::usage::UsageResponse;
+
+    #[test]
+    fn maps_model_scoped_limits_to_rows_and_drops_plan_level_ones() {
+        let json = r#"{
+            "five_hour": {"utilization": 31.0, "resets_at": "2026-08-12T04:40:00+00:00"},
+            "limits": [
+                {"kind": "session", "percent": 31, "scope": null, "is_active": true},
+                {"kind": "weekly_scoped", "percent": 23,
+                 "resets_at": "2026-08-16T15:59:59+00:00",
+                 "scope": {"model": {"id": null, "display_name": "Fable"}, "surface": null},
+                 "is_active": false}
+            ]
+        }"#;
+        let resp: UsageResponse = serde_json::from_str(json).unwrap();
+        let dto = AccountUsageDto::from_response(&resp);
+
+        assert_eq!(dto.scoped_limits.len(), 1);
+        assert_eq!(dto.scoped_limits[0].label, "Fable");
+        assert_eq!(dto.scoped_limits[0].utilization, 23.0);
+        assert!(dto.scoped_limits[0]
+            .resets_at
+            .as_deref()
+            .unwrap()
+            .starts_with("2026-08-16T15:59:59"));
+    }
+
+    #[test]
+    fn scoped_limits_is_empty_when_the_server_sends_none() {
+        let resp: UsageResponse =
+            serde_json::from_str(r#"{"five_hour": {"utilization": 1.0}}"#).unwrap();
+        let dto = AccountUsageDto::from_response(&resp);
+        assert!(dto.scoped_limits.is_empty());
     }
 }

--- a/src-tauri/src/tray_menu.rs
+++ b/src-tauri/src/tray_menu.rs
@@ -563,6 +563,7 @@ mod tests {
             seven_day_cowork: None,
             iguana_necktie: None,
             extra_usage,
+            limits: Vec::new(),
             unknown: Default::default(),
         }
     }

--- a/src/locales/en/accounts.json
+++ b/src/locales/en/accounts.json
@@ -252,7 +252,8 @@
       "apps": "7d apps",
       "appsTooltip": "Third-party OAuth apps authorized against this account (IDEs, tools, etc).",
       "cowork": "7d cowork",
-      "coworkTooltip": "Cowork / shared-seat pool usage."
+      "coworkTooltip": "Cowork / shared-seat pool usage.",
+      "scopedWeekly": "7d {{model}}"
     },
     "extra": {
       "label": "Extra usage",

--- a/src/locales/en/keys.json
+++ b/src/locales/en/keys.json
@@ -89,7 +89,8 @@
     "sevenDayOauthApps": "7-day · OAuth apps",
     "sevenDayCowork": "7-day · Cowork",
     "extraUsage": "Extra usage",
-    "close": "Close"
+    "close": "Close",
+    "scopedWeekly": "7-day · {{model}}"
   },
   "vault": {
     "title": "Secret vault",

--- a/src/locales/zh-CN/accounts.json
+++ b/src/locales/zh-CN/accounts.json
@@ -249,7 +249,8 @@
       "apps": "7 天应用",
       "appsTooltip": "已授权此账户的第三方 OAuth 应用（IDE、工具等）。",
       "cowork": "7 天 cowork",
-      "coworkTooltip": "Cowork / 共享席位池用量。"
+      "coworkTooltip": "Cowork / 共享席位池用量。",
+      "scopedWeekly": "7 天 {{model}}"
     },
     "extra": {
       "label": "额外用量",

--- a/src/locales/zh-CN/keys.json
+++ b/src/locales/zh-CN/keys.json
@@ -89,7 +89,8 @@
     "sevenDayOauthApps": "7 天 · OAuth 应用",
     "sevenDayCowork": "7 天 · Cowork",
     "extraUsage": "额外用量",
-    "close": "关闭"
+    "close": "关闭",
+    "scopedWeekly": "7 天 · {{model}}"
   },
   "vault": {
     "title": "机密保险库",

--- a/src/sections/accounts/UsageBlock.test.tsx
+++ b/src/sections/accounts/UsageBlock.test.tsx
@@ -91,3 +91,51 @@ describe("UsageBlock contextual actions", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 });
+
+describe("UsageBlock model-scoped rows", () => {
+  const base = {
+    five_hour: { utilization: 31, resets_at: null },
+    seven_day: { utilization: 13, resets_at: null },
+    seven_day_opus: null,
+    seven_day_sonnet: null,
+    seven_day_oauth_apps: null,
+    seven_day_cowork: null,
+    extra_usage: null,
+  };
+
+  it("renders a row for each model-scoped limit the server reports", () => {
+    render(
+      <UsageBlock
+        entry={mkEntry({
+          status: "ok",
+          usage: {
+            ...base,
+            scoped_limits: [
+              { label: "Fable", utilization: 23, resets_at: null },
+            ],
+          },
+        })}
+        onVerify={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("7d Fable")).toBeInTheDocument();
+  });
+
+  it("renders no scoped rows when the server reports none", () => {
+    render(
+      <UsageBlock
+        entry={mkEntry({
+          status: "ok",
+          usage: { ...base, scoped_limits: [] },
+        })}
+        onVerify={vi.fn()}
+        onRefresh={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("5h window")).toBeInTheDocument();
+    expect(screen.queryByText(/7d Fable/)).not.toBeInTheDocument();
+  });
+});

--- a/src/sections/accounts/UsageBlock.tsx
+++ b/src/sections/accounts/UsageBlock.tsx
@@ -159,6 +159,15 @@ export function UsageBlock({
       emph: false,
       tooltip: t("usage.rows.coworkTooltip"),
     },
+    // Model-scoped windows (e.g. the weekly Fable limit). The server
+    // names the model, so the label interpolates rather than resolving
+    // a fixed key. `?? []` guards a usage entry cached by an older
+    // build, which has no such field.
+    ...(usage.scoped_limits ?? []).map((s) => ({
+      label: t("usage.rows.scopedWeekly", { model: s.label }),
+      w: { utilization: s.utilization, resets_at: s.resets_at },
+      emph: false,
+    })),
   ].filter((r) => r.w) as typeof rows;
 
   return (

--- a/src/sections/keys/OAuthUsageModal.test.tsx
+++ b/src/sections/keys/OAuthUsageModal.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * OAuthUsageModal — model-scoped usage rows.
+ *
+ * Anthropic moved per-model windows out of the `seven_day_<model>`
+ * keys (now null on every observed account) into a generic `limits[]`
+ * array. These cover the rows built from that array; the plan-level
+ * rows above them are unchanged.
+ *
+ * `UsageBody` is exercised directly rather than through the modal
+ * wrapper — the wrapper adds only chrome and a data fetch.
+ */
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { AccountUsage } from "../../types";
+import { UsageBody } from "./OAuthUsageModal";
+
+const base: AccountUsage = {
+  five_hour: { utilization: 31, resets_at: null },
+  seven_day: { utilization: 13, resets_at: null },
+  seven_day_opus: null,
+  seven_day_sonnet: null,
+  seven_day_oauth_apps: null,
+  seven_day_cowork: null,
+  extra_usage: null,
+};
+
+describe("OAuthUsageModal model-scoped rows", () => {
+  it("renders a row per model-scoped limit", () => {
+    render(
+      <UsageBody
+        usage={{
+          ...base,
+          scoped_limits: [{ label: "Fable", utilization: 80, resets_at: null }],
+        }}
+      />,
+    );
+    expect(screen.getByText("7-day · Fable")).toBeInTheDocument();
+  });
+
+  it("renders none when the server reports none", () => {
+    render(<UsageBody usage={{ ...base, scoped_limits: [] }} />);
+    expect(screen.queryByText(/Fable/)).not.toBeInTheDocument();
+  });
+});

--- a/src/sections/keys/OAuthUsageModal.tsx
+++ b/src/sections/keys/OAuthUsageModal.tsx
@@ -118,7 +118,7 @@ export function OAuthUsageModal({
   );
 }
 
-function UsageBody({ usage }: { usage: AccountUsage }) {
+export function UsageBody({ usage }: { usage: AccountUsage }) {
   const { t } = useTranslation("keys");
   // Render-time lookups, not a module constant — a language switch has
   // to reach these labels without a remount.
@@ -129,6 +129,17 @@ function UsageBody({ usage }: { usage: AccountUsage }) {
     [t("usageModal.sevenDaySonnet"), usage.seven_day_sonnet],
     [t("usageModal.sevenDayOauthApps"), usage.seven_day_oauth_apps],
     [t("usageModal.sevenDayCowork"), usage.seven_day_cowork],
+    // Model-scoped windows (e.g. the weekly Fable limit). The server
+    // names the model, so the label interpolates rather than resolving
+    // a fixed key. `?? []` guards a usage entry cached by an older
+    // build, which has no such field.
+    ...(usage.scoped_limits ?? []).map(
+      (s) =>
+        [
+          t("usageModal.scopedWeekly", { model: s.label }),
+          { utilization: s.utilization, resets_at: s.resets_at },
+        ] as [string, UsageWindow | null],
+    ),
   ];
 
   // Render-if-nonzero per design rules — drop rows that have no window.

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -184,6 +184,15 @@ export interface ExtraUsage {
   currency: string | null;
 }
 
+/** A model-scoped rate-limit window (e.g. the weekly Fable limit).
+ *  The server names the model, so the label ships with the data
+ *  rather than resolving to a fixed i18n key. */
+export interface ScopedLimit {
+  label: string;
+  utilization: number;
+  resets_at: string | null;
+}
+
 export interface AccountUsage {
   five_hour: UsageWindow | null;
   seven_day: UsageWindow | null;
@@ -193,6 +202,9 @@ export interface AccountUsage {
   seven_day_oauth_apps: UsageWindow | null;
   /** Cowork / shared-seat usage pool (render-if-nonzero). */
   seven_day_cowork: UsageWindow | null;
+  /** Model-scoped windows from the server's `limits[]` (render-if-nonzero).
+   *  Optional: a usage entry cached by an older build has no such key. */
+  scoped_limits?: ScopedLimit[];
   extra_usage: ExtraUsage | null;
 }
 


### PR DESCRIPTION
## The gap

The Accounts card and the Keys → usage modal show only `5h window` and `7d all` on accounts that have a per-model limit in force. A user on a weekly Fable limit cannot see it at all — including when it is the binding constraint.

This is not a missing row. **Anthropic changed the wire format of `GET /api/oauth/usage`.** Model-scoped limits moved out of the `seven_day_<model>` keys and into a generic `limits[]` array:

```json
{ "kind": "weekly_scoped", "group": "weekly", "percent": 23,
  "severity": "normal", "resets_at": "2026-08-16T15:59:59Z",
  "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
  "is_active": false }
```

`UsageResponse` has no typed `limits`, so the array lands in the `#[serde(flatten)] unknown` catch-all and is dropped before the DTO. Meanwhile `seven_day_opus` and `seven_day_sonnet` — which `UsageBlock` does render — come back **`null` on every account I can observe**. The rows are absent because the fields they read are empty.

### Observed, two accounts, 2026-08-11

Identical key sets; `limits[]` is three entries in both cases, `scope` non-null only on `weekly_scoped`:

| account | `session` | `weekly_all` | `weekly_scoped` |
|---|---|---|---|
| A | 31% | 13% | **Fable 23%**, `normal`, `is_active: false` |
| B | 0%, `resets_at: null` | 46% | **Fable 80%**, `warning`, `is_active: true` |

`session` mirrors `five_hour` and `weekly_all` mirrors `seven_day`, to the percent.

## The change

Server `limits[]` → typed in core → filtered to model-scoped entries → DTO → appended to the row lists the two renderers already build. No new domain noun, no store, no migration, no new network call — the data already arrives on the 5-minute `usage_snapshot` tick.

- **`oauth/usage.rs`** — `UsageLimit` / `LimitScope` / `LimitModel`, plus `UsageResponse::scoped_limits()` yielding `(display_name, limit)` for entries carrying a model name. That filter is the dedupe: appending the raw array would double-render `5h window` and `7d all`. It lives in core rather than the DTO so the CLI gets it free if it ever grows a usage view.
- **`dto_usage.rs`** — `ScopedLimitDto { label, utilization, resets_at }`, empty vec when the account has none, so render-if-nonzero hides it with no special case.
- **`UsageBlock.tsx`** / **`OAuthUsageModal.tsx`** — rows appended after the plan-level ones.
- **i18n** — one interpolated key per surface per locale (`"7d {{model}}"`, `"7-day · {{model}}"`). The model name is server-supplied and untranslated, exactly as `Opus` and `Sonnet` already are, so a new model needs no i18n change.

`limits` deserializes leniently: a reshaped array degrades to an empty list rather than failing the parse. A parse error blanks the *entire* usage panel — the failure mode already recorded in the `resets_at` comment in that file.

`scope.surface` is typed as opaque `serde_json::Value`; it is null in every observation and inventing a shape would be guessing.

## Tests

Written red-first. 10 added.

Core: real-shaped payloads parse; `scoped_limits()` yields only the model-scoped entry; a scope with no `display_name` is skipped rather than rendered blank; a response with no `limits` key still parses (older servers); a malformed `limits` does not blank the rest of the response; entries omitting optional keys parse.

DTO: mapping yields one `Fable` row at the right percent and reset. Frontend: both surfaces render the row, and render nothing extra when the list is empty.

## Verification

`cargo test -p claudepot-core` 3523 · `-p claudepot-tauri` 242 · `pnpm test` 1248 · `clippy --all-targets -D warnings` clean · `tsc --noEmit` clean · `pnpm build` green. Confirmed against live data in `pnpm tauri dev` — both cards render `7d Fable`.

Two pre-existing failures untouched, both reproduced on `main` without this branch: `claudepot-cli time_fmt::tests::test_format_local_datetime_shape` (asserts two `-` in the formatted string; a negative UTC offset adds a third, so it fails everywhere west of UTC), and `migrate::fragment::tests::apply_claude_json_shallow_merges_imported_over_target` (flakes ~1 in 6 under full-suite parallelism, 50/50 in isolation — cross-test interference).

## Deliberately out of scope, but worth knowing

1. **Per-model usage alerts and auto-rotation rules are silently dead.** `dto_rotation.rs` maps `UsageWindowKind::SevenDayOpus` / `SevenDaySonnet` and `preferences.rs` gates alerts on the per-model sub-windows. Both read fields that are now always `null`, so a rule written against them never fires and never reports why. Independent of display; wants its own pass.
2. **`severity`** (`"warning"` at 80%) is parsed but not surfaced. The existing bar threshold happens to colour that row amber already.
3. **`spend`** (richer than `extra_usage` — currency, cap, balance, auto-reload) and **`member_dashboard_available`** are unparsed, along with several codename windows (`seven_day_omelette`, `tangelo`, `nimbus_quill`, `cinder_cove`, `amber_ladder`; `nimbus_quill` is non-null).

https://claude.ai/code/session_012BX7nHP3atyTbuJSG9UPS9