### PR TITLE
chore(release): 0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,27 @@ Versioning scheme:
 - `0.1.x` — beta
 - `1.0.0+` — stable
 
-## 0.4.8 — beta (unreleased)
+## 0.4.9 — beta (unreleased)
+
+### Fixed
+
+- **Per-model rate limits were invisible.** Anthropic moved the
+  per-model windows out of the `seven_day_<model>` keys — which now
+  return null on every account — into a generic `limits[]` array that
+  nothing parsed. The Activities and Keys usage views show them again.
+  Thanks to @zhuligs.
+- **An auto-rotation rule on the 7d-Opus or 7d-Sonnet window could
+  never fire, and said "no data" rather than saying so.** Same retired
+  fields as above. The audit reported a transient-sounding skip every
+  tick, so a rule the user believed was armed sat inert indefinitely.
+  It now states plainly that the rule can never fire and needs
+  rewriting against the 5h or 7d window. The replacement data is
+  deliberately not wired up yet: the entry carrying it has no model
+  attribution, and guessing would swap the account on the wrong signal.
+- A test-isolation gap that let one `desktop_backend::swap` test race
+  its siblings and fail intermittently on CI.
+
+## 0.4.8 — beta (released 2026-08-12)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudepot-cli"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-core"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-tauri"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 # Floor set by std file_lock (File::{lock,try_lock,unlock}, 1.89) —
 # the cross-process advisory locks in claudepot-core depend on it.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you use Claude Code or Claude Desktop daily, you've probably hit at least one
 
 ### Install
 
-> **Status: beta** (`0.4.8`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
+> **Status: beta** (`0.4.9`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
 
 You'll need a recent **Rust toolchain** ([rustup.rs](https://rustup.rs)) and **Node 20+** with **pnpm** ([pnpm.io](https://pnpm.io)). No other system dependencies.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claudepot",
   "private": true,
-  "version": "0.4.8",
+  "version": "0.4.9",
   "license": "ISC",
   "type": "module",
   "engines": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claudepot",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "identifier": "com.claudepot.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/web/src/app/(reader)/app/install/page.mdx
+++ b/web/src/app/(reader)/app/install/page.mdx
@@ -5,7 +5,7 @@ export const metadata = {
 
 # Install
 
-> **Status: beta (`0.4.8`).** Daily-driven on macOS. Linux and
+> **Status: beta (`0.4.9`).** Daily-driven on macOS. Linux and
 > Windows builds are green but less seasoned.
 
 Two paths: grab a signed installer from the latest release (fast,


### PR DESCRIPTION
Version bump across all five lock-step sites plus `Cargo.lock`, and the CHANGELOG for what shipped since 0.4.8.

## What's in 0.4.9 — all three are the same root cause

Anthropic retired the `seven_day_<model>` fields (they return null on every account now) and moved per-model data into a generic `limits[]` array.

- **Per-model rate limits were invisible.** Nothing parsed `limits[]`, so those rows silently vanished from the usage views. Restored — thanks to @zhuligs (#61).
- **An auto-rotation rule on 7d-Opus or 7d-Sonnet could never fire, and said "no data" rather than saying so** (#65). The audit reported a transient-sounding skip every tick, so a rule the user believed was armed sat inert indefinitely. It now states plainly that the rule can never fire and needs rewriting. The replacement data is deliberately **not** wired up: the entry carrying it has no model attribution, and guessing would swap the account on the wrong signal.
- A test-isolation gap letting one `desktop_backend::swap` test race its siblings and fail intermittently on CI (#64).

## Verification

`cargo check --workspace` green · `pnpm test` 1248 passed / 135 files · `cargo xtask verify-docs` green

## Flaky test worth flagging

During this bump, `pnpm test` failed once on
`CommandPalette.activation.test.tsx > every visible row activates the same handler by Enter as by click`,
then passed on re-run — both alone (4/4) and in the full suite. Intermittent, not order-deterministic.

That test guards a real previously-shipped bug (the palette's two-orderings defect, where Enter on a highlighted "Open Projects" ran "Sign Desktop out"). A flake there is worth fixing rather than re-running past, since it protects behaviour that has already gone wrong once. Not fixed here — flagged for its own pass.