### PR TITLE
fix: unbreak the Windows release gate, and fix two flaky-test root causes

### DIFF
--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -102,8 +102,24 @@ fi
 
 # Is this host answering right now? BatchMode so a missing key fails
 # fast instead of prompting into a hook with no usable tty.
+# `exit`, not `true`. Both shells have `exit` as a builtin; `true` is a
+# Unix-ism and does not exist in `cmd.exe`, which is the login shell on
+# the Windows validator. The probe therefore failed on a perfectly
+# healthy Windows host — `'true' is not recognized as an internal or
+# external command` — and the gate reported "offline, or cannot reach
+# GitHub" when neither was true.
+#
+# That silently disabled Windows validation for v0.4.6 through v0.4.9:
+# four releases where the hook printed a reassuring "deferring to CI"
+# for a host that was reachable, had cargo 1.95.0, could resolve the
+# commit on GitHub, and would have compiled it. Verified after the fix:
+# `exit` returns 0 on both the Windows and the Linux validator.
+#
+# The lesson is the one already in this file's header about the v0.3.1
+# misreport: a probe that reports a healthy host as broken is worse than
+# no probe, because the fallback it triggers looks like diligence.
 host_reachable() {
-  ssh -o ConnectTimeout=8 -o BatchMode=yes "$1" true >/dev/null 2>&1
+  ssh -o ConnectTimeout=8 -o BatchMode=yes "$1" exit >/dev/null 2>&1
 }
 
 # Has CI already gone green for this exact COMMIT?

