### PR TITLE
fix(test): take the data-dir lock in the one swap test that skipped it

### DIFF
--- a/crates/claudepot-core/src/desktop_backend/swap_tests.rs
+++ b/crates/claudepot-core/src/desktop_backend/swap_tests.rs
@@ -443,6 +443,24 @@ async fn test_switch_no_outgoing_skips_snapshot() {
 
 #[tokio::test]
 async fn test_switch_not_installed_returns_error() {
+    // Every other test in this file takes this lock; this one did not,
+    // which is why it flaked on CI (Windows, 2026-08-12) while passing
+    // on the same commit when re-run.
+    //
+    // The mock itself is deterministic — `is_installed()` is just
+    // `data_dir_path.is_some()`, and that is `None` here — so the
+    // assertion can only fail if `switch` returns some *other* error
+    // first. It can: without the lock this test runs concurrently with
+    // siblings that mutate the shared `CLAUDEPOT_DATA_DIR`, so the
+    // account-store open can fail under it and the result is an error
+    // that simply is not `NotInstalled`.
+    //
+    // Worth stating plainly: nothing about this is Windows-specific.
+    // Windows only lost the race more often. The same gap would surface
+    // anywhere given different scheduling, which is exactly why
+    // re-running until green is not a fix.
+    let _lock = crate::testing::lock_data_dir();
+    let _env_dir = setup_test_data_dir();
     let (store, _db_dir) = test_store();
     let tgt = make_account("t@example.com");
     store.insert(&tgt).unwrap();


### PR DESCRIPTION
`test_switch_not_installed_returns_error` failed on CI (Windows, 2026-08-12) and passed on a re-run of the **identical commit**, which blocked the 0.4.8 tag.

## Root cause — not Windows, not the mock

`MockDesktopPlatform` is deterministic here: `is_installed()` is `data_dir_path.is_some()`, and the test sets it to `None`. So the assertion can only fail if `switch` returns some *other* error before reaching that check. It can.

This was **the only test in the file not holding `crate::testing::lock_data_dir()`** — all twenty others take it, and the file's own header states the contract: *"tests hold `lock_data_dir()` across `.await`"*. Without it, the test ran concurrently with siblings that mutate the shared `CLAUDEPOT_DATA_DIR`, and the account-store open under it fails with an error that simply is not `NotInstalled`.

Windows only lost the race more often. The same gap surfaces anywhere given different scheduling — which is why re-running until green was not a fix, and why the comment on the test now says so.

## Verification

`cargo test -p claudepot-core --lib desktop_backend::swap` — 22 passed.

Note that a single green CI run does **not** prove a flake is fixed; this one passed before too. The argument here is the mechanism: the test now holds the same lock every sibling holds, so the race it lost cannot occur.