### PR TITLE
chore(release): 0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,25 @@ Versioning scheme:
 - `0.1.x` — beta
 - `1.0.0+` — stable
 
-## 0.4.10 — beta (unreleased)
+## 0.4.11 — beta (unreleased)
+
+### Fixed
+
+- **Downloaded `.dmg` files were rejected by Gatekeeper.** Tauri
+  notarizes and staples the `.app` and signs the disk image, but never
+  notarizes the image itself — so macOS refused the download with
+  "Unnotarized Developer ID" before the stapled app inside was ever
+  assessed. Fresh downloads only; in-app updates were never affected.
+  Applies from this release onward, so a `.dmg` from 0.4.10 or earlier
+  still shows the warning.
+- **Verifying the active account could sign you out of a running Claude
+  Code session.** The private-slot fallback spent the slot's single-use
+  refresh token even when a live `claude` might still be holding that
+  same token in memory, retiring it and forcing a re-login. The
+  live-session gate that already protected the keychain path now covers
+  the slot path too. Thanks to @zhuligs.
+
+## 0.4.10 — beta (released 2026-08-12)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudepot-cli"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-core"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-tauri"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 # Floor set by std file_lock (File::{lock,try_lock,unlock}, 1.89) —
 # the cross-process advisory locks in claudepot-core depend on it.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you use Claude Code or Claude Desktop daily, you've probably hit at least one
 
 ### Install
 
-> **Status: beta** (`0.4.10`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
+> **Status: beta** (`0.4.11`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
 
 You'll need a recent **Rust toolchain** ([rustup.rs](https://rustup.rs)) and **Node 20+** with **pnpm** ([pnpm.io](https://pnpm.io)). No other system dependencies.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claudepot",
   "private": true,
-  "version": "0.4.10",
+  "version": "0.4.11",
   "license": "ISC",
   "type": "module",
   "engines": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claudepot",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "identifier": "com.claudepot.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/web/src/app/(reader)/app/install/page.mdx
+++ b/web/src/app/(reader)/app/install/page.mdx
@@ -5,7 +5,7 @@ export const metadata = {
 
 # Install
 
-> **Status: beta (`0.4.10`).** Daily-driven on macOS. Linux and
+> **Status: beta (`0.4.11`).** Daily-driven on macOS. Linux and
 > Windows builds are green but less seasoned.
 
 Two paths: grab a signed installer from the latest release (fast,


### PR DESCRIPTION
Version bump across all five lock-step sites plus `Cargo.lock`, and the CHANGELOG for what shipped since 0.4.10.

## What's in 0.4.11 — two user-facing fixes

**Downloaded `.dmg` files were rejected by Gatekeeper** (#70). Tauri notarizes and staples the `.app` and signs the disk image, but never notarizes the image itself — so macOS refused the download with "Unnotarized Developer ID" before the stapled app inside was ever assessed. Fresh downloads only; in-app updates were never affected.

Note this applies **from this release onward**. A `.dmg` downloaded from 0.4.10 or earlier still shows the warning, so if that matters for anyone already on those artifacts, 0.4.10 would need a re-cut separately.

**Verifying the active account could sign you out of a running Claude Code session** (#69, @zhuligs). The private-slot fallback spent the slot's single-use refresh token even when a live `claude` might still be holding that same token in memory — retiring it, failing CC's next refresh, and forcing a re-login. The live-session gate that already protected the keychain path now covers the slot path too, re-reading the active pointer rather than trusting an earlier check, since a concurrent swap can land in between.

## Verification

`cargo check --workspace` green · `pnpm test` 1248 passed · `cargo xtask verify-docs` green

The tag push will exercise the repaired Windows gate, which validated cleanly on real hardware for v0.4.10.