### PR TITLE
chore(release): 0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,28 @@ Versioning scheme:
 - `0.1.x` — beta
 - `1.0.0+` — stable
 
-## 0.4.7 — beta (unreleased)
+## 0.4.8 — beta (unreleased)
+
+### Added
+
+- **Replace a stored key without losing the row.** The Keys pane could
+  add, remove, rename, copy and probe, but not rotate — replacing a key
+  meant remove-then-re-add, which minted a new id and reset the
+  creation date, destroying the answer to "how long has this credential
+  been in service" at exactly the moment you were asking it. Label,
+  account and age now survive; only the secret changes. Any earlier
+  verification result is cleared, because it described a secret that no
+  longer exists.
+
+### Fixed
+
+- **Pasted secrets could survive an early return.** `key_api_add` and
+  `key_oauth_add` scrubbed their working copy only on the success path,
+  so a failure to open the key store dropped the secret unscrubbed —
+  `String`'s own drop does not zero memory. All four add/rotate paths
+  now scrub on every exit.
+
+## 0.4.7 — beta (released 2026-08-12)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudepot-cli"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-core"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-tauri"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 # Floor set by std file_lock (File::{lock,try_lock,unlock}, 1.89) —
 # the cross-process advisory locks in claudepot-core depend on it.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you use Claude Code or Claude Desktop daily, you've probably hit at least one
 
 ### Install
 
-> **Status: beta** (`0.4.7`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
+> **Status: beta** (`0.4.8`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
 
 You'll need a recent **Rust toolchain** ([rustup.rs](https://rustup.rs)) and **Node 20+** with **pnpm** ([pnpm.io](https://pnpm.io)). No other system dependencies.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claudepot",
   "private": true,
-  "version": "0.4.7",
+  "version": "0.4.8",
   "license": "ISC",
   "type": "module",
   "engines": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claudepot",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "identifier": "com.claudepot.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/web/src/app/(reader)/app/install/page.mdx
+++ b/web/src/app/(reader)/app/install/page.mdx
@@ -5,7 +5,7 @@ export const metadata = {
 
 # Install
 
-> **Status: beta (`0.4.7`).** Daily-driven on macOS. Linux and
+> **Status: beta (`0.4.8`).** Daily-driven on macOS. Linux and
 > Windows builds are green but less seasoned.
 
 Two paths: grab a signed installer from the latest release (fast,


### PR DESCRIPTION
Version bump across all five lock-step sites plus `Cargo.lock`, and the CHANGELOG section for what shipped since 0.4.7.

## What's in 0.4.8

**Added** — Replace a stored key without losing the row (#62). Rotating used to mean remove-then-re-add, which minted a new id and reset the creation date, destroying the answer to "how long has this credential been in service" at exactly the moment you were asking it. Label, account and age now survive; only the secret changes. Prior verification results are cleared, because they described a secret that no longer exists.

**Fixed** — Pasted secrets could survive an early return. `key_api_add` and `key_oauth_add` scrubbed their working copy only on the success path, so a failure to open the key store dropped the secret unscrubbed — `String`'s own drop does not zero memory. Found by auditing the new rotate code, which had inherited the same shape by following the file's existing pattern. All four add/rotate paths now scrub on every exit.

## Verification

`cargo check --workspace` green · `pnpm test` 1244 passed · `cargo xtask verify-docs` green

## Note

PR #61 (external contributor, +390/-5 across 15 files) is **not** included — it is unreviewed third-party code and does not belong in a release cut without a read-through.