### PR TITLE
fix(identity): gate the private-slot fallback on the live-session probe

### DIFF
--- a/crates/claudepot-core/src/services/identity.rs
+++ b/crates/claudepot-core/src/services/identity.rs
@@ -194,7 +194,8 @@ pub async fn verify_account_identity_with_probe(
     // rotated token in place, rather than rotating the stale private-slot
     // copy (which would orphan CC's session → forced re-login). Only when
     // CC's keychain holds no usable blob do we fall through to the
-    // private-slot check below (there is nothing live to protect then).
+    // private-slot check below — and that fallthrough is gated on the
+    // live-session probe too (see the `ProfileCheck::Rejected` arm).
     if active_cli_matches(store, uuid)? {
         if let Some(outcome) =
             verify_active_via_keychain(&account.email, platform, fetcher, refresher, probe).await
@@ -233,6 +234,33 @@ pub async fn verify_account_identity_with_probe(
     let outcome = match run_profile_check(&blob, fetcher).await {
         ProfileCheck::Ok(actual) => classify(&account.email, actual),
         ProfileCheck::Rejected => {
+            // Live-session gate — the same rule `resolve_cc_identity`
+            // applies to the keychain, applied here to the slot.
+            //
+            // Reaching this arm as the ACTIVE account means the keychain
+            // resolver returned `None` (CC's blob unreadable/unparseable),
+            // not that CC is gone. CC's keychain was last populated FROM
+            // this slot, so a live `claude` may still hold this very
+            // refresh token in memory: spending it here retires the token
+            // CC holds, its next refresh fails, and the user is forced to
+            // re-login — the exact bug the keychain-path gate prevents.
+            //
+            // Re-read the active pointer rather than reusing the check
+            // above: the profile round-trip since then is long enough for
+            // a concurrent swap, and this is the instant that matters.
+            // Failing closed on a corrupt pointer is the point.
+            if active_cli_matches(store, uuid)? && probe.is_cc_running().await {
+                tracing::info!(
+                    account = %uuid,
+                    "active account with a live claude session — declining to spend the slot's \
+                     single-use refresh token"
+                );
+                let outcome = VerifyOutcome::NetworkError;
+                store
+                    .update_verification(uuid, &outcome)
+                    .map_err(|e| VerifyError::Store(e.to_string()))?;
+                return Ok(outcome);
+            }
             // 401 — try one refresh, then re-check. If refresh fails, it's
             // Rejected. If refresh succeeds but the new profile email
             // doesn't match the label, Drift (and we DON'T save).
@@ -1148,6 +1176,94 @@ mod tests {
             VerifyOutcome::Ok {
                 email: "alice@example.com".into()
             }
+        );
+        swap::delete_private(uuid).await.unwrap();
+    }
+
+    /// The keychain-empty fallback is NOT exempt from the live-session gate.
+    ///
+    /// `verify_active_via_keychain` returns `None` when CC's keychain read
+    /// yields nothing parseable, and the caller then falls through to the
+    /// private-slot path. That fallthrough spends the slot's single-use
+    /// refresh token with no gate and no keychain write-back — so a
+    /// keychain read that comes up empty *while a `claude` process is
+    /// live* retires the token CC still holds in memory, and CC's next
+    /// refresh fails. "Nothing live to protect" is an assumption about the
+    /// keychain, but the probe is the only thing that actually knows.
+    #[tokio::test]
+    async fn active_account_live_session_gate_applies_to_slot_fallback() {
+        let _lock = crate::testing::lock_data_dir();
+        let _env = crate::testing::setup_test_data_dir();
+        let (store, _dir, uuid) = setup_account("alice@example.com");
+        store.set_active_cli(uuid).unwrap();
+        swap::save_private(uuid, &crate::testing::fresh_blob_json())
+            .await
+            .unwrap();
+
+        let platform = MockKeychain::empty(); // read came up empty
+        let fetcher = MockFetcher::rejecting(); // /profile → 401
+
+        let outcome = verify_account_identity_with_probe(
+            &store,
+            uuid,
+            &platform,
+            &fetcher,
+            &NeverRefresher,
+            &LiveProbe,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            VerifyOutcome::NetworkError,
+            "a live claude session must make this transient, never Rejected"
+        );
+        swap::delete_private(uuid).await.unwrap();
+    }
+
+    /// The gate on the fallback is conditional, not a blanket ban. Same
+    /// setup as the test above with NO live session: the refresh still
+    /// happens and still lands in the slot. Pairs with it so a fix that
+    /// simply stops refreshing the fallback path is caught.
+    #[tokio::test]
+    async fn slot_fallback_still_refreshes_without_a_live_session() {
+        let _lock = crate::testing::lock_data_dir();
+        let _env = crate::testing::setup_test_data_dir();
+        let (store, _dir, uuid) = setup_account("alice@example.com");
+        store.set_active_cli(uuid).unwrap();
+        swap::save_private(uuid, &crate::testing::fresh_blob_json())
+            .await
+            .unwrap();
+
+        let platform = MockKeychain::empty();
+        let fetcher = MockFetcher {
+            email: Mutex::new(Some("alice@example.com".into())),
+            err: Mutex::new(Some(OAuthError::AuthFailed("401".into()))),
+        };
+        let refresher = MockRefresher::ok_with("sk-ant-oat01-slot", "sk-ant-ort01-slot");
+
+        let outcome = verify_account_identity_with_probe(
+            &store,
+            uuid,
+            &platform,
+            &fetcher,
+            &refresher,
+            &crate::cli_backend::swap::NoLiveSessionProbe,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            VerifyOutcome::Ok {
+                email: "alice@example.com".into()
+            }
+        );
+        let saved = swap::load_private(uuid).await.unwrap();
+        assert!(
+            saved.contains("sk-ant-oat01-slot"),
+            "no live session → the rotated blob is persisted to the slot"
         );
         swap::delete_private(uuid).await.unwrap();
     }


### PR DESCRIPTION
## The hole

`verify_account_identity_with_probe` routes the active CLI account to
`verify_active_via_keychain`, which is correctly gated — it declines to spend a
single-use refresh token while a `claude` process is alive.

But when that resolver returns `None`, control falls through to the private-slot
path at `identity.rs:239`, and **that path has no live-session gate and no
keychain write-back**. The comment justified it as:

> Only when CC's keychain holds no usable blob do we fall through to the
> private-slot check below (there is nothing live to protect then).

`None` means the keychain read came up empty or unparseable — not that CC is
gone. CC's keychain was last populated *from this slot*, so a live `claude` can
still hold that same refresh token in memory. Rotating it there retires the
token CC holds, CC's next refresh fails, and the user is forced to re-login —
precisely the failure the keychain-path gate exists to prevent. "Nothing live to
protect" is an assumption about the keychain when the probe is the only thing
that actually knows.

## Observed at 0.4.10

Three consecutive verifies took this path for the active account while a session
was live:

```
01:58:42  profile returned 401 — attempting refresh_token exchange account=3a65a18b…
01:58:43  verify_all_with_progress: result account=3a65a18b… status="rejected"
01:59:49  (same)
02:01:13  (same)
```

That log line is `identity.rs:471`, inside `try_refresh`, whose only caller is
the slot path. No `keychain_write` was logged at any of those moments, so each
rotation landed in the private slot and never reached CC.

## The fix

Apply the same rule to the slot that `resolve_cc_identity` applies to the
keychain: if this is the active account and a live session is running, record
`NetworkError` — transient, and it preserves `verified_email` history — instead
of spending the token.

The active pointer is re-read at the gate rather than reusing the check at the
top of the function: the profile round-trip since then is long enough for a
concurrent swap, and this is the instant that matters. A corrupt pointer fails
closed, as `active_cli_matches` already guarantees.

## Tests

- `active_account_live_session_gate_applies_to_slot_fallback` — active + empty
  keychain + 401 + live session. Uses the existing `NeverRefresher`, so it fails
  on the *attempt*, not on a discarded result. Red before the fix:

  ```
  panicked: refresh must not be attempted while a live claude session is running
  ```

- `slot_fallback_still_refreshes_without_a_live_session` — its pair. Same setup,
  no live session: the refresh proceeds and the rotated blob lands in the slot.
  Guards against the fix regressing into a blanket ban.

The suite already had `active_account_live_cc_session_does_not_spend_refresh_token`
and `active_account_falls_back_to_slot_when_keychain_empty`, but nothing
combining them — which is how the gap survived.

`cargo test -p claudepot-core --lib` → 3530 passed, 0 failed.
`cargo clippy --all-targets -p claudepot-core -p claudepot-cli -- -D warnings` → clean.

## Not addressed

Whatever first made the keychain resolver return `None` is upstream of this and
is not diagnosed here. This fix stops Claudepot from converting that condition
into a forced re-login; it does not explain the condition.