### PR TITLE
chore(release): 0.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,22 @@ Versioning scheme:
 - `0.1.x` — beta
 - `1.0.0+` — stable
 
-## 0.4.9 — beta (unreleased)
+## 0.4.10 — beta (unreleased)
+
+### Fixed
+
+- **The Windows release gate had been silently skipping itself for four
+  releases.** Its reachability probe ran a command that does not exist
+  in `cmd.exe`, so it failed on a perfectly healthy validator and the
+  hook reported the host as offline. v0.4.6 through v0.4.9 all shipped
+  with Windows verification quietly deferred to CI. Developer-facing
+  only — no effect on the app.
+- Five flaky tests, each fixed at its cause rather than by re-running:
+  four assertion races that waited for one element then synchronously
+  asserted another, and a command-palette test whose row count depended
+  on whether an earlier test had left the optional Boards section on.
+
+## 0.4.9 — beta (released 2026-08-12)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudepot-cli"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-core"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-tauri"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 # Floor set by std file_lock (File::{lock,try_lock,unlock}, 1.89) —
 # the cross-process advisory locks in claudepot-core depend on it.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you use Claude Code or Claude Desktop daily, you've probably hit at least one
 
 ### Install
 
-> **Status: beta** (`0.4.9`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
+> **Status: beta** (`0.4.10`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
 
 You'll need a recent **Rust toolchain** ([rustup.rs](https://rustup.rs)) and **Node 20+** with **pnpm** ([pnpm.io](https://pnpm.io)). No other system dependencies.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claudepot",
   "private": true,
-  "version": "0.4.9",
+  "version": "0.4.10",
   "license": "ISC",
   "type": "module",
   "engines": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claudepot",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "identifier": "com.claudepot.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/web/src/app/(reader)/app/install/page.mdx
+++ b/web/src/app/(reader)/app/install/page.mdx
@@ -5,7 +5,7 @@ export const metadata = {
 
 # Install
 
-> **Status: beta (`0.4.9`).** Daily-driven on macOS. Linux and
+> **Status: beta (`0.4.10`).** Daily-driven on macOS. Linux and
 > Windows builds are green but less seasoned.
 
 Two paths: grab a signed installer from the latest release (fast,


### PR DESCRIPTION
Version bump across all five lock-step sites plus `Cargo.lock`, and the CHANGELOG for what shipped since 0.4.9.

## What's in 0.4.10

**The Windows release gate had been silently skipping itself for four releases.** Its reachability probe ran `true`, which does not exist in `cmd.exe`, so it failed on a perfectly healthy validator and the hook reported the host as offline. v0.4.6 through v0.4.9 all shipped with Windows verification quietly deferred to CI. Developer-facing only — no effect on the app.

**Five flaky tests, each fixed at its cause rather than by re-running.** Four assertion races (waiting for one element, then synchronously asserting another that lands in a different render), and a command-palette test whose row count depended on whether an earlier test had left the optional Boards section on.

## Verification

`cargo check --workspace` green · `pnpm test` 1248 passed · `cargo xtask verify-docs` green

Additionally, on the real Windows validator: `desktop_backend::swap` 20/20, including the previously-flaky `test_switch_not_installed_returns_error`.

## This tag is itself the first test of the fix

The gate repair is *in* this release, so pushing `v0.4.10` is the first tag since v0.4.5 where the hook should run a genuine Windows compile instead of printing "deferring to CI". If it defers again, the fix is wrong and the tag should not be trusted.