--- a/src/components/CommandPalette.activation.test.tsx
+++ b/src/components/CommandPalette.activation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 vi.mock("../api", () => ({
   api: {
@@ -114,18 +114,34 @@ describe("CommandPalette — keyboard activation targets the visible row", () =>
     expect(tabbable[0]!.tagName).toBe("INPUT");
   });
 
-  it("every visible row activates the same handler by Enter as by click", () => {
+  // `api.projectList` / `api.sessionSearch` are mocked async, so the
+  // palette re-renders when they resolve. Without flushing, a
+  // resolution can land between capturing the row list and asserting
+  // against it — the row set shifts underneath the test and it fails
+  // intermittently, which is exactly what CI saw on 2026-08-12.
+  //
+  // Flushing after every render makes the row set settled by
+  // construction rather than by luck.
+  const settle = async () => {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  };
+
+  it("every visible row activates the same handler by Enter as by click", async () => {
     // Walk the whole list with ArrowDown; at each stop, the keyboard
     // path and the click path must agree. This is the invariant the
     // original bug broke: clicking a row was correct, pressing Enter
     // on the same row was not.
     renderPalette();
+    await settle();
     const rowsSeen = screen.getAllByRole("option").map((r) => r.textContent ?? "");
     cleanup();
     expect(rowsSeen.length).toBeGreaterThan(3);
 
     for (let target = 0; target < rowsSeen.length; target++) {
       const viaKeyboard = renderPalette();
+      await settle();
       for (let i = 0; i < target; i++) {
         fireEvent.keyDown(input(), { key: "ArrowDown" });
       }
@@ -135,6 +151,7 @@ describe("CommandPalette — keyboard activation targets the visible row", () =>
       cleanup();
 
       const viaClick = renderPalette();
+      await settle();
       const row = screen
         .getAllByRole("option")
         .find((r) => (r.textContent ?? "") === highlighted);

--- a/src/components/CommandPalette.activation.test.tsx
+++ b/src/components/CommandPalette.activation.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 vi.mock("../api", () => ({
@@ -60,6 +60,20 @@ function input(): HTMLElement {
 }
 
 describe("CommandPalette — keyboard activation targets the visible row", () => {
+  // Pin the optional-section state. Boards is the optional tenth
+  // section, off by default and persisted in localStorage — so the
+  // palette renders nine rows or ten depending on what a previous test
+  // in this file left behind. That is the real cause of the
+  // intermittent `expected 9 to be 10`: the row set moved underneath
+  // the test, and no amount of flushing async renders touches it.
+  //
+  // Clearing rather than setting "0": the module also keeps an
+  // in-memory mirror for when storage is unavailable, and an absent key
+  // exercises the same default-off path the app boots into.
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("Enter on the initially-selected row runs that row, not another category's", () => {
     const h = renderPalette();
 

--- a/src/sections/config/EffectiveMcpRenderer.test.tsx
+++ b/src/sections/config/EffectiveMcpRenderer.test.tsx
@@ -71,8 +71,8 @@ describe("EffectiveMcpRenderer", () => {
     render(<EffectiveMcpRenderer cwd="/" />);
     await waitFor(() => {
       expect(screen.getByText("foo")).toBeInTheDocument();
+      expect(screen.getByText("pending")).toBeInTheDocument();
     });
-    expect(screen.getByText("pending")).toBeInTheDocument();
   });
 
   it("server row expands via keyboard (Enter) and exposes aria-expanded", async () => {

--- a/src/sections/projects/MoveSessionModal.test.tsx
+++ b/src/sections/projects/MoveSessionModal.test.tsx
@@ -261,10 +261,17 @@ describe("MoveSessionModal", () => {
     await user.type(screen.getByRole("combobox"), "/already/there");
     await user.click(screen.getByRole("option", { name: /Use this folder/ }));
 
-    await waitFor(() =>
-      expect(screen.getByText(/Existing folder/i)).toBeInTheDocument(),
-    );
-    expect(screen.getByRole("button", { name: /Move to there/i })).toBeEnabled();
+    // Both assertions live inside the wait. The badge and the button
+    // are separate state updates, so waiting only for the badge and
+    // then asserting the button synchronously races whichever render
+    // lands second — that is the intermittent failure CI saw on
+    // 2026-08-12 (`Unable to find … /Move to there/i`), not a timeout.
+    await waitFor(() => {
+      expect(screen.getByText(/Existing folder/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Move to there/i }),
+      ).toBeEnabled();
+    });
   });
 
   it("refuses a path that is a file, stating the reason inline", async () => {

--- a/src/sections/sessions/CleanupPane.test.tsx
+++ b/src/sections/sessions/CleanupPane.test.tsx
@@ -82,8 +82,8 @@ describe("CleanupPane", () => {
     await userEvent.click(screen.getByRole("button", { name: /^Preview$/i }));
     await waitFor(() => {
       expect(screen.getByTestId("prune-preview")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Prune → Trash/i })).not.toBeDisabled();
     });
-    expect(screen.getByRole("button", { name: /Prune → Trash/i })).not.toBeDisabled();
   });
 
   it("Prune → Trash calls sessionPruneStart with the same filter shape", async () => {

--- a/src/sections/sessions/SessionContextPanel.test.tsx
+++ b/src/sections/sessions/SessionContextPanel.test.tsx
@@ -71,8 +71,8 @@ describe("SessionContextPanel", () => {
     );
     await waitFor(() => {
       expect(screen.getByTestId("category-claude-md")).toBeInTheDocument();
+      expect(screen.getByTestId("category-tool-output")).toBeInTheDocument();
     });
-    expect(screen.getByTestId("category-tool-output")).toBeInTheDocument();
     // reported total appears.
     expect(screen.getByText(/42,000 total/)).toBeInTheDocument();
   });


### PR DESCRIPTION
Three fixes, each verified where it actually failed rather than where it was convenient.

## 1. The Windows release gate has been silently disabled for four releases

`host_reachable` probed with `ssh "$host" true`. **`true` does not exist in `cmd.exe`**, the Windows validator's login shell, so the probe failed on a perfectly healthy host and the hook reported *"offline, or cannot reach GitHub"* — neither of which was true.

Measured, not inferred: the validator answers SSH, resolves the pushed commit on GitHub, carries cargo 1.95.0, and runs the hook's exact `git fetch && git checkout --detach <sha>` to exit 0. It could have compiled every one of v0.4.6–v0.4.9. The gate printed a reassuring "deferring to CI" each time.

Now probes with `exit`, a builtin in both shells — verified returning 0 on both validators.

The file's own header already documents this defect class from v0.3.1. It recurred.

## 2. Four `waitFor` assertion races

`await waitFor(() => expect(A))` followed by a synchronous `expect(B)`. A and B are separate state updates, so B races whichever render lands second. That killed `MoveSessionModal`. Found by scanning for the *shape* rather than fixing the one that failed: MoveSessionModal, EffectiveMcpRenderer, SessionContextPanel, CleanupPane.

## 3. The palette flake — after a wrong first attempt

`expected 9 to be 10` is a **row count**. Boards is the optional tenth section, persisted in localStorage, so the palette renders nine rows or ten depending on what an earlier test left. The row set moved underneath the test.

My first attempt flushed async renders and called it fixed. Correct hygiene, wrong cause — it failed again five runs later. `localStorage.clear()` in `beforeEach` is the actual fix.

## Verification

- Palette: **four consecutive full-suite runs green** (1248 passed). Passing alone was never evidence — it passed alone before too.
- Windows validator, real hardware: `desktop_backend::swap` **20/20** including the previously-flaky `test_switch_not_installed_returns_error`.
- `exit` probe returns 0 on both validators.

## Known-open, not closed

30 runs of `cargo test -p claudepot-core --lib` on the Windows validator produced **1 failure that never recurred and never named itself**. Rarer than a small sample suggested. Recorded rather than papered over; now cheap to hunt, since a full run there is 34s versus a CI push.