### PR TITLE
Release 0.4.12: surface tray Desktop actions, close four silent-failure gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,11 @@ typescript
 # preflight.sh and by the `check:envvar-layout` package script, so leaving it
 # out would point a committed gate at a file a fresh clone does not have.
 !/scripts/check-envvar-layout.mjs
+# Its unit tests, which vitest DOES run in CI (`scripts/**/*.test.mjs` is in
+# vitest.config.ts's include). Leaving this ignored would put a test file in
+# the working tree that no other clone has and CI never sees — the same
+# never-ran-anywhere failure the web suite's hand-listed runner had.
+!/scripts/check-envvar-layout.test.mjs
 # Locale-catalog gate. ci.yml runs it via `pnpm check:catalogs`, so the same
 # rule as the entry above applies with teeth: leaving it out points a
 # committed CI step at a file a fresh clone does not have, and the job fails

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,22 @@ version lock-step check (tag vs `Cargo.toml`, `package.json`,
 - Eight SQLite files live in `~/.claudepot/` (override with
   `CLAUDEPOT_DATA_DIR`; the authoritative list is whatever joins onto
   `claudepot_core::paths::claudepot_data_dir()`, and
-  `cargo xtask verify-docs` fails when this list drifts from it):
+  `cargo xtask verify-docs` fails when this list drifts from it).
+
+  **Every one of them opens through
+  `claudepot-core::db_pragmas::apply_standard_pragmas`**, and
+  `verify-docs` fails a `Connection::open` that doesn't. Hand-rolling
+  the pragma batch is the failure, not getting it wrong: `corpus.rs`
+  hand-rolled a batch that *looked* deliberate and silently omitted
+  `journal_size_limit` + `wal_autocheckpoint`, leaving the largest
+  database in the app outside the bound that exists because
+  `sessions.db-wal` once reached 6.3 GB. The helper also retries the
+  `delete` → `wal` transition, because SQLite does **not** run the busy
+  handler for it — `busy_timeout` does not cover that statement, and
+  racing the first open of a file failed outright with "database is
+  locked" (measured: 2 failures per 320 concurrent opens). Per-store
+  extras like `synchronous=NORMAL` or `foreign_keys=ON` go in a second
+  batch *after* the helper, never instead of it.
   - `accounts.db` — authoritative account + verification state, linked to Keychain.
   - `boards.db` — durable agent-written boards (grid spec, typed
     series, rows). Owned by `claudepot-core::board::store`. **User
@@ -402,6 +417,29 @@ All writes go through `claudepot-core::settings_mutex`, the one
 serialized read-modify-write boundary for CC's settings files — see
 below.
 
+## Locating CC's global config — one resolver, two meanings
+
+Two different questions, and picking the wrong one is a silent bug:
+
+| You mean | Call |
+|---|---|
+| the file at `$HOME/.claude.json` | `paths::claude_json_path()` |
+| the file **CC will actually read** | `paths::global_claude_json_target()` (or `resolved_global_claude_json()` when "it doesn't exist" is a distinct answer) |
+
+The second mirrors CC's `getGlobalClaudeFile` (`utils/env.ts:14-26`):
+legacy `<config_dir>/.config.json` wins when present, else
+`$CLAUDE_CONFIG_DIR/.claude.json`, else `~/.claude.json`. **Never
+hand-roll that three-way check** — it was re-implemented three times
+and two copies were wrong. `config_view::effective_io` dropped the
+legacy branch while claiming parity in its own comment, so Config →
+Effective MCP read the wrong file and showed no user-scope servers
+while the preview beside it read the right one; `cc_tips::history`
+hardcoded the home sibling, so under `CLAUDE_CONFIG_DIR` the tips
+ledger reported `num_startups: 0` forever — into
+`cc_tips_snapshots.jsonl`, which is append-only and unreconstructable.
+`claude_json_path()` is correct only where the home sibling is
+genuinely the target (project-move rewriting the `projects` map).
+
 ## Command palette (⌘K)
 
 `src/components/CommandPalette.tsx` + `usePaletteActions` +
@@ -511,7 +549,17 @@ parity is asserted on plural *bases*, since zh legitimately carries
 only `_other` where en carries `_one` + `_other`. Point
 `CLAUDEPOT_LOCALES_DIR` at a fixture to exercise the gate itself — a
 check nobody has watched fail is indistinguishable from one that
-cannot fail, which is precisely what `check:envvar-layout` had become.
+cannot fail.
+
+`check:envvar-layout` was the standing example of that decay: it drives
+the real app over the debug-only MCP bridge, so CI cannot run it and
+nobody had ever seen it go red. It now has both halves covered —
+`node scripts/check-envvar-layout.mjs --self-test` forces `.envvar-list`
+to 0px against the live pane and fails if the assertions *don't* fire,
+and `scripts/check-envvar-layout.test.mjs` unit-tests the pure
+`evaluate()` half in CI. Split the judgement out of the measurement in
+any guard of this shape; the measurement may need a screen, the
+judgement never does.
 
 ## Settings-file mutation boundary
 
@@ -771,6 +819,23 @@ See `dev-docs/implementation-plan.md` for the full plan.
   `op-progress::<op_id>` channels → the op-progress modal subscribes
   by op_id. The `RunningOps` map on the backend is the polling
   backstop; see `src-tauri/src/ops.rs`.
+- **Every event channel `src-tauri/src/events.rs` declares must have a
+  subscriber in `src/`**, and `cargo xtask verify-docs` fails when one
+  doesn't. Seven had none: the four tray→Desktop channels
+  (`tray-desktop-switched`, `tray-desktop-switch-failed`,
+  `tray-desktop-launch-failed`, `desktop-reconciled`), so a tray
+  Desktop swap left the account cards stale and a *failed* one produced
+  no toast, no banner, nothing — while the CLI sibling had toast, OS
+  banner and Undo; plus three (`desktop-adopted`, `desktop-cleared`,
+  `desktop-running-changed`) that only re-announced what the invoking
+  command had already returned, now deleted. `events.rs` had a test
+  called "wire-contract lock" that compared each constant to its own
+  literal — a tautology inside one crate cannot see the far end of a
+  cross-boundary contract. Deliberate non-subscriptions go in
+  `UNSUBSCRIBED_BY_DESIGN` in `verify_docs.rs` **with the reason**;
+  entries there are validated in both directions, so one cannot outlive
+  its rationale. A tray action emits because nothing returns to a
+  caller — if nobody listens, the click silently does nothing.
 
 ## Web (claudepot.com)
 
@@ -797,6 +862,18 @@ records to `76.76.21.21`. Phase-1 plan and full migration log in
 
 CI: `.github/workflows/ci-web.yml` runs typecheck + tests on
 `web/**` changes (no build — Vercel handles the build per push).
+
+`pnpm test` here is `node scripts/run-tests.mjs`, which **discovers**
+`tests/*.test.ts` rather than listing them. It used to be 23 filenames
+chained with `&&`, so adding a test file did not add it to the suite —
+and three never ran anywhere: `username.test.ts` (reserved names and
+self-rename cooldown, the impersonation surface of a public site),
+`editorial-routing.test.ts`, and `social-format.test.ts`. All three
+passed once run, which is the bad case: 45 assertions looked like
+coverage while CI was green without them. A list of files is a cache of
+the directory; read the directory. `tests/integration/` stays out on
+purpose — it needs `--env-file=.env.local` and a live Neon connection,
+so it keeps its own `test:integration` script.
 
 The `web/.tokenize/` config currently runs the hook in
 `{"mode": "maintainer", "strictness": "advisory"}` — it flags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,59 @@ Versioning scheme:
 - `0.1.x` — beta
 - `1.0.0+` — stable
 
-## 0.4.11 — beta (unreleased)
+## 0.4.12 — beta (released 2026-08-14)
+
+### Fixed
+
+- **Switching Claude Desktop from the tray told you nothing, including
+  when it failed.** The tray emitted four events the app never
+  subscribed to, so a Desktop swap left the account cards showing the
+  previous binding, and a swap or launch that *failed* produced no
+  toast, no banner and no message anywhere — the click simply appeared
+  to do nothing. The equivalent CLI actions had carried full feedback
+  the whole time. Desktop swaps now refresh the cards and report
+  success and failure the same way, and the tray names the account it
+  switched to. Unlike the CLI swap there is no Undo: reversing a
+  Desktop switch is not symmetric with performing one.
+- **Databases could refuse to open with "database is locked" when
+  Claudepot's windows, the CLI and the MCP server started together.**
+  Switching a database into WAL mode needs a brief exclusive lock, and
+  SQLite does not apply `busy_timeout` to that one step — so the first
+  process to open a file could lose the race and fail outright rather
+  than wait. Measured at 2 failures per 320 concurrent first-opens.
+  Affected every Claudepot database.
+- **Global → Config → Effective MCP read the wrong file** on installs
+  carrying a legacy `~/.claude/.config.json`, reporting no user-scope
+  MCP servers while Claude Code was actively applying them. The config
+  preview beside it read the correct file, so the same pane disagreed
+  with itself.
+- **The Claude Code tips ledger reported zero startups** for anyone
+  using `CLAUDE_CONFIG_DIR` or that same legacy config file — it read
+  `~/.claude.json` regardless of where Claude Code actually keeps its
+  global config. Because those counters feed an append-only log, past
+  zeroes cannot be reconstructed; the ledger is correct from this
+  release forward.
+- **`corpus.db`'s write-ahead log had no size bound.** The largest
+  database Claudepot keeps was the one store that configured its own
+  SQLite pragmas by hand, and silently omitted the two that cap WAL
+  growth — the same shape as the incident that put those caps in place.
+- `boards.db` migrations now decide what to apply while holding the
+  write lock. Harmless today, since the only migration is idempotent,
+  but boards hold data that exists nowhere else and the next migration
+  would not have been.
+
+### Changed
+
+- Developer-facing, no effect on the app: three classes of defect above
+  were invisible because nothing checked for them, so each now has a
+  gate. `cargo xtask verify-docs` fails a database opened without the
+  standard pragmas, and fails an event channel the backend emits with
+  no subscriber in the frontend. The web suite discovers its test files
+  instead of running a hand-written list — three test files, 45
+  assertions, had never run anywhere. Every one of these gates was
+  checked by breaking the thing it watches and confirming it goes red.
+
+## 0.4.11 — beta (released 2026-08-14)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudepot-cli"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-core"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-tauri"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.11"
+version = "0.4.12"
 edition = "2021"
 # Floor set by std file_lock (File::{lock,try_lock,unlock}, 1.89) —
 # the cross-process advisory locks in claudepot-core depend on it.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you use Claude Code or Claude Desktop daily, you've probably hit at least one
 
 ### Install
 
-> **Status: beta** (`0.4.11`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
+> **Status: beta** (`0.4.12`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
 
 You'll need a recent **Rust toolchain** ([rustup.rs](https://rustup.rs)) and **Node 20+** with **pnpm** ([pnpm.io](https://pnpm.io)). No other system dependencies.
 

--- a/crates/claudepot-core/src/board/store.rs
+++ b/crates/claudepot-core/src/board/store.rs
@@ -1419,19 +1419,47 @@ fn row_to_board(db: &Connection, board_id: &str) -> Result<Board, BoardError> {
 /// A version newer than this build understands is an error, not a
 /// best-effort read: an older Claudepot writing rows under a newer
 /// schema's assumptions is how user data gets silently mangled.
+///
+/// # The decision is re-read INSIDE the transaction
+///
+/// This store is opened directly by the GUI, the CLI, the MCP server
+/// subprocess and any script, with no channel between them (see the
+/// module docs). Deciding from a version read *before* `BEGIN
+/// IMMEDIATE` lets two processes both observe the pre-migration number
+/// and both run the same migration: the first commits, the second
+/// re-applies it to an already-migrated database.
+///
+/// That was survivable only by accident. v1 is `CREATE TABLE IF NOT
+/// EXISTS`, so a double-apply is a no-op — but the comment below
+/// promises the next migration will "ALTER and backfill", and a
+/// backfill applied twice corrupts rows in a file whose whole premise
+/// is that it holds user data existing nowhere else.
+///
+/// The read outside the lock is kept as a **fast path only**. It is
+/// safe there because the version is monotonic: "already current" can
+/// never become "needs migrating", so an early return on that answer
+/// cannot be racing anything. Every answer that leads to a *write* is
+/// re-derived under the lock, where the loser of a race sees the
+/// version the winner committed and does nothing. Taking `BEGIN
+/// IMMEDIATE` unconditionally would be simpler and wrong in the other
+/// direction — it would serialize every `open()` behind any concurrent
+/// writer, on the common path where there is nothing to migrate.
 fn migrate(db: &Connection) -> Result<(), BoardError> {
-    let version: i64 = db.query_row("PRAGMA user_version", [], |r| r.get(0))?;
-    if version > SCHEMA_VERSION {
-        return Err(BoardError::SchemaTooNew {
-            found: version,
-            supported: SCHEMA_VERSION,
-        });
-    }
-    if version == SCHEMA_VERSION {
+    if !needs_migration(read_version(db)?)? {
         return Ok(());
     }
+
+    // `busy_timeout` (via `apply_standard_pragmas`) applies at `BEGIN
+    // IMMEDIATE`, so a concurrent migration is waited on, not raced.
     db.execute_batch("BEGIN IMMEDIATE;")?;
+
     let apply = |db: &Connection| -> Result<(), BoardError> {
+        // Authoritative re-read: whatever we saw above is now stale by
+        // however long we waited for the write lock.
+        let version = read_version(db)?;
+        if !needs_migration(version)? {
+            return Ok(());
+        }
         if version < 1 {
             db.execute_batch(SCHEMA_V1)?;
         }
@@ -1440,6 +1468,7 @@ fn migrate(db: &Connection) -> Result<(), BoardError> {
         db.execute_batch(&format!("PRAGMA user_version = {SCHEMA_VERSION};"))?;
         Ok(())
     };
+
     match apply(db) {
         Ok(()) => {
             db.execute_batch("COMMIT;")?;
@@ -1450,6 +1479,27 @@ fn migrate(db: &Connection) -> Result<(), BoardError> {
             Err(e)
         }
     }
+}
+
+fn read_version(db: &Connection) -> Result<i64, BoardError> {
+    Ok(db.query_row("PRAGMA user_version", [], |r| r.get(0))?)
+}
+
+/// `Ok(true)` when this build must migrate, `Ok(false)` when the file
+/// is already current, `Err` when it was written by a newer build.
+///
+/// One function so the fast path and the under-lock re-read cannot
+/// disagree — two copies of a three-way comparison, in the code that
+/// decides whether to rewrite user data, is how the fast path ends up
+/// meaning something subtly different from the authoritative one.
+fn needs_migration(version: i64) -> Result<bool, BoardError> {
+    if version > SCHEMA_VERSION {
+        return Err(BoardError::SchemaTooNew {
+            found: version,
+            supported: SCHEMA_VERSION,
+        });
+    }
+    Ok(version < SCHEMA_VERSION)
 }
 
 #[cfg(test)]
@@ -1538,6 +1588,73 @@ mod tests {
             BoardStore::open(&path),
             Err(BoardError::SchemaTooNew { found: 999, .. })
         ));
+    }
+
+    /// `needs_migration` is the one three-way comparison both the fast
+    /// path and the under-lock re-read consult. Locking its boundaries
+    /// separately is what stops the two from drifting apart.
+    #[test]
+    fn needs_migration_covers_all_three_answers() {
+        assert!(matches!(needs_migration(0), Ok(true)), "fresh file");
+        assert!(
+            matches!(needs_migration(SCHEMA_VERSION), Ok(false)),
+            "already current — the early-return the fast path relies on"
+        );
+        assert!(matches!(
+            needs_migration(SCHEMA_VERSION + 1),
+            Err(BoardError::SchemaTooNew { .. })
+        ));
+    }
+
+    /// Many processes opening one boards.db concurrently is the normal
+    /// case — GUI, CLI and the MCP subprocess all open it directly with
+    /// no channel between them. Every one must land on a consistent
+    /// schema, and the rows written through them must all survive.
+    ///
+    /// This passed before the fix too, because v1 is `CREATE TABLE IF
+    /// NOT EXISTS` and double-applying it is a no-op. It is here as the
+    /// regression guard for the migration *after* this one: the moment
+    /// a `version < 2` arm does an ALTER or a backfill, a re-applied
+    /// migration stops being harmless and this is the shape that
+    /// catches it.
+    #[test]
+    fn concurrent_opens_converge_on_one_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("boards.db");
+
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let path = path.clone();
+                std::thread::spawn(move || {
+                    let s = BoardStore::open(&path).expect("concurrent open must succeed");
+                    let b = s
+                        .create_board(&format!("b{i}"), &BoardSpec::empty(), &[runs_series()])
+                        .expect("create");
+                    s.push(&push_req(
+                        &b.board_id,
+                        vec![row("2026-07-31T00:00:00+00:00", i as f64)],
+                    ))
+                    .expect("push");
+                    b.board_id
+                })
+            })
+            .collect();
+
+        let ids: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        let s = BoardStore::open(&path).unwrap();
+        let v: i64 = s
+            .db()
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, SCHEMA_VERSION);
+        for id in &ids {
+            assert_eq!(
+                s.row_count(id, "runs").unwrap(),
+                1,
+                "a concurrent writer's row was lost"
+            );
+        }
     }
 
     #[test]

--- a/crates/claudepot-core/src/cc_tips/history.rs
+++ b/crates/claudepot-core/src/cc_tips/history.rs
@@ -44,12 +44,23 @@ pub struct TipsHistoryRead {
     pub tips_history: BTreeMap<String, u32>,
 }
 
+/// Read CC's `numStartups` + `tipsHistory` from its global config.
+///
+/// The default resolves through `paths::global_claude_json_target`,
+/// NOT a hand-built `$HOME/.claude.json`. CC reads these two counters
+/// out of `getGlobalConfig()` → `getGlobalClaudeFile()`
+/// (`utils/env.ts:14-26`), which honours `CLAUDE_CONFIG_DIR` and
+/// prefers a legacy `<config_dir>/.config.json`. Pointing at the home
+/// sibling regardless meant that on any install using either, this
+/// returned `num_startups: 0` and an empty history — indistinguishable
+/// from "you have never seen a tip".
+///
+/// That is worse here than in a normal reader: these counters are the
+/// input to `cc_tips_snapshots.jsonl`, the append-only log that
+/// converts CC's counter-only state into wall-clock time. A zero
+/// recorded today cannot be reconstructed later.
 pub fn read_tips_history(global_config_path: Option<PathBuf>) -> TipsResult<TipsHistoryRead> {
-    let path = global_config_path.unwrap_or_else(|| {
-        dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("/"))
-            .join(".claude.json")
-    });
+    let path = global_config_path.unwrap_or_else(crate::paths::global_claude_json_target);
     let bytes = match std::fs::read(&path) {
         Ok(b) => b,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -256,6 +267,57 @@ mod tests {
             num_startups: n,
             tips_history: th,
         }
+    }
+
+    /// The default path must be the file CC actually reads.
+    ///
+    /// This hardcoded `$HOME/.claude.json`, so under
+    /// `CLAUDE_CONFIG_DIR` it read a file CC never writes and returned
+    /// zeroes — reported to the user as "no tip has ever been shown".
+    /// Asserting on the *counters* rather than on the resolved path is
+    /// deliberate: a test that only checked which path was chosen
+    /// would pass again the moment someone reintroduced a second
+    /// resolver that happens to agree on this one input.
+    #[test]
+    fn the_default_config_path_follows_claude_config_dir() {
+        let _lock = crate::testing::lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join("config-dir");
+        std::fs::create_dir_all(&cfg).unwrap();
+
+        // What CC would have written there.
+        std::fs::write(
+            cfg.join(".claude.json"),
+            br#"{"numStartups": 42, "tipsHistory": {"ide-hotkey": 7}}"#,
+        )
+        .unwrap();
+
+        std::env::set_var("CLAUDE_CONFIG_DIR", &cfg);
+        let got = read_tips_history(None).expect("read");
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+
+        assert_eq!(
+            got.num_startups, 42,
+            "read the home sibling instead of $CLAUDE_CONFIG_DIR/.claude.json"
+        );
+        assert_eq!(got.tips_history.get("ide-hotkey"), Some(&7));
+    }
+
+    /// And the legacy branch, which `getGlobalClaudeFile` checks first.
+    #[test]
+    fn the_default_config_path_prefers_the_legacy_config_json() {
+        let _lock = crate::testing::lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join("config-dir");
+        std::fs::create_dir_all(&cfg).unwrap();
+        std::fs::write(cfg.join(".config.json"), br#"{"numStartups": 99}"#).unwrap();
+        std::fs::write(cfg.join(".claude.json"), br#"{"numStartups": 1}"#).unwrap();
+
+        std::env::set_var("CLAUDE_CONFIG_DIR", &cfg);
+        let got = read_tips_history(None).expect("read");
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+
+        assert_eq!(got.num_startups, 99, "legacy .config.json must win");
     }
 
     #[test]

--- a/crates/claudepot-core/src/config_view/discover.rs
+++ b/crates/claudepot-core/src/config_view/discover.rs
@@ -831,19 +831,12 @@ pub fn collect_policy_managed_files() -> Vec<FileNode> {
 /// var is unset). Surface the actual file so the preview points to the
 /// authoritative location.
 pub fn collect_redacted_user_config() -> Option<FileNode> {
-    let legacy = claude_config_dir().join(".config.json");
-    let primary_base = std::env::var_os("CLAUDE_CONFIG_DIR")
-        .map(PathBuf::from)
-        .or_else(dirs::home_dir)
-        .unwrap_or_else(|| PathBuf::from("/tmp"));
-    let primary = primary_base.join(".claude.json");
-    let p = if legacy.is_file() {
-        legacy
-    } else if primary.is_file() {
-        primary
-    } else {
-        return None;
-    };
+    // `resolved_global_claude_json` is the one implementation of this
+    // three-way resolution; the copy that used to live here was right,
+    // but two of the other three copies were not (see that function's
+    // docs). `None` means CC has no global config at all, which is why
+    // this wants the existence-checked form rather than the target.
+    let p = crate::paths::resolved_global_claude_json()?;
     let meta = std::fs::metadata(&p).ok()?;
     let size = meta.len();
     let mtime = mtime_ns(&meta);

--- a/crates/claudepot-core/src/config_view/effective_io.rs
+++ b/crates/claudepot-core/src/config_view/effective_io.rs
@@ -108,19 +108,19 @@ fn json_kind(v: &Value) -> &'static str {
     }
 }
 
-/// Resolve CC's `.claude.json` location identically to
-/// `discover::collect_redacted_user_config`. CC stores this file at
-/// `$CLAUDE_CONFIG_DIR/.claude.json` when the env var is set, otherwise
-/// `$HOME/.claude.json` — note this is a SIBLING of `$HOME/.claude/`,
-/// NOT a child of it. Resolving via `claude_config_dir().join(...)`
-/// would land at `~/.claude/.claude.json`, which CC never writes, so
-/// every MCP read would see an empty map.
+/// Resolve CC's global config location.
+///
+/// Delegates to `paths::global_claude_json_target` rather than
+/// re-deriving it. The hand-rolled version this replaces handled
+/// `CLAUDE_CONFIG_DIR` but silently dropped the legacy
+/// `<claude_config_dir>/.config.json` branch — which is the FIRST
+/// thing `getGlobalClaudeFile` (`env.ts:14-26`) checks — while its own
+/// comment claimed parity with that function. On a machine carrying
+/// the legacy file, the MCP reads below saw an empty map for a file CC
+/// was actively applying, and `collect_redacted_user_config` (which
+/// did check it) pointed at a different file on the same pane.
 fn resolve_claude_json_path() -> PathBuf {
-    let base = std::env::var_os("CLAUDE_CONFIG_DIR")
-        .map(PathBuf::from)
-        .or_else(dirs::home_dir)
-        .unwrap_or_else(|| PathBuf::from("/tmp"));
-    base.join(".claude.json")
+    crate::paths::global_claude_json_target()
 }
 
 fn non_empty_or_none(v: Value) -> Option<Value> {

--- a/crates/claudepot-core/src/corpus.rs
+++ b/crates/claudepot-core/src/corpus.rs
@@ -229,13 +229,28 @@ impl CorpusIndex {
                 .open(path);
         }
         let conn = Connection::open(path)?;
-        // `busy_timeout` matters: the GUI and the CLI both open this
-        // file, and `corpus index` holds write transactions. Without it
-        // a concurrent `corpus status` fails instantly with SQLITE_BUSY.
-        conn.execute_batch(
-            "PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; \
-             PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
-        )?;
+        // WAL + `busy_timeout` + the WAL size bounds, from the one
+        // helper every other store uses. `busy_timeout` matters here in
+        // particular: the GUI and the CLI both open this file, and
+        // `corpus index` holds write transactions, so without it a
+        // concurrent `corpus status` fails instantly with SQLITE_BUSY.
+        //
+        // This used to hand-roll the pragma batch and, in doing so,
+        // omitted `journal_size_limit` / `wal_autocheckpoint` — leaving
+        // the LARGEST database in the app (≈880 MB with a bulk-insert
+        // indexer) as the only one outside the bound that exists
+        // because `sessions.db-wal` once reached 6.3 GB. Hand-rolling
+        // is what made that divergence invisible; call the helper.
+        crate::db_pragmas::apply_standard_pragmas(&conn)?;
+        // Beyond the standard set: FK enforcement (corpus_files /
+        // corpus_exchanges / corpus_tool_calls all cascade from
+        // corpus_sessions) and `synchronous=NORMAL`. NORMAL is safe
+        // here and nowhere else in this crate — the corpus is derived
+        // data, rebuildable by one ~5-minute pass, so trading the FULL
+        // fsync for indexing throughput costs nothing a rebuild can't
+        // restore. Credential stores must stay at FULL; see
+        // `db_pragmas`' module docs for why that decision is per-store.
+        conn.execute_batch("PRAGMA synchronous=NORMAL; PRAGMA foreign_keys=ON;")?;
         conn.execute_batch(SCHEMA)?;
         // WAL sidecars are created by SQLite at the umask, so tighten
         // them too — they hold the same content as the main file.
@@ -627,6 +642,59 @@ mod tests {
 
     fn corpus() -> CorpusIndex {
         CorpusIndex::in_memory().unwrap()
+    }
+
+    /// The WAL of the largest database in the app must be bounded.
+    ///
+    /// This file used to hand-roll its pragma batch and, in doing so,
+    /// silently omitted `journal_size_limit` and `wal_autocheckpoint`
+    /// — the two that exist because `sessions.db-wal` once reached
+    /// 6.3 GB. `cargo xtask verify-docs` now refuses a
+    /// `Connection::open` that skips `apply_standard_pragmas`, but a
+    /// static check proves the CALL happened, not that the connection
+    /// ended up configured. Assert the observable state as well: the
+    /// two layers fail for different reasons, and the silent-failure
+    /// history here has earned both.
+    ///
+    /// File-backed on purpose — `open_in_memory` downgrades
+    /// `journal_mode` to `memory`, so an in-memory assertion would be
+    /// green for a reason unrelated to the bug.
+    #[test]
+    fn open_bounds_the_wal_and_keeps_foreign_keys_on() {
+        let tmp = TempDir::new().unwrap();
+        let c = CorpusIndex::open(&tmp.path().join("corpus.db")).unwrap();
+        let db = c.conn();
+
+        let mode: String = db
+            .pragma_query_value(None, "journal_mode", |r| r.get(0))
+            .unwrap();
+        assert_eq!(mode.to_lowercase(), "wal");
+
+        let limit: i64 = db
+            .pragma_query_value(None, "journal_size_limit", |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            limit,
+            crate::db_pragmas::WAL_SIZE_LIMIT_BYTES,
+            "corpus.db-wal has no size bound — the 2026-05-24 shape"
+        );
+
+        let autockpt: i64 = db
+            .pragma_query_value(None, "wal_autocheckpoint", |r| r.get(0))
+            .unwrap();
+        assert_eq!(autockpt, 1000);
+
+        let busy: i64 = db
+            .pragma_query_value(None, "busy_timeout", |r| r.get(0))
+            .unwrap();
+        assert_eq!(busy, 5000, "GUI + CLI + MCP all open this file");
+
+        // Not part of the standard set, and still required here: the
+        // corpus_* children cascade from corpus_sessions.
+        let fk: i64 = db
+            .pragma_query_value(None, "foreign_keys", |r| r.get(0))
+            .unwrap();
+        assert_eq!(fk, 1);
     }
 
     #[test]

--- a/crates/claudepot-core/src/db_pragmas.rs
+++ b/crates/claudepot-core/src/db_pragmas.rs
@@ -17,7 +17,7 @@
 //!   forcing it on globally could activate dormant constraints
 //!   in stores that later gain FK schemas without review.
 
-use rusqlite::Connection;
+use rusqlite::{Connection, ErrorCode};
 use std::time::Duration;
 
 /// Cap each WAL file at 64 MB after every successful checkpoint.
@@ -34,6 +34,14 @@ pub(crate) const WAL_SIZE_LIMIT_BYTES: i64 = 64 * 1024 * 1024;
 /// helper sets it centrally so new stores inherit it for free.
 pub(crate) const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Retry schedule for the WAL-mode transition, in milliseconds.
+///
+/// Sums to ~3.2 s, comfortably inside [`BUSY_TIMEOUT`] — a caller that
+/// already tolerates a 5-second wait on writer contention is not
+/// surprised by this one, and bounding it below that keeps the open
+/// path's worst case unchanged.
+const WAL_SWITCH_BACKOFF_MS: &[u64] = &[2, 5, 10, 20, 40, 80, 160, 320, 640, 960, 960];
+
 /// Apply Claudepot's standard SQLite pragmas to a fresh connection.
 ///
 /// Idempotent: safe to call repeatedly on the same connection.
@@ -41,19 +49,102 @@ pub(crate) const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 /// any schema DDL — see store call sites for the full ordering
 /// (open → pragmas → optional FK opt-in → schema → sidecar
 /// materialization → chmod).
-///
-/// `busy_timeout` is set first so the subsequent `PRAGMA
-/// journal_mode=WAL` (which needs a momentary exclusive lock to
-/// switch modes) can wait on a concurrent claudepot process
-/// instead of returning `SQLITE_BUSY` immediately.
 pub fn apply_standard_pragmas(conn: &Connection) -> rusqlite::Result<()> {
     conn.busy_timeout(BUSY_TIMEOUT)?;
+    enter_wal_mode(conn)?;
     conn.execute_batch(&format!(
-        "PRAGMA journal_mode=WAL;\n\
-         PRAGMA wal_autocheckpoint=1000;\n\
+        "PRAGMA wal_autocheckpoint=1000;\n\
          PRAGMA journal_size_limit={WAL_SIZE_LIMIT_BYTES};"
     ))?;
     Ok(())
+}
+
+/// Is this the "someone else holds the file" error?
+fn is_busy(e: &rusqlite::Error) -> bool {
+    matches!(
+        e,
+        rusqlite::Error::SqliteFailure(ffi, _)
+            if matches!(ffi.code, ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+    )
+}
+
+fn journal_mode(conn: &Connection) -> rusqlite::Result<String> {
+    conn.pragma_query_value(None, "journal_mode", |r| r.get::<_, String>(0))
+}
+
+/// Put the connection into WAL mode, retrying while another process
+/// holds the file.
+///
+/// # `busy_timeout` does not cover this, whatever it looks like
+///
+/// This helper used to be one `execute_batch` beginning `PRAGMA
+/// journal_mode=WAL`, with a comment claiming `busy_timeout` was set
+/// first precisely so that statement "can wait on a concurrent
+/// claudepot process instead of returning `SQLITE_BUSY` immediately."
+/// That is not what SQLite does. Switching **into** WAL needs a
+/// momentary exclusive lock, and the busy handler is **not** invoked
+/// for it — the statement fails immediately with `SQLITE_BUSY`
+/// ("database is locked") no matter how long the timeout is.
+///
+/// Measured, not reasoned about: 8 threads opening one fresh
+/// `boards.db` concurrently, over 40 rounds, produced 2 hard failures
+/// out of 320 opens. That is the documented deployment for
+/// `boards.db` — GUI, CLI and the MCP subprocess all open it directly
+/// with no channel between them — and `sessions.db` and `corpus.db`
+/// follow the same access pattern. The user-visible shape was a store
+/// that intermittently refused to open with "database is locked".
+///
+/// Two properties make the retry cheap:
+///
+/// - **The transition happens once per file, ever.** Re-issuing the
+///   pragma against a database already in WAL is a no-op that takes no
+///   exclusive lock, so the early return below is the path taken on
+///   every open after the first. Steady state costs one pragma read.
+/// - **Losing the race is self-resolving.** Whoever won it left the
+///   file in WAL, so the loser's next check succeeds rather than
+///   needing the lock at all.
+///
+/// Exhausting the schedule returns the underlying busy error rather
+/// than proceeding: a connection silently left in `delete` journal
+/// mode would take the *store's* write lock for whole transactions
+/// instead of WAL's per-writer one, which converts a rare open failure
+/// into a permanent, invisible concurrency regression.
+fn enter_wal_mode(conn: &Connection) -> rusqlite::Result<()> {
+    let mut last_busy: Option<rusqlite::Error> = None;
+
+    for (i, delay) in WAL_SWITCH_BACKOFF_MS.iter().enumerate() {
+        // Already there — the common path, and the reason a retry loop
+        // costs nothing in steady state.
+        if journal_mode(conn)?.eq_ignore_ascii_case("wal") {
+            return Ok(());
+        }
+        // `journal_mode` returns the resulting mode as a row, so this
+        // needs the `_and_check` form; plain `pragma_update` rejects a
+        // statement that returns results.
+        match conn.pragma_update_and_check(None, "journal_mode", "WAL", |r| r.get::<_, String>(0)) {
+            Ok(mode) if mode.eq_ignore_ascii_case("wal") => return Ok(()),
+            // Reported some other mode. Not an error per se — retry and
+            // let the loop's own verification decide.
+            Ok(_) => {}
+            Err(e) if is_busy(&e) => last_busy = Some(e),
+            Err(e) => return Err(e),
+        }
+        if i + 1 < WAL_SWITCH_BACKOFF_MS.len() {
+            std::thread::sleep(Duration::from_millis(*delay));
+        }
+    }
+
+    // One last look: the winner of the race may have landed between
+    // our final attempt and here.
+    if journal_mode(conn)?.eq_ignore_ascii_case("wal") {
+        return Ok(());
+    }
+    Err(last_busy.unwrap_or_else(|| {
+        rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_BUSY),
+            Some("could not switch journal_mode to WAL".to_string()),
+        )
+    }))
 }
 
 #[cfg(test)]
@@ -134,6 +225,55 @@ mod tests {
         apply_standard_pragmas(&conn).unwrap();
         let after = pragma_i64(&conn, "synchronous");
         assert_eq!(before, after);
+    }
+
+    /// The regression this helper's retry loop exists for.
+    ///
+    /// `boards.db` is opened directly and concurrently by the GUI, the
+    /// CLI and the MCP subprocess with no channel between them;
+    /// `sessions.db` and `corpus.db` share that pattern. Before the
+    /// retry, racing the *first* open of a file — the one that has to
+    /// perform the `delete` → `wal` transition — failed outright with
+    /// `SQLITE_BUSY`, because SQLite does not run the busy handler for
+    /// that transition however large `busy_timeout` is.
+    ///
+    /// Measured at 2 failures per 320 opens before the fix, so the
+    /// thread count and round count here are chosen to make a
+    /// regression fail reliably rather than occasionally.
+    #[test]
+    fn concurrent_first_open_never_returns_busy() {
+        for round in 0..40 {
+            let dir = TempDir::new().expect("tempdir");
+            let path = dir.path().join("concurrent.db");
+            let errors = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+
+            let handles: Vec<_> = (0..8)
+                .map(|_| {
+                    let path = path.clone();
+                    let errors = std::sync::Arc::clone(&errors);
+                    std::thread::spawn(move || {
+                        let conn = Connection::open(&path).expect("open");
+                        if let Err(e) = apply_standard_pragmas(&conn) {
+                            errors.lock().unwrap().push(e.to_string());
+                            return;
+                        }
+                        // And the connection really is in WAL — not
+                        // silently left in `delete`, which would take
+                        // whole-database write locks in production.
+                        assert_eq!(pragma_string(&conn, "journal_mode").to_lowercase(), "wal");
+                    })
+                })
+                .collect();
+            for h in handles {
+                h.join().expect("worker panicked");
+            }
+
+            let errors = errors.lock().unwrap();
+            assert!(
+                errors.is_empty(),
+                "round {round}: concurrent open failed: {errors:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/claudepot-core/src/paths.rs
+++ b/crates/claudepot-core/src/paths.rs
@@ -37,16 +37,53 @@ pub fn claude_json_path() -> Option<PathBuf> {
 /// file CC is actively applying.
 ///
 /// Returns the first candidate that exists; `None` when neither does.
+/// Use [`global_claude_json_target`] when you need the path regardless
+/// of existence.
 pub fn resolved_global_claude_json() -> Option<PathBuf> {
+    let p = global_claude_json_target();
+    p.is_file().then_some(p)
+}
+
+/// [`resolved_global_claude_json`] without the existence requirement:
+/// the path CC *would* read, whether or not anything is there yet.
+///
+/// # This is THE resolver — do not hand-roll a fourth one
+///
+/// The distinction from [`claude_json_path`] is subtle enough that it
+/// was independently re-implemented three times, and two copies were
+/// wrong:
+///
+/// - `config_view::effective_io::resolve_claude_json_path` handled
+///   `CLAUDE_CONFIG_DIR` but dropped the legacy `.config.json` branch,
+///   while its own comment claimed parity with `getGlobalClaudeFile`.
+///   On a machine carrying that legacy file, Config → Effective MCP
+///   read the wrong file and showed no user-scope servers, while the
+///   config preview beside it read the right one.
+/// - `cc_tips::history::read_tips_history` hardcoded
+///   `$HOME/.claude.json`, so under `CLAUDE_CONFIG_DIR` the tips
+///   ledger reported `num_startups: 0` and an empty history forever —
+///   and its output feeds `cc_tips_snapshots.jsonl`, which is
+///   append-only and cannot be reconstructed after the fact.
+///
+/// Both now call this. A new caller meaning "the file CC reads" calls
+/// this too; a fresh copy of the three-way resolution is a review
+/// finding.
+///
+/// One shape is deliberately NOT modelled: `fileSuffixForOauthConfig`
+/// (`constants/oauth.ts:18`) can make the filename
+/// `.claude-staging-oauth.json` and friends. The suffix is empty for
+/// production, so modelling it would add a branch no shipped user
+/// reaches.
+pub fn global_claude_json_target() -> PathBuf {
     let legacy = claude_config_dir().join(".config.json");
     if legacy.is_file() {
-        return Some(legacy);
+        return legacy;
     }
-    let base = std::env::var_os("CLAUDE_CONFIG_DIR")
+    std::env::var_os("CLAUDE_CONFIG_DIR")
         .map(PathBuf::from)
-        .or_else(dirs::home_dir)?;
-    let primary = base.join(".claude.json");
-    primary.is_file().then_some(primary)
+        .or_else(dirs::home_dir)
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join(".claude.json")
 }
 
 /// Claude Desktop data directory (macOS / Windows). Returns None on Linux.
@@ -268,6 +305,66 @@ mod tests {
         } else {
             assert!(result.is_none());
         }
+    }
+
+    /// The three-way resolution CC's `getGlobalClaudeFile` performs.
+    ///
+    /// Each branch is asserted separately because the copies that
+    /// drifted did so by dropping exactly one of them: `effective_io`
+    /// lost the legacy branch, `cc_tips` lost both.
+    #[test]
+    fn global_claude_json_target_honors_the_config_dir() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join("config-dir");
+        std::fs::create_dir_all(&cfg).unwrap();
+        std::env::set_var("CLAUDE_CONFIG_DIR", &cfg);
+
+        // No legacy file → `$CLAUDE_CONFIG_DIR/.claude.json`, NOT the
+        // home sibling. This is the branch `cc_tips` was missing.
+        assert_eq!(global_claude_json_target(), cfg.join(".claude.json"));
+
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+    }
+
+    #[test]
+    fn global_claude_json_target_prefers_the_legacy_config_json() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join("config-dir");
+        std::fs::create_dir_all(&cfg).unwrap();
+        std::env::set_var("CLAUDE_CONFIG_DIR", &cfg);
+
+        // Both candidates present: legacy wins, exactly as
+        // `getGlobalClaudeFile` checks it first. This is the branch
+        // `effective_io` was missing.
+        std::fs::write(cfg.join(".config.json"), b"{}").unwrap();
+        std::fs::write(cfg.join(".claude.json"), b"{}").unwrap();
+        assert_eq!(global_claude_json_target(), cfg.join(".config.json"));
+
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
+    }
+
+    /// The existence-checked wrapper must agree with the target, and
+    /// must report `None` only when nothing is there.
+    #[test]
+    fn resolved_global_claude_json_tracks_the_target() {
+        let _lock = lock_data_dir();
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tmp.path().join("config-dir");
+        std::fs::create_dir_all(&cfg).unwrap();
+        std::env::set_var("CLAUDE_CONFIG_DIR", &cfg);
+
+        assert_eq!(resolved_global_claude_json(), None, "nothing on disk yet");
+
+        std::fs::write(cfg.join(".claude.json"), b"{}").unwrap();
+        assert_eq!(
+            resolved_global_claude_json(),
+            Some(global_claude_json_target()),
+            "once it exists the two must name the same file"
+        );
+
+        std::env::remove_var("CLAUDE_CONFIG_DIR");
     }
 
     #[test]

--- a/crates/xtask/src/data_dir_scan.rs
+++ b/crates/xtask/src/data_dir_scan.rs
@@ -56,7 +56,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use syn::visit::Visit;
 
-/// Filenames the crate joins onto its data dir.
+/// What the data-dir-writing crates do with their files: which ones
+/// they name, and whether each database they open is set up correctly.
 #[derive(Debug, Default)]
 pub struct DataDirFiles {
     /// Every `*.db`. Not restricted to `claudepot_data_dir()` receivers:
@@ -70,6 +71,30 @@ pub struct DataDirFiles {
     /// `~/.claude.json` and bundle entries like `manifest.json`, and a
     /// check that cries wolf is one people learn to skip.
     pub jsons: BTreeSet<String>,
+    /// Production functions that call `Connection::open` **without**
+    /// reaching `apply_standard_pragmas`. See [`UnpragmadOpen`].
+    pub unpragmad_opens: Vec<UnpragmadOpen>,
+}
+
+/// A `Connection::open` that never reaches `apply_standard_pragmas`.
+///
+/// `db_pragmas` exists because `sessions.db-wal` once reached 6.3 GB,
+/// and its module doc says every store "should call" the helper. That
+/// was enforced by nobody: `corpus.rs` hand-rolled its own pragma batch
+/// and omitted `journal_size_limit` + `wal_autocheckpoint`, which left
+/// the largest database in the app — ~880 MB, bulk-insert indexer,
+/// opened concurrently by GUI, CLI and the MCP subprocess — as the one
+/// store outside the bound. The omission was invisible precisely
+/// because the file *looked* like it configured itself properly.
+///
+/// A hand-rolled batch that happens to be right today is still a
+/// divergence tomorrow, so the rule is the helper, not the pragmas.
+#[derive(Debug)]
+pub struct UnpragmadOpen {
+    /// Repo-relative path of the file.
+    pub file: String,
+    /// The enclosing function's name.
+    pub function: String,
 }
 
 /// Crates that write into the Claudepot data dir.
@@ -122,7 +147,78 @@ pub fn scan(repo: &Path) -> Result<DataDirFiles> {
     for f in &parsed {
         v.visit_file(f);
     }
+
+    // Pass 3 — which whole FILES are test-only, resolved from the
+    // `#[cfg(test)] mod foo;` declarations that pull them in.
+    let test_only = test_only_files(&files, &parsed);
+
+    // Pass 4 — pragma discipline, per file so the report can name one.
+    for (path, f) in files.iter().zip(&parsed) {
+        if test_only.contains(path) {
+            continue;
+        }
+        let rel = path
+            .strip_prefix(repo)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .into_owned();
+        let mut p = PragmaVisitor {
+            file: rel,
+            out: &mut v.out.unpragmad_opens,
+        };
+        p.visit_file(f);
+    }
     Ok(v.out)
+}
+
+/// Files that exist only under `cfg(test)`, because the `mod foo;` that
+/// pulls them in carries the attribute.
+///
+/// `is_cfg_test` works on nodes *within* a file, which is enough for an
+/// inline `#[cfg(test)] mod tests { … }` and blind to the other half of
+/// the convention: `shared_memory/migration_tests.rs` is 700 lines of
+/// pure test code whose only `#[cfg(test)]` sits on the `mod` line in
+/// its parent. Judging by filename (`*_tests.rs`) would work today and
+/// is precisely the kind of heuristic this module's history is a list
+/// of; resolving the declaration is the same amount of code and cannot
+/// drift.
+///
+/// Both layouts Rust allows for `mod foo;` are resolved: `foo.rs`
+/// beside the declaring file, and `foo/mod.rs` below it.
+fn test_only_files(files: &[PathBuf], parsed: &[syn::File]) -> BTreeSet<PathBuf> {
+    struct Collector<'a> {
+        dir: PathBuf,
+        out: &'a mut BTreeSet<PathBuf>,
+    }
+    impl<'ast> Visit<'ast> for Collector<'_> {
+        fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+            // `content: None` is `mod foo;` — a declaration pointing at
+            // another file. An inline `mod foo { … }` is already
+            // handled by the visitors' own `is_cfg_test` checks.
+            if node.content.is_none() && is_cfg_test(&node.attrs) {
+                let name = node.ident.to_string();
+                self.out.insert(self.dir.join(format!("{name}.rs")));
+                self.out.insert(self.dir.join(&name).join("mod.rs"));
+            }
+            syn::visit::visit_item_mod(self, node);
+        }
+    }
+
+    let mut out = BTreeSet::new();
+    for (path, f) in files.iter().zip(parsed) {
+        let dir = match path.file_name().and_then(|n| n.to_str()) {
+            // `mod.rs` and `lib.rs`/`main.rs` declare siblings of
+            // themselves; any other file declares children in a
+            // same-named subdirectory.
+            Some("mod.rs") | Some("lib.rs") | Some("main.rs") => {
+                path.parent().unwrap_or(Path::new("")).to_path_buf()
+            }
+            _ => path.with_extension(""),
+        };
+        let mut c = Collector { dir, out: &mut out };
+        c.visit_file(f);
+    }
+    out
 }
 
 fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
@@ -304,6 +400,107 @@ impl<'ast> Visit<'ast> for JoinVisitor<'_> {
     }
 }
 
+// ─── Pragma discipline ───────────────────────────────────────────────
+
+/// Does this block contain a call whose path ends in `tail`?
+///
+/// Tail matching on the last N segments, so `Connection::open` and
+/// `rusqlite::Connection::open` resolve alike, and
+/// `apply_standard_pragmas` matches with or without its
+/// `crate::db_pragmas::` prefix.
+///
+/// The `Connection` segment is load-bearing: matching a bare `open`
+/// would sweep in `File::open`, `OpenOptions::…::open` and every other
+/// unrelated opener in three crates, and a gate that cries wolf is one
+/// people learn to pass with an `#[allow]`.
+fn calls_path_ending_in(block: &syn::Block, tail: &[&str]) -> bool {
+    struct Finder<'a>(&'a [&'a str], bool);
+    impl<'ast> Visit<'ast> for Finder<'_> {
+        fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+            if let syn::Expr::Path(p) = &*node.func {
+                let segs: Vec<String> = p
+                    .path
+                    .segments
+                    .iter()
+                    .map(|s| s.ident.to_string())
+                    .collect();
+                if segs.len() >= self.0.len()
+                    && segs[segs.len() - self.0.len()..]
+                        .iter()
+                        .zip(self.0)
+                        .all(|(a, b)| a == b)
+                {
+                    self.1 = true;
+                }
+            }
+            syn::visit::visit_expr_call(self, node);
+        }
+    }
+    let mut v = Finder(tail, false);
+    v.visit_block(block);
+    v.1
+}
+
+/// Flags production functions that open a SQLite connection without
+/// routing it through `db_pragmas::apply_standard_pragmas`.
+///
+/// Two open shapes are deliberately NOT flagged, because neither wants
+/// the standard set:
+///
+/// - `open_in_memory` — WAL silently downgrades to `memory` journal
+///   mode on a connection with no file behind it, so the pragmas are
+///   meaningless rather than missing.
+/// - `open_with_flags` — `db_housekeeping::checkpoint_one` uses it
+///   precisely to avoid `SQLITE_OPEN_CREATE`, and sets its own short
+///   busy timeout because backing off fast is the point there.
+///
+/// Both are matched on the method *name*, so this is a structural
+/// exemption rather than an allowlist that can rot.
+struct PragmaVisitor<'a> {
+    file: String,
+    out: &'a mut Vec<UnpragmadOpen>,
+}
+
+impl PragmaVisitor<'_> {
+    fn check(&mut self, name: String, attrs: &[syn::Attribute], block: &syn::Block) -> bool {
+        if is_cfg_test(attrs) {
+            return false;
+        }
+        if calls_path_ending_in(block, &["Connection", "open"])
+            && !calls_path_ending_in(block, &["apply_standard_pragmas"])
+        {
+            self.out.push(UnpragmadOpen {
+                file: self.file.clone(),
+                function: name,
+            });
+        }
+        true
+    }
+}
+
+impl<'ast> Visit<'ast> for PragmaVisitor<'_> {
+    fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+        if is_cfg_test(&node.attrs) {
+            return;
+        }
+        syn::visit::visit_item_mod(self, node);
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        if !self.check(node.sig.ident.to_string(), &node.attrs, &node.block) {
+            return;
+        }
+        syn::visit::visit_item_fn(self, node);
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        if !self.check(node.sig.ident.to_string(), &node.attrs, &node.block) {
+            return;
+        }
+        syn::visit::visit_impl_item_fn(self, node);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -442,6 +639,131 @@ mod tests {
     fn unresolvable_names_are_skipped() {
         let out = scan_src(r#"fn t(name: &str) -> PathBuf { claudepot_data_dir().join(name) }"#);
         assert!(out.jsons.is_empty() && out.dbs.is_empty());
+    }
+
+    // ─── Pragma discipline ───────────────────────────────────────────
+
+    fn pragma_scan(src: &str) -> Vec<UnpragmadOpen> {
+        let f = syn::parse_file(src).expect("parse");
+        let mut out = Vec::new();
+        PragmaVisitor {
+            file: "x.rs".into(),
+            out: &mut out,
+        }
+        .visit_file(&f);
+        out
+    }
+
+    /// The `corpus.rs` shape: a real store that configures itself by
+    /// hand. It looks deliberate, which is exactly why nobody noticed
+    /// it had dropped two of the four pragmas.
+    #[test]
+    fn hand_rolled_pragmas_do_not_satisfy_the_rule() {
+        let out = pragma_scan(
+            r#"
+            impl S {
+                pub fn open(path: &Path) -> Result<Self> {
+                    let conn = Connection::open(path)?;
+                    conn.execute_batch("PRAGMA journal_mode=WAL;")?;
+                    Ok(Self { conn })
+                }
+            }
+            "#,
+        );
+        assert_eq!(out.len(), 1, "hand-rolled batch must still be flagged");
+        assert_eq!(out[0].function, "open");
+    }
+
+    #[test]
+    fn calling_the_helper_satisfies_the_rule() {
+        for call in [
+            "apply_standard_pragmas(&db)?;",
+            "crate::db_pragmas::apply_standard_pragmas(&db)?;",
+        ] {
+            let out = pragma_scan(&format!(
+                "impl S {{ pub fn open(p: &Path) -> R {{ let db = Connection::open(p)?; {call} Ok(()) }} }}"
+            ));
+            assert!(out.is_empty(), "should accept `{call}`");
+        }
+    }
+
+    /// `rusqlite::Connection::open` is the same call with a prefix.
+    #[test]
+    fn a_qualified_connection_path_is_still_an_open() {
+        let out =
+            pragma_scan("fn f(p: &Path) -> R { let c = rusqlite::Connection::open(p)?; Ok(()) }");
+        assert_eq!(out.len(), 1);
+    }
+
+    /// The two exempt shapes, and the reason each is exempt: WAL is
+    /// meaningless in memory, and `checkpoint_one` wants its own short
+    /// busy timeout so it can back off fast.
+    #[test]
+    fn in_memory_and_flagged_opens_are_exempt() {
+        let out = pragma_scan(
+            r#"
+            fn a() -> R { let c = Connection::open_in_memory()?; Ok(()) }
+            fn b(p: &Path) -> R { let c = Connection::open_with_flags(p, flags)?; Ok(()) }
+            "#,
+        );
+        assert!(out.is_empty(), "got {out:?}");
+    }
+
+    /// Unrelated openers must not be swept in — the check keys on
+    /// `Connection`, not on the bare method name.
+    #[test]
+    fn other_open_calls_are_not_database_opens() {
+        let out = pragma_scan(
+            r#"
+            fn a(p: &Path) -> R { let f = File::open(p)?; Ok(()) }
+            fn b(p: &Path) -> R { let f = std::fs::File::open(p)?; Ok(()) }
+            "#,
+        );
+        assert!(out.is_empty(), "got {out:?}");
+    }
+
+    /// Test fixtures open connections constantly and correctly do not
+    /// pragma them; flagging those would train people to ignore this.
+    #[test]
+    fn test_code_is_not_held_to_the_rule() {
+        let out = pragma_scan(
+            r#"
+            #[cfg(test)]
+            mod tests {
+                fn fixture(p: &Path) { let c = Connection::open(p).unwrap(); }
+            }
+            #[cfg(test)]
+            fn helper(p: &Path) { let c = Connection::open(p).unwrap(); }
+            "#,
+        );
+        assert!(out.is_empty(), "got {out:?}");
+    }
+
+    /// `shared_memory/migration_tests.rs` in miniature: a whole file of
+    /// test code whose only `#[cfg(test)]` is on the parent's `mod`
+    /// line. Both file layouts Rust permits must resolve.
+    #[test]
+    fn a_cfg_test_mod_declaration_marks_the_whole_file() {
+        let decl =
+            syn::parse_file("pub mod real;\n#[cfg(test)]\npub mod migration_tests;\n").unwrap();
+        let dir = PathBuf::from("/repo/src/shared_memory");
+        let out = test_only_files(&[dir.join("mod.rs")], &[decl]);
+
+        assert!(out.contains(&dir.join("migration_tests.rs")));
+        assert!(out.contains(&dir.join("migration_tests").join("mod.rs")));
+        assert!(
+            !out.contains(&dir.join("real.rs")),
+            "a plain `mod` declaration must not be marked test-only"
+        );
+    }
+
+    /// A non-`mod.rs` file declares its children in a same-named
+    /// subdirectory, not beside itself.
+    #[test]
+    fn child_modules_of_a_leaf_file_resolve_into_its_subdirectory() {
+        let decl = syn::parse_file("#[cfg(test)]\nmod swap_tests;\n").unwrap();
+        let out = test_only_files(&[PathBuf::from("/repo/src/desktop_backend.rs")], &[decl]);
+        assert!(out.contains(&PathBuf::from("/repo/src/desktop_backend/swap_tests.rs")));
     }
 
     /// A wrapped chain is a tree, so line breaks are irrelevant — the

--- a/crates/xtask/src/verify_docs.rs
+++ b/crates/xtask/src/verify_docs.rs
@@ -30,7 +30,12 @@
 //!    whole data-dir list was gated. `migrate-peers.json` was added
 //!    and the gate stayed green;
 //! 5. every documented screenshot exists and its two committed copies
-//!    are byte-identical.
+//!    are byte-identical;
+//! 6. every `Connection::open` in production code reaches
+//!    `db_pragmas::apply_standard_pragmas`. Not a docs fact, but the
+//!    same shape of failure and it belongs beside check 3: that one
+//!    gates WAL *cleanup* coverage, this one gates WAL *growth* bounds,
+//!    and `corpus.db` was missing from both for as long as it existed.
 //!
 //! Screenshot *freshness* is deliberately not here — see
 //! [`verify_screenshots`], which is on demand.
@@ -99,6 +104,7 @@ pub fn verify_docs(repo: &Path) -> Result<()> {
     check_settings_panes(repo, &mut problems)?;
     check_data_dir_databases(repo, &mut problems)?;
     check_data_dir_json_state(repo, &mut problems)?;
+    check_event_channels_have_listeners(repo, &mut problems)?;
     // Screenshot *freshness* is `cargo xtask verify-screenshots`, on
     // demand — see that function for why it is not a pull-request gate.
     check_screenshot_pairs(repo, &mut problems)?;
@@ -344,6 +350,279 @@ fn check_data_dir_databases(repo: &Path, problems: &mut Vec<String>) -> Result<(
             problems.push(format!(
                 "`{db}` ships but is absent from `KNOWN_DB_FILENAMES` in db_housekeeping.rs \
                  — its `*.db-wal` sidecar will never be cleaned up"
+            ));
+        }
+    }
+
+    // Layer 1 of the same WAL defense: the housekeeping list bounds
+    // *cleanup at startup*, `apply_standard_pragmas` bounds *growth*.
+    // A store that skips the helper is covered only by the startup
+    // pass, which backs off after 1s whenever another process holds
+    // the file — exactly the situation a long index run creates.
+    // `corpus.rs` hand-rolled its pragmas and silently dropped
+    // `journal_size_limit` / `wal_autocheckpoint` for as long as it
+    // existed, on the largest database in the app.
+    let scan = crate::data_dir_scan::scan(repo)?;
+    for open in &scan.unpragmad_opens {
+        problems.push(format!(
+            "`{}::{}` calls `Connection::open` without `db_pragmas::apply_standard_pragmas` \
+             — its WAL has no size bound. Call the helper rather than hand-rolling a pragma \
+             batch; a hand-rolled batch that is right today is a divergence tomorrow",
+            open.file, open.function
+        ));
+    }
+    Ok(())
+}
+
+// ─── 7. Event channels have a subscriber ─────────────────────────────
+
+/// Channels the renderer deliberately does not subscribe to, and why.
+///
+/// An exception has to be written down somewhere a reader will find it
+/// *while looking at the failure*, or the next person deletes a real
+/// subscriber and assumes the red gate is the usual noise. Both
+/// directions are validated in [`check_event_channels_have_listeners`],
+/// so an entry cannot outlive the reason for it.
+const UNSUBSCRIBED_BY_DESIGN: &[(&str, &str)] = &[(
+    "agent-event-dispatched",
+    "a successful event-agent run already lands in RunHistoryPanel with its structured \
+     output; a toast per fire would spam every settled-session narration. \
+     `useAgentEventToasts.ts` documents it and its test asserts the channel stays unsubscribed",
+)];
+
+/// Channel names declared as `pub const … : &str = "…"` in `events.rs`,
+/// plus any emitted as a bare literal elsewhere in the Tauri crate.
+///
+/// Both halves matter: the tray and app-menu files historically kept
+/// their channel strings at the emit site rather than in `events.rs`,
+/// and three of the four channels that turned out to have no listener
+/// were exactly those.
+fn declared_channels(repo: &Path) -> Result<BTreeSet<String>> {
+    let mut out = BTreeSet::new();
+
+    let events = read(repo, "src-tauri/src/events.rs")?;
+    for line in events.lines() {
+        let t = line.trim();
+        if !t.starts_with("pub const ") || !t.contains("&str") {
+            continue;
+        }
+        if let Some(v) = t.split('"').nth(1) {
+            out.insert(v.to_string());
+        }
+    }
+
+    let mut files = Vec::new();
+    collect_rs(&repo.join("src-tauri/src"), &mut files)?;
+    for f in files {
+        let src = std::fs::read_to_string(&f)?;
+        let mut rest = src.as_str();
+        while let Some(i) = rest.find("emit(\"") {
+            rest = &rest[i + "emit(\"".len()..];
+            if let Some(j) = rest.find('"') {
+                out.insert(rest[..j].to_string());
+                rest = &rest[j + 1..];
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn collect_rs(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let p = entry?.path();
+        if p.is_dir() {
+            collect_rs(&p, out)?;
+        } else if p.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(p);
+        }
+    }
+    Ok(())
+}
+
+/// Strip `//` and `/* */` comments, without being fooled by the same
+/// characters inside a string literal.
+///
+/// Needed because the thing being searched for is a channel *name*,
+/// and prose mentions one constantly — `useTrayBridge`'s own header
+/// comment lists all four Desktop channels. Searching raw text made
+/// the gate pass with every real subscriber deleted, which is the
+/// failure it exists to catch.
+fn strip_ts_comments(src: &str) -> String {
+    let b = src.as_bytes();
+    let mut out = String::with_capacity(src.len());
+    let mut i = 0;
+    // `Some(q)` while inside a string opened with quote byte `q`.
+    let mut quote: Option<u8> = None;
+
+    while i < b.len() {
+        let c = b[i];
+        if let Some(q) = quote {
+            // Skip an escaped character wholesale so `"\\\""` does not
+            // read as the end of the string.
+            if c == b'\\' && i + 1 < b.len() {
+                out.push(c as char);
+                out.push(b[i + 1] as char);
+                i += 2;
+                continue;
+            }
+            if c == q {
+                quote = None;
+            }
+            out.push(c as char);
+            i += 1;
+            continue;
+        }
+        if c == b'"' || c == b'\'' || c == b'`' {
+            quote = Some(c);
+            out.push(c as char);
+            i += 1;
+            continue;
+        }
+        if c == b'/' && i + 1 < b.len() {
+            if b[i + 1] == b'/' {
+                while i < b.len() && b[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            if b[i + 1] == b'*' {
+                i += 2;
+                while i + 1 < b.len() && !(b[i] == b'*' && b[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(b.len());
+                continue;
+            }
+        }
+        // Non-ASCII bytes are copied as-is; only ASCII delimiters
+        // matter to this scanner, and the search is for ASCII channel
+        // names.
+        out.push(c as char);
+        i += 1;
+    }
+    out
+}
+
+/// Comment-stripped concatenation of every **shipped** `.ts`/`.tsx`
+/// file under `src/`.
+///
+/// Two exclusions, both established by deleting the real subscribers
+/// and checking the gate actually goes red:
+///
+/// - **Test files.** A test that fires a channel names it, so
+///   `useTrayBridge.test.tsx` alone satisfied "somebody references
+///   `tray-desktop-switched`" while the shipped hook subscribed to
+///   nothing.
+/// - **Comments.** With tests excluded the gate *still* passed,
+///   because the hook's own header comment lists the channels it
+///   handles. A doc mention is not a subscription.
+fn frontend_sources(repo: &Path) -> Result<String> {
+    fn is_test_file(p: &Path) -> bool {
+        p.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.contains(".test.") || n.contains(".spec."))
+    }
+
+    fn walk(dir: &Path, buf: &mut String) -> Result<()> {
+        // `src/test/` is fixtures and harness setup, not shipped code.
+        if dir.file_name().and_then(|n| n.to_str()) == Some("test") {
+            return Ok(());
+        }
+        for entry in std::fs::read_dir(dir)? {
+            let p = entry?.path();
+            if p.is_dir() {
+                walk(&p, buf)?;
+            } else if matches!(
+                p.extension().and_then(|e| e.to_str()),
+                Some("ts") | Some("tsx")
+            ) && !is_test_file(&p)
+            {
+                buf.push_str(&strip_ts_comments(&std::fs::read_to_string(&p)?));
+                buf.push('\n');
+            }
+        }
+        Ok(())
+    }
+    let mut buf = String::new();
+    walk(&repo.join("src"), &mut buf)?;
+    Ok(buf)
+}
+
+/// Every backend-emitted channel must be named somewhere in `src/`.
+///
+/// # Why this is a gate and not a unit test
+///
+/// `events.rs` carried a test called "wire-contract lock" whose body
+/// was `assert_eq!(DESKTOP_ADOPTED, "desktop-adopted")` twenty-one
+/// times over — each constant compared to its own literal. It could
+/// only ever catch a rename, while its docstring claimed to protect
+/// the contract with the renderer.
+///
+/// It did not. Seven declared channels had zero subscribers in `src/`:
+/// `tray-desktop-switched`, `tray-desktop-switch-failed`,
+/// `tray-desktop-launch-failed` and `desktop-reconciled` (so a tray
+/// Desktop swap left the UI stale and a FAILED one produced no signal
+/// anywhere), plus `desktop-adopted`, `desktop-cleared` and
+/// `desktop-running-changed` (dead weight — the invoking command
+/// already returned the same facts). A tautology inside one crate
+/// cannot see the other end of a cross-boundary contract; only a check
+/// that reads both sides can.
+///
+/// Deliberately a *name* search rather than a listener-registration
+/// parse: the renderer reaches channels through `useTauriEvent`,
+/// `useTauriEvents` object keys, and shared constants in
+/// `lib/events.ts`. Matching the string covers all three, and the
+/// failure being prevented is "nobody mentions this at all".
+fn check_event_channels_have_listeners(repo: &Path, problems: &mut Vec<String>) -> Result<()> {
+    let declared = declared_channels(repo)?;
+    if declared.len() < 10 {
+        problems.push(format!(
+            "only parsed {} event channels from src-tauri — the listener cross-check is \
+             effectively blind. Fix `declared_channels`, not the events",
+            declared.len()
+        ));
+        return Ok(());
+    }
+    let frontend = frontend_sources(repo)?;
+
+    // The allowlist is kept honest in both directions below: an entry
+    // naming a channel that no longer exists, or one that has since
+    // gained a subscriber, is itself a drift. Otherwise silencing this
+    // gate would be a one-line edit with no cost, which is how a gate
+    // stops meaning anything.
+    for (ch, _) in UNSUBSCRIBED_BY_DESIGN {
+        if !declared.contains(*ch) {
+            problems.push(format!(
+                "`{ch}` is listed in UNSUBSCRIBED_BY_DESIGN but is no longer emitted \
+                 — delete the stale entry"
+            ));
+        }
+    }
+
+    for ch in &declared {
+        if let Some((_, why)) = UNSUBSCRIBED_BY_DESIGN.iter().find(|(c, _)| c == ch) {
+            if frontend.contains(&format!("\"{ch}\"")) {
+                problems.push(format!(
+                    "`{ch}` is listed in UNSUBSCRIBED_BY_DESIGN ({why}) but the renderer now \
+                     subscribes to it — remove the entry or the subscription"
+                ));
+            }
+            continue;
+        }
+        // Quoted forms only. Every real subscription spells the
+        // channel as a `"…"` / `'…'` literal — `useTauriEvent("x", …)`,
+        // a `useTauriEvents({ "x": … })` key, or a shared constant in
+        // `lib/events.ts`. Requiring the quotes is a second, cheaper
+        // guard against a bare mention counting as a subscriber.
+        let quoted = [format!("\"{ch}\""), format!("'{ch}'")];
+        if !quoted.iter().any(|q| frontend.contains(q.as_str())) {
+            problems.push(format!(
+                "channel `{ch}` is emitted by the backend but named nowhere under `src/` \
+                 — either the renderer is missing a subscriber (a tray action that \
+                 silently does nothing) or the channel is dead and should be deleted"
             ));
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claudepot",
   "private": true,
-  "version": "0.4.11",
+  "version": "0.4.12",
   "license": "ISC",
   "type": "module",
   "engines": {

--- a/scripts/check-envvar-layout.mjs
+++ b/scripts/check-envvar-layout.mjs
@@ -36,12 +36,18 @@
 // No `screenshot-fixture` needed — that exists so screenshots don't capture
 // real data, and this writes nothing to disk.
 //
-// Usage:  node scripts/check-envvar-layout.mjs [--debug]
+// Usage:  node scripts/check-envvar-layout.mjs [--debug] [--self-test]
+//
+//         --self-test first forces `.envvar-list` to 0px and asserts the
+//         assertions REPORT that, then restores the pane and runs for real.
+//         Use it whenever you touch this script or the pane: CI cannot run
+//         this guard, so proving it still bites is a manual step or nothing.
 // Exit:   0 assertions pass · 1 an assertion failed · 2 could not run
 //         (2 is "app not running" — callers should skip, not fail)
 
 const PORT = process.env.MCP_BRIDGE_PORT ?? 9223;
 const DEBUG = process.argv.includes("--debug");
+const SELF_TEST = process.argv.includes("--self-test");
 
 let seq = 0;
 const pending = new Map();
@@ -180,12 +186,89 @@ async function main() {
     })()`,
   );
 
+  // --self-test: prove the assertions can still FAIL before trusting
+  // that they passed.
+  //
+  // This guard cannot run in CI — it needs a macOS GUI session, a Vite
+  // server and a debug build carrying the MCP bridge — so nobody has
+  // ever watched it go red, and a check nobody has watched fail is
+  // indistinguishable from one that cannot fail. `AGENTS.md` names
+  // this script as the example of that decay. It is the same reason
+  // `check:catalogs` takes `CLAUDEPOT_LOCALES_DIR`: exercising the
+  // gate must itself be one command.
+  //
+  // Injecting the ORIGINAL fault rather than a synthetic one: the
+  // shipped bug was `.envvar-list` resolving to 0px, so that is what
+  // gets reproduced.
+  let selfTest = null;
+  if (SELF_TEST) {
+    await js(
+      ws,
+      `(() => {
+        const s = document.createElement('style');
+        s.id = '__envvar_selftest__';
+        s.textContent = '.envvar-list { height: 0 !important; min-height: 0 !important; flex: 0 0 0 !important; }';
+        document.head.appendChild(s);
+        return true;
+      })()`,
+    );
+    await new Promise((r) => setTimeout(r, 250));
+    const broken = await js(ws, MEASURE);
+    await js(
+      ws,
+      `(() => {
+        document.getElementById('__envvar_selftest__')?.remove();
+        return true;
+      })()`,
+    );
+    await new Promise((r) => setTimeout(r, 250));
+    selfTest = evaluate(broken, broken);
+  }
+
   ws.close();
   if (DEBUG) {
     console.error("collapsed:", JSON.stringify(collapsed, null, 2));
     console.error("expanded:", JSON.stringify(expanded, null, 2));
   }
 
+  if (SELF_TEST) {
+    if (selfTest.length === 0) {
+      console.error(
+        "envvar-layout: SELF-TEST FAILED — the pane was forced to 0px and the " +
+          "assertions still passed. This guard is inert; fix it before trusting " +
+          "a green run.",
+      );
+      process.exit(1);
+    }
+    console.error(
+      `envvar-layout: self-test ok — a 0px list produced ${selfTest.length} ` +
+        `failure(s), so the assertions still bite.`,
+    );
+  }
+
+  const failures = evaluate(collapsed, expanded);
+  if (failures.length) {
+    console.error("envvar-layout: FAILED");
+    for (const f of failures) console.error(`  ✗ ${f}`);
+    process.exit(1);
+  }
+  console.error(
+    `envvar-layout: ok — collapsed ${collapsed.listHeight}px ` +
+      `(${collapsed.visibleRows}/${collapsed.totalRows} rows), ` +
+      `expanded ${expanded.listHeight}px ` +
+      `(${expanded.visibleRows}/${expanded.totalRows} rows), ` +
+      `1 scroller, ${collapsed.bucketCount} bucket(s) inside it`,
+  );
+}
+
+/**
+ * The assertions, as a pure function of two measurements.
+ *
+ * Extracted from `main` so `--self-test` can run them against a
+ * deliberately-broken layout. Inline, they could only ever be executed
+ * on whatever the app happened to render.
+ */
+function evaluate(collapsed, expanded) {
   const failures = [];
   for (const [state, m] of [["collapsed", collapsed], ["expanded", expanded]]) {
     if (!(m.listHeight > 0)) {
@@ -215,21 +298,21 @@ async function main() {
     );
   }
 
-  if (failures.length) {
-    console.error("envvar-layout: FAILED");
-    for (const f of failures) console.error(`  ✗ ${f}`);
-    process.exit(1);
-  }
-  console.error(
-    `envvar-layout: ok — collapsed ${collapsed.listHeight}px ` +
-      `(${collapsed.visibleRows}/${collapsed.totalRows} rows), ` +
-      `expanded ${expanded.listHeight}px ` +
-      `(${expanded.visibleRows}/${expanded.totalRows} rows), ` +
-      `1 scroller, ${r.bucketCount} bucket(s) inside it`,
-  );
+  return failures;
 }
 
-main().catch((e) => {
-  console.error(`envvar-layout: ${e.message}`);
-  process.exit(e.code === 2 ? 2 : 1);
-});
+// Auto-run only when invoked directly, so `evaluate` can be imported
+// and exercised without a GUI session. The assertions are the part of
+// this script most worth checking and the part hardest to reach: the
+// measurement needs a running app, the judgement does not.
+export { evaluate };
+
+if (
+  process.argv[1] &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href
+) {
+  main().catch((e) => {
+    console.error(`envvar-layout: ${e.message}`);
+    process.exit(e.code === 2 ? 2 : 1);
+  });
+}

--- a/scripts/check-envvar-layout.test.mjs
+++ b/scripts/check-envvar-layout.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for the *judgement* half of `check-envvar-layout.mjs`.
+ *
+ * The guard itself cannot run in CI — it drives the real app over the
+ * debug-only MCP bridge, which needs a macOS GUI session, a Vite
+ * server and a windowed debug build. `AGENTS.md` names this script as
+ * the example of a check nobody has watched fail, which is
+ * indistinguishable from one that cannot fail.
+ *
+ * Splitting `evaluate()` out from the measurement fixes the half that
+ * is fixable. Feeding it a synthetic 0px measurement proves the
+ * assertions still bite without needing a screen; `--self-test` does
+ * the same thing against the live pane, for the half that genuinely
+ * needs one.
+ *
+ * The fixtures below are the shapes `MEASURE` returns, and the 0px one
+ * is the bug that prompted the whole script: `.envvar-list` resolving
+ * to `flex-basis: 0` with every row in the DOM and none on screen.
+ */
+import { describe, expect, it } from "vitest";
+import { evaluate } from "./check-envvar-layout.mjs";
+
+const healthy = {
+  listHeight: 420,
+  listScrollHeight: 900,
+  visibleRows: 9,
+  totalRows: 60,
+  scrollers: ["envvar-list"],
+  bucketsInsideList: true,
+  bucketCount: 3,
+};
+/** The shipped bug: list pinned to basis 0, nothing visible. */
+const zeroPx = { ...healthy, listHeight: 0, visibleRows: 0 };
+
+describe("check-envvar-layout — evaluate()", () => {
+  it("passes a healthy pane", () => {
+    expect(evaluate(healthy, healthy)).toEqual([]);
+  });
+
+  it("flags a zero-height list and says how much is clipped", () => {
+    const f = evaluate(zeroPx, zeroPx).join("\n");
+    expect(f).toContain("height 0px");
+    expect(f).toContain("900px of content is clipped");
+  });
+
+  it("flags that no row intersects the viewport", () => {
+    expect(evaluate(zeroPx, zeroPx).join("\n")).toContain("0 of 60 rows");
+  });
+
+  it("reports both disclosure states, not just the default", () => {
+    // The original bug scored 136px collapsed and 0px expanded, so a
+    // guard that only measured the default would have understated it.
+    const f = evaluate(zeroPx, zeroPx);
+    expect(f.filter((m) => m.startsWith("[collapsed]"))).toHaveLength(2);
+    expect(f.filter((m) => m.startsWith("[expanded]"))).toHaveLength(2);
+  });
+
+  it("catches a break that only appears when the appendix is expanded", () => {
+    expect(evaluate(healthy, zeroPx).length).toBeGreaterThan(0);
+  });
+
+  it("flags nested scroll containers", () => {
+    const nested = { ...healthy, scrollers: ["envvar-pane", "envvar-list"] };
+    expect(evaluate(nested, nested).join("\n")).toContain("scroll container");
+  });
+
+  it("flags an appendix bucket rendered outside the list", () => {
+    const outside = { ...healthy, bucketsInsideList: false };
+    expect(evaluate(outside, outside).join("\n")).toContain(
+      "outside .envvar-list",
+    );
+  });
+
+  it("does not flag bucket placement when there are no buckets", () => {
+    const none = { ...healthy, bucketCount: 0, bucketsInsideList: false };
+    expect(evaluate(none, none)).toEqual([]);
+  });
+});

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -84,9 +84,16 @@ if [ "$rust_only" -eq 0 ]; then
   # pixels — which is exactly how that pane shipped with its entire editable
   # list invisible. Needs `pnpm tauri dev` running; skipped, not failed, when
   # it isn't (exit 2 means "could not run").
+  #
+  # `--self-test` first forces the pane to 0px and fails if the
+  # assertions DON'T fire. Since CI can never run this guard, a run
+  # that merely reports "ok" tells you nothing about whether the guard
+  # still works; this makes every local run also a run of the guard
+  # against a known-bad layout. The pure `evaluate()` half is covered
+  # in CI by `scripts/check-envvar-layout.test.mjs`.
   step "env-vars pane layout (live app)"
   layout_rc=0
-  node scripts/check-envvar-layout.mjs || layout_rc=$?
+  node scripts/check-envvar-layout.mjs --self-test || layout_rc=$?
   case "$layout_rc" in
     0) ok "envvar layout" ;;
     2) printf '\033[1;33m• skipped — app not running (pnpm tauri dev)\033[0m\n' ;;

--- a/src-tauri/src/commands/desktop.rs
+++ b/src-tauri/src/commands/desktop.rs
@@ -194,10 +194,7 @@ pub async fn desktop_adopt(
     uuid: String,
     overwrite: bool,
     lock: tauri::State<'_, crate::state::DesktopOpState>,
-    app: tauri::AppHandle,
 ) -> Result<dto::DesktopAdoptOutcome, ErrorDto> {
-    use tauri::Emitter;
-
     let _guard = lock.0.lock().await;
 
     let target_uuid = Uuid::parse_str(&uuid).map_err(|e| {
@@ -236,7 +233,10 @@ pub async fn desktop_adopt(
     .await
     .map_err(ErrorDto::from)?;
 
-    let _ = app.emit(crate::events::DESKTOP_ADOPTED, &outcome.account_email);
+    // No event: the renderer invoked this command and gets the same
+    // facts back in `DesktopAdoptOutcome`. The `desktop-adopted`
+    // channel that used to fire here never had a subscriber, because
+    // there was nothing for one to learn.
     Ok(dto::DesktopAdoptOutcome {
         account_email: outcome.account_email,
         captured_items: outcome.captured_items,
@@ -251,10 +251,7 @@ pub async fn desktop_adopt(
 pub async fn desktop_clear(
     keep_snapshot: bool,
     lock: tauri::State<'_, crate::state::DesktopOpState>,
-    app: tauri::AppHandle,
 ) -> Result<dto::DesktopClearOutcome, ErrorDto> {
-    use tauri::Emitter;
-
     let _guard = lock.0.lock().await;
 
     let store = open_account_store()?;
@@ -265,7 +262,8 @@ pub async fn desktop_clear(
         .await
         .map_err(ErrorDto::from)?;
 
-    let _ = app.emit(crate::events::DESKTOP_CLEARED, &outcome.email);
+    // No event — see `desktop_adopt`. `DesktopClearOutcome` already
+    // carries everything `desktop-cleared` announced.
     Ok(dto::DesktopClearOutcome {
         email: outcome.email,
         snapshot_kept: outcome.snapshot_kept,
@@ -314,14 +312,12 @@ pub async fn sync_from_current_desktop(
 #[tauri::command]
 pub async fn desktop_launch(
     lock: tauri::State<'_, crate::state::DesktopOpState>,
-    app: tauri::AppHandle,
 ) -> Result<(), ErrorDto> {
-    use tauri::Emitter;
     let _guard = lock.0.lock().await;
     let platform =
         claudepot_core::desktop_backend::create_platform().ok_or_else(desktop_unsupported)?;
-    // `DesktopSwapError` carries its own code.
+    // `DesktopSwapError` carries its own code. No event — see
+    // `desktop_adopt`; `Ok(())` here IS "Desktop is running now".
     platform.launch().await.map_err(ErrorDto::from)?;
-    let _ = app.emit(crate::events::DESKTOP_RUNNING_CHANGED, true);
     Ok(())
 }

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -98,14 +98,45 @@ pub const AGENT_EVENT_BURST_CAPPED: &str = "agent-event-burst-capped";
 /// A watched config-tree file changed; payload is the tree patch.
 pub const CONFIG_TREE_PATCH: &str = "config-tree-patch";
 
-/// Desktop slot adopted an account's session files.
-pub const DESKTOP_ADOPTED: &str = "desktop-adopted";
+// `desktop-adopted`, `desktop-cleared` and `desktop-running-changed`
+// used to live here. All three were emitted from the Tauri *command*
+// the renderer had just invoked, so the caller already had the outcome
+// in the command's return value and nobody ever subscribed. Deleted
+// rather than wired up: an event whose only purpose is to re-announce
+// what the caller just learned is noise, and a channel with no
+// subscriber reads to the next author as a contract they must not
+// break.
+//
+// The tray channels below are different — nothing returns to a caller
+// there, because the click happened outside the webview.
 
-/// Desktop slot cleared.
-pub const DESKTOP_CLEARED: &str = "desktop-cleared";
+/// Tray → Desktop swap succeeded. Payload: [`TrayDesktopSwitched`].
+///
+/// The tray performs the swap with `no_launch=true` and cannot render
+/// anything itself, so this is the *only* route by which the main
+/// window learns the Desktop binding moved.
+pub const TRAY_DESKTOP_SWITCHED: &str = "tray-desktop-switched";
 
-/// Claude Desktop process started or stopped.
-pub const DESKTOP_RUNNING_CHANGED: &str = "desktop-running-changed";
+/// Tray → Desktop swap failed. Payload: the error message.
+pub const TRAY_DESKTOP_SWITCH_FAILED: &str = "tray-desktop-switch-failed";
+
+/// Tray → Launch Claude Desktop failed. Payload: the error message.
+pub const TRAY_DESKTOP_LAUNCH_FAILED: &str = "tray-desktop-launch-failed";
+
+/// Tray → Desktop flag reconcile finished. Payload: how many account
+/// flags flipped, so the renderer can stay quiet when nothing changed.
+pub const DESKTOP_RECONCILED: &str = "desktop-reconciled";
+
+/// Payload of [`TRAY_DESKTOP_SWITCHED`].
+///
+/// Carries the account so the toast can name it. The emit used to be
+/// `()`, which left the renderer unable to say *which* account it had
+/// switched to even once it started listening — mirroring
+/// `tray-cli-switched`, whose payload has always named the target.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TrayDesktopSwitched {
+    pub to_email: String,
+}
 
 /// Full live-session roster snapshot.
 pub const LIVE_ALL: &str = "live-all";
@@ -117,36 +148,43 @@ pub fn live_channel(session_id: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    //! Wire-contract lock: the renderer subscribes by exact string,
-    //! so any drift in these values is a frontend-visible break.
-    //! Update `src/` listeners in the same change if one of these
-    //! assertions ever needs to move.
+    //! # Why the old "wire-contract lock" test is gone
+    //!
+    //! It read `assert_eq!(DESKTOP_ADOPTED, "desktop-adopted")` — every
+    //! constant compared to its own literal, twenty-one times. That
+    //! catches a rename and nothing else, while its docstring claimed
+    //! to protect a contract with the renderer.
+    //!
+    //! It could not, and did not. Seven of the channels it "locked"
+    //! had **zero** subscribers in `src/`: four tray/Desktop ones where
+    //! that meant swap failures vanished silently, and three that were
+    //! pure dead weight. A tautology cannot notice the other end of the
+    //! contract is missing, which is the only failure that had actually
+    //! occurred.
+    //!
+    //! The real check is cross-boundary and now lives in
+    //! `cargo xtask verify-docs`, which greps `src/` for every channel
+    //! this file declares. What remains here is the part that is
+    //! genuinely local: the naming convention for per-instance
+    //! channels, and the shape of payloads the renderer destructures.
 
     use super::*;
 
+    /// Payload shapes the renderer destructures by field name. Unlike
+    /// the channel strings, these are not greppable from the frontend,
+    /// so a serde rename would be invisible until runtime.
     #[test]
-    fn test_channel_constants_match_frontend_contract() {
-        assert_eq!(OP_TERMINAL, "cp-op-terminal");
-        assert_eq!(UPDATES_CYCLE_COMPLETE, "updates::cycle-complete");
-        assert_eq!(SERVICE_STATUS_UPDATED, "service-status::updated");
-        assert_eq!(ROTATION_SUGGESTED, "rotation-suggested");
-        assert_eq!(ROTATION_STALLED, "rotation-stalled");
-        assert_eq!(ROTATION_APPLIED, "rotation-applied");
-        assert_eq!(ROTATION_FAILED, "rotation-failed");
-        assert_eq!(ROTATION_BREAKER_TRIPPED, "rotation-breaker-tripped");
-        assert_eq!(PERMISSION_REVERTED, "permission-reverted");
-        assert_eq!(PERMISSION_BREAKER_TRIPPED, "permission-breaker-tripped");
-        assert_eq!(USAGE_THRESHOLD_CROSSED, "usage-threshold-crossed");
-        assert_eq!(USAGE_REFETCH, "usage::refetch");
-        assert_eq!(MEMORY_CHANGED, "memory:changed");
-        assert_eq!(AGENT_EVENT_DISPATCHED, "agent-event-dispatched");
-        assert_eq!(AGENT_EVENT_FAILED, "agent-event-failed");
-        assert_eq!(AGENT_EVENT_BURST_CAPPED, "agent-event-burst-capped");
-        assert_eq!(CONFIG_TREE_PATCH, "config-tree-patch");
-        assert_eq!(DESKTOP_ADOPTED, "desktop-adopted");
-        assert_eq!(DESKTOP_CLEARED, "desktop-cleared");
-        assert_eq!(DESKTOP_RUNNING_CHANGED, "desktop-running-changed");
-        assert_eq!(LIVE_ALL, "live-all");
+    fn tray_desktop_switched_serializes_the_account_it_switched_to() {
+        let json = serde_json::to_value(TrayDesktopSwitched {
+            to_email: "someone@example.com".into(),
+        })
+        .expect("serialize");
+        assert_eq!(
+            json.get("to_email").and_then(|v| v.as_str()),
+            Some("someone@example.com"),
+            "useTrayBridge reads `to_email`; renaming the field silently \
+             degrades the toast to the unknown-account branch"
+        );
     }
 
     #[test]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -671,7 +671,7 @@ fn handle_desktop_launch(app: &AppHandle) {
         };
         if let Err(e) = platform.launch().await {
             tracing::warn!("tray desktop-launch failed: {e}");
-            let _ = app.emit("tray-desktop-launch-failed", e.to_string());
+            let _ = app.emit(crate::events::TRAY_DESKTOP_LAUNCH_FAILED, e.to_string());
         }
     });
 }
@@ -693,7 +693,7 @@ fn handle_desktop_reconcile(app: &AppHandle) {
                         tracing::warn!("tray rebuild after desktop reconcile failed: {e}");
                     }
                 }
-                let _ = app.emit("desktop-reconciled", outcome.flag_flips.len());
+                let _ = app.emit(crate::events::DESKTOP_RECONCILED, outcome.flag_flips.len());
             }
             Err(e) => tracing::warn!("tray desktop-reconcile failed: {e}"),
         }
@@ -841,18 +841,25 @@ fn handle_desktop_switch(app: &AppHandle, uuid_str: &str) {
                 return;
             }
         };
-        match crate::commands::desktop::desktop_use(email, true, lock).await {
+        match crate::commands::desktop::desktop_use(email.clone(), true, lock).await {
             Ok(()) => {
                 if let Err(e) = rebuild(&app).await {
                     tracing::warn!("tray rebuild after desktop switch failed: {e}");
                 }
-                let _ = app.emit("tray-desktop-switched", ());
+                // Payload names the account: the main window has no
+                // other way to learn a tray click moved the Desktop
+                // binding, so an empty payload left it unable to say
+                // which one even after it started listening.
+                let _ = app.emit(
+                    crate::events::TRAY_DESKTOP_SWITCHED,
+                    crate::events::TrayDesktopSwitched { to_email: email },
+                );
             }
             Err(e) => {
                 // `desktop_use` now rejects with an `ErrorDto`; the
                 // English lives in `message` (see `dto_error.rs`).
                 tracing::warn!("tray desktop_use failed: {}", e.message);
-                let _ = app.emit("tray-desktop-switch-failed", e.message);
+                let _ = app.emit(crate::events::TRAY_DESKTOP_SWITCH_FAILED, e.message);
             }
         }
     });

--- a/src-tauri/src/usage_snapshot.rs
+++ b/src-tauri/src/usage_snapshot.rs
@@ -56,12 +56,19 @@ async fn run_tick(app: &AppHandle) {
     // cannot silently kill *every* orchestrator for the GUI's
     // lifetime. The previous shape — `loop { run_tick().await;
     // sleep().await; }` with zero panic isolation — meant a malformed
-    // `result.json`, an unmanaged `app.state::<…>()` call, or any
-    // subprocess panic stopped permission revert + PR refresh + the
-    // event orchestrator + snapshot writer + rotation all at once.
+    // `result.json` or any subprocess panic stopped permission revert
+    // + PR refresh + the event orchestrator + snapshot writer +
+    // rotation all at once.
     // Note `panic = "abort"` in the release profile defeats this in
     // production binaries, but the guard still pays off in dev,
     // tests, and any future profile change.
+    //
+    // Managed-state lookups are deliberately NOT left to that guard.
+    // This comment used to list "an unmanaged `app.state::<…>()` call"
+    // among the things it covered, while every such call sat OUTSIDE
+    // the guarded futures — and `catch_unwind` could not have helped
+    // in release regardless. They now use `try_state` and degrade with
+    // a log, which works under `panic = "abort"` too.
 
     // Revert any expired permission grants first — this is independent
     // of account state, so it must run before the early returns below
@@ -150,18 +157,33 @@ async fn run_tick(app: &AppHandle) {
     // than five minutes from now. Nothing to do — and no network — when
     // every slot is still valid. Never touches the active account; see
     // `token_refresh_orchestrator::pick`.
+    //
+    // `try_state`, not `state`: the latter PANICS when the type is not
+    // managed. This block sat OUTSIDE `guarded` while `guarded`'s own
+    // comment named "an unmanaged `app.state::<…>()` call" as one of
+    // the things it protected against — so the one hazard it called
+    // out by name was the one it could not catch. Worse, `guarded`
+    // relies on `catch_unwind`, which `panic = "abort"` makes a no-op
+    // in the shipped release profile. A `Result`-shaped miss degrades
+    // this tick and logs; a panic takes the whole GUI down.
+    if let Some(orch) =
+        app.try_state::<Arc<crate::token_refresh_orchestrator::TokenRefreshOrchestrator>>()
     {
-        let orch = app.state::<Arc<crate::token_refresh_orchestrator::TokenRefreshOrchestrator>>();
         let orch: Arc<_> = Arc::clone(&orch);
         guarded(
             "token_refresh_orchestrator",
             async move { orch.tick(app).await },
         )
         .await;
+    } else {
+        tracing::warn!("usage_snapshot: TokenRefreshOrchestrator not managed; skipping refresh");
     }
 
+    let Some(cache_state) = app.try_state::<UsageCache>() else {
+        tracing::warn!("usage_snapshot: UsageCache not managed; skipping this tick");
+        return;
+    };
     let outcomes = {
-        let cache_state = app.state::<UsageCache>();
         let cache: &UsageCache = &cache_state;
         cache.fetch_batch_detailed_verified(&store, &uuids).await
     };
@@ -201,13 +223,21 @@ async fn run_tick(app: &AppHandle) {
     // mode (auto / confirm). When no rules exist, the orchestrator
     // returns immediately — zero overhead for users who don't opt in.
     if let Some(active_uuid) = active_cli_uuid(&accounts) {
-        let orchestrator = app.state::<Arc<RotationOrchestrator>>();
-        let orchestrator: Arc<RotationOrchestrator> = Arc::clone(&orchestrator);
-        guarded(
-            "rotation_orchestrator",
-            orchestrator.tick(app, &snapshot, active_uuid),
-        )
-        .await;
+        // `try_state` for the same reason as above — see the
+        // token-refresh block.
+        match app.try_state::<Arc<RotationOrchestrator>>() {
+            Some(orchestrator) => {
+                let orchestrator: Arc<RotationOrchestrator> = Arc::clone(&orchestrator);
+                guarded(
+                    "rotation_orchestrator",
+                    orchestrator.tick(app, &snapshot, active_uuid),
+                )
+                .await;
+            }
+            None => {
+                tracing::warn!("usage_snapshot: RotationOrchestrator not managed; skipping")
+            }
+        }
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claudepot",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "identifier": "com.claudepot.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/hooks/useTrayBridge.test.tsx
+++ b/src/hooks/useTrayBridge.test.tsx
@@ -237,6 +237,120 @@ describe("useTrayBridge — tray-cli-switch-failed", () => {
   });
 });
 
+// The Desktop half of the tray bridge. Every one of these channels
+// was emitted by the backend with NO subscriber in `src/`, so a tray
+// Desktop swap silently left the account cards stale and a failed one
+// produced no signal at all. These lock the parity with the CLI
+// channels above.
+describe("useTrayBridge — tray Desktop channels", () => {
+  it("subscribes to every Desktop channel the backend emits", async () => {
+    const bus = setupBus();
+    renderHook(() => useTrayBridge(makeArgs()));
+    await Promise.resolve();
+
+    for (const ch of [
+      "tray-desktop-switched",
+      "tray-desktop-switch-failed",
+      "tray-desktop-launch-failed",
+      "desktop-reconciled",
+    ]) {
+      expect(bus.has(ch), `${ch} has no subscriber`).toBe(true);
+    }
+  });
+
+  it("tray-desktop-switched refreshes the cards and names the account", async () => {
+    const bus = setupBus();
+    const args = makeArgs();
+    renderHook(() => useTrayBridge(args));
+    await Promise.resolve();
+
+    bus.fire("tray-desktop-switched", { to_email: "b@example.com" });
+
+    // The refresh is the load-bearing half: without it the
+    // `is_desktop_active` badge keeps pointing at the old account.
+    expect(args.refreshAccounts).toHaveBeenCalled();
+    const call = args.emit.mock.calls[0][0];
+    expect(call.category).toBe("accountSwitched");
+    expect(call.title).toBe("Desktop → b@example.com");
+    // The tray always swaps with no_launch=true, so the body must say
+    // Desktop was not relaunched.
+    expect(call.body).toContain("not relaunched");
+    // No Undo: reversing a Desktop swap is not symmetric with doing it.
+    expect(call.toastAction).toBeUndefined();
+  });
+
+  it("still refreshes when the switched payload is unrecognizable", async () => {
+    const bus = setupBus();
+    const args = makeArgs();
+    renderHook(() => useTrayBridge(args));
+    await Promise.resolve();
+
+    bus.fire("tray-desktop-switched", { wrong: "shape" });
+    expect(args.refreshAccounts).toHaveBeenCalledTimes(1);
+    expect(args.emit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["tray-desktop-switch-failed", "Desktop switch failed"],
+    ["tray-desktop-launch-failed", "Desktop launch failed"],
+  ])("%s surfaces an error entry carrying the detail", async (ch, title) => {
+    const bus = setupBus();
+    const args = makeArgs();
+    renderHook(() => useTrayBridge(args));
+    await Promise.resolve();
+
+    bus.fire(ch, "Desktop is running");
+    const call = args.emit.mock.calls[0][0];
+    expect(call.kind).toBe("error");
+    expect(call.title).toBe(title);
+    expect(call.body).toBe("Desktop is running");
+  });
+
+  it.each(["tray-desktop-switch-failed", "tray-desktop-launch-failed"])(
+    "%s falls back to 'unknown' rather than a blank body",
+    async (ch) => {
+      const bus = setupBus();
+      const args = makeArgs();
+      renderHook(() => useTrayBridge(args));
+      await Promise.resolve();
+
+      bus.fire(ch, "");
+      expect(args.emit.mock.calls[0][0].body).toBe("unknown");
+    },
+  );
+
+  it("desktop-reconciled refreshes and reports only when flags flipped", async () => {
+    const bus = setupBus();
+    const args = makeArgs();
+    renderHook(() => useTrayBridge(args));
+    await Promise.resolve();
+
+    // Nothing changed — the tray runs this on demand, and "no work
+    // needed" is not worth a notification.
+    bus.fire("desktop-reconciled", 0);
+    expect(args.emit).not.toHaveBeenCalled();
+    expect(args.refreshAccounts).not.toHaveBeenCalled();
+
+    bus.fire("desktop-reconciled", 2);
+    expect(args.refreshAccounts).toHaveBeenCalledTimes(1);
+    expect(args.emit.mock.calls[0][0].title).toBe(
+      "Reconciled 2 Desktop bindings",
+    );
+  });
+
+  it("desktop-reconciled pluralizes a single flip", async () => {
+    const bus = setupBus();
+    const args = makeArgs();
+    renderHook(() => useTrayBridge(args));
+    await Promise.resolve();
+
+    bus.fire("desktop-reconciled", 1);
+    expect(args.emit.mock.calls[0][0].title).toBe(
+      "Reconciled 1 Desktop binding",
+    );
+  });
+});
+
 describe("useTrayBridge — tray routing", () => {
   it("cp-activity-open-session resolves the transcript and jumps to projects", async () => {
     const bus = setupBus();

--- a/src/hooks/useTrayBridge.ts
+++ b/src/hooks/useTrayBridge.ts
@@ -16,6 +16,15 @@ import type { AccountSummary } from "../types";
  *     actions routed through the shell's confirmation modal flow
  *   - `tray-cli-switched` / `tray-cli-switch-failed` — one-click CLI
  *     swap feedback (toast with Undo + OS banner mirror)
+ *   - `tray-desktop-switched` / `tray-desktop-switch-failed` /
+ *     `tray-desktop-launch-failed` / `desktop-reconciled` — the same
+ *     feedback for the Desktop slot
+ *
+ * Every channel the backend emits for a tray action is handled here.
+ * That is now enforced by `cargo xtask verify-docs`, which fails when
+ * a channel declared in `src-tauri/src/events.rs` has no subscriber
+ * anywhere in `src/` — the four Desktop channels above were emitted
+ * for releases with nobody listening.
  *
  * Every subscription is registered once for the shell's lifetime —
  * useTauriEvent(s) hold handlers in refs, so the unstable arg
@@ -29,6 +38,11 @@ interface TrayCliSwitchedPayload {
   to_email: string;
   from_email: string | null;
   cc_was_running: boolean;
+}
+
+/** Payload of `tray-desktop-switched` (`events.rs::TrayDesktopSwitched`). */
+interface TrayDesktopSwitchedPayload {
+  to_email: string;
 }
 
 export function useTrayBridge(args: {
@@ -201,17 +215,93 @@ export function useTrayBridge(args: {
       });
     },
     "tray-cli-switch-failed": (ev: TauriEvent<string>) => {
-      const detail =
-        typeof ev?.payload === "string" && ev.payload.length > 0
-          ? ev.payload
-          : i18n.t("ui.unknown");
       void emit({
         category: "accountSwitched",
         kind: "error",
         title: i18n.t("account.cliSwitchFailed"),
-        body: detail,
+        body: detailOf(ev),
+        target: { kind: "app", route: { section: "accounts" } },
+      });
+    },
+
+    // Tray → Desktop feedback. The CLI channels above had all of this
+    // and the Desktop ones had none: nothing in the renderer
+    // subscribed, so a tray Desktop swap left the account cards
+    // showing the previous binding, and a FAILED swap produced no
+    // signal anywhere — no toast, no banner, no log the user can see.
+    // The only recovery was `useDesktopIdentitySync`, which is
+    // throttled to one probe per five minutes AND only fires on window
+    // focus, so a swap performed while the window was already visible
+    // stayed invisible indefinitely.
+    //
+    // No Undo here, unlike the CLI swap. Undoing a Desktop switch is
+    // not symmetric with performing one — the previous session's files
+    // are in a snapshot dir that may or may not still hold them — so
+    // offering a one-click reversal would promise more than the
+    // backend guarantees.
+    "tray-desktop-switched": (ev: TauriEvent<TrayDesktopSwitchedPayload>) => {
+      const p = ev.payload;
+      // Always refresh, even when the payload is unrecognizable: the
+      // `is_desktop_active` flags in the cards are stale either way,
+      // and a stale badge is the more misleading of the two failures.
+      void refreshAccounts();
+      if (!p || typeof p.to_email !== "string") return;
+      void emit({
+        category: "accountSwitched",
+        title: i18n.t("tray.desktopSwitchedTitle", { email: p.to_email }),
+        // The tray always swaps with `no_launch=true`, so Desktop is
+        // never relaunched by this path — say so, or the user stares
+        // at a Desktop window still showing the old account.
+        body: i18n.t("tray.desktopSwitchedBody"),
+        target: { kind: "app", route: { section: "accounts" } },
+      });
+    },
+    "tray-desktop-switch-failed": (ev: TauriEvent<string>) => {
+      void emit({
+        category: "accountSwitched",
+        kind: "error",
+        title: i18n.t("account.desktopSwitchFailed"),
+        body: detailOf(ev),
+        target: { kind: "app", route: { section: "accounts" } },
+      });
+    },
+    "tray-desktop-launch-failed": (ev: TauriEvent<string>) => {
+      void emit({
+        category: "accountSwitched",
+        kind: "error",
+        // `components:` prefix — `toasts.*` is not in the default
+        // `common` namespace, and the typed `t()` is what caught it.
+        title: i18n.t("components:toasts.desktopLaunchFailed"),
+        body: detailOf(ev),
+        target: { kind: "app", route: { section: "accounts" } },
+      });
+    },
+    // Reconcile flips `is_desktop_active` in the store, so the cards
+    // are stale whenever it changed anything. Silent at zero flips:
+    // the tray runs this on demand and "nothing needed fixing" is not
+    // worth a notification.
+    "desktop-reconciled": (ev: TauriEvent<number>) => {
+      const flips = typeof ev?.payload === "number" ? ev.payload : 0;
+      if (flips <= 0) return;
+      void refreshAccounts();
+      void emit({
+        category: "accountSwitched",
+        title: i18n.t("tray.desktopReconciled", { count: flips }),
         target: { kind: "app", route: { section: "accounts" } },
       });
     },
   });
+}
+
+/**
+ * Error text from a string-payload channel, falling back to "unknown".
+ *
+ * Four channels needed the identical guard; the fallback matters
+ * because an empty payload would otherwise render an error toast with
+ * a blank body, which reads as a UI bug rather than as a failed swap.
+ */
+function detailOf(ev: TauriEvent<string>): string {
+  return typeof ev?.payload === "string" && ev.payload.length > 0
+    ? ev.payload
+    : i18n.t("ui.unknown");
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -148,7 +148,11 @@
     "cliSwitchedTitleRestart": "CLI → {{email}} — restart Claude Code to apply",
     "cliSwitchedBodyRestart": "Restart Claude Code to apply. Open Claudepot to undo.",
     "cliSwitchedBodyUndo": "Open Claudepot within 10 s to undo.",
-    "undoFailed": "Undo failed: {{email}} not found"
+    "undoFailed": "Undo failed: {{email}} not found",
+    "desktopSwitchedTitle": "Desktop → {{email}}",
+    "desktopSwitchedBody": "Claude Desktop was not relaunched; restart it to pick up the new session.",
+    "desktopReconciled_one": "Reconciled {{count}} Desktop binding",
+    "desktopReconciled_other": "Reconciled {{count}} Desktop bindings"
   },
   "status": {
     "keychain": {

--- a/src/locales/zh-CN/common.json
+++ b/src/locales/zh-CN/common.json
@@ -148,7 +148,10 @@
     "cliSwitchedTitleRestart": "CLI → {{email}} — 重启 Claude Code 后生效",
     "cliSwitchedBodyRestart": "重启 Claude Code 后生效。打开 Claudepot 可撤销。",
     "cliSwitchedBodyUndo": "10 秒内打开 Claudepot 可撤销。",
-    "undoFailed": "撤销失败：未找到 {{email}}"
+    "undoFailed": "撤销失败：未找到 {{email}}",
+    "desktopSwitchedTitle": "Desktop → {{email}}",
+    "desktopSwitchedBody": "Claude Desktop 未重新启动；请重启以加载新会话。",
+    "desktopReconciled_other": "已校正 {{count}} 个 Desktop 绑定"
   },
   "status": {
     "keychain": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,12 @@ export default defineConfig({
     },
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.test.{ts,tsx}"],
+    // `scripts/` is included so the repo's guard scripts can have their
+    // *judgement* unit-tested even when their *measurement* needs a GUI
+    // session CI does not have. `check-envvar-layout.mjs` is the case
+    // that motivated it: nobody had ever watched it fail, so nothing
+    // distinguished it from a guard that could not fail.
+    include: ["src/**/*.test.{ts,tsx}", "scripts/**/*.test.{ts,mjs}"],
     // Vitest's 5000 ms default was never calibrated for this suite's
     // heaviest files. `App.test.tsx` calls `vi.resetModules()` in
     // `beforeEach` and re-imports the ENTIRE App module graph per test

--- a/web/package.json
+++ b/web/package.json
@@ -11,16 +11,14 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "tsx tests/build-comment-tree.test.ts && tsx tests/safe-redirect.test.ts && tsx tests/unsubscribe-token.test.ts && tsx tests/api-constitution.test.ts && tsx tests/api-cursor.test.ts && tsx tests/api-decisions.test.ts && tsx tests/api-manifest.test.ts && tsx tests/editorial-writes-schemas.test.ts && tsx tests/moderation-schema.test.ts && tsx tests/moderation-prompt.test.ts && tsx tests/moderation-exempt.test.ts && tsx tests/moderation-ladder.test.ts && tsx tests/youtube-embed.test.ts && tsx tests/markdown-youtube.test.ts && tsx tests/spotify-embed.test.ts && tsx tests/apple-podcasts-embed.test.ts && tsx tests/markdown-media-embeds.test.ts && tsx tests/avatars.test.ts && tsx tests/citizen-bots-schemas.test.ts && tsx tests/csp.test.ts && tsx tests/magic-link-rate-limit.test.ts && tsx tests/api-scope-entitlement.test.ts && tsx tests/data-export-rate-limit.test.ts",
+    "test": "node scripts/run-tests.mjs",
     "projects:sync": "tsx scripts/sync-projects.ts",
     "projects:seed": "tsx --env-file=.env.local scripts/sync-projects.ts --seed",
     "editorial:score": "tsx --env-file=.env.local scripts/editorial-score.ts",
-    "test:editorial": "tsx tests/editorial-routing.test.ts",
     "policy:moderate": "tsx --env-file=.env.local scripts/policy-moderate.ts",
     "test:integration": "tsx --env-file=.env.local tests/integration/createSubmission-moderation.test.ts && tsx --env-file=.env.local tests/integration/createComment-moderation.test.ts && tsx --env-file=.env.local tests/integration/editorial-writes.test.ts",
     "social:post": "tsx --env-file=.env.local scripts/social-post.ts",
-    "social:test": "tsx --env-file=.env.local scripts/social-test-auth.ts",
-    "test:social": "tsx tests/social-format.test.ts"
+    "social:test": "tsx --env-file=.env.local scripts/social-test-auth.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.209",

--- a/web/scripts/run-tests.mjs
+++ b/web/scripts/run-tests.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Discover and run every `tests/*.test.ts`.
+ *
+ * # Why discovery instead of a list
+ *
+ * `package.json`'s `test` script used to be 23 filenames chained with
+ * `&&`. Adding a test file did not add it to the suite — you had to
+ * remember the second edit, and three people did not:
+ *
+ *   - `tests/username.test.ts` (24 assertions: reserved names,
+ *     self-rename cooldown — the impersonation surface of a public
+ *     site)
+ *   - `tests/editorial-routing.test.ts` (12 assertions: moderation
+ *     gate thresholds)
+ *   - `tests/social-format.test.ts` (9 assertions: X / Bluesky length
+ *     budgets)
+ *
+ * All three passed when finally run, so nothing was ever red. That is
+ * the bad case, not the good one: 45 assertions sat in the repo
+ * looking like coverage while `pnpm test` reported green without them,
+ * and CI runs only `pnpm test`.
+ *
+ * A list of files is a cache of the directory. This reads the
+ * directory.
+ *
+ * # Scope
+ *
+ * Top-level `tests/*.test.ts` only. `tests/integration/` stays out
+ * deliberately — those need `--env-file=.env.local` and a live Neon
+ * connection, so they cannot run in CI and have their own
+ * `test:integration` script.
+ */
+import { readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const testsDir = join(webRoot, "tests");
+
+const files = readdirSync(testsDir, { withFileTypes: true })
+  .filter((e) => e.isFile() && e.name.endsWith(".test.ts"))
+  .map((e) => e.name)
+  .sort();
+
+if (files.length === 0) {
+  // A discovery run that finds nothing must fail loudly. Exiting 0
+  // here would reproduce the exact failure this script replaces: a
+  // green suite that ran no tests.
+  console.error("run-tests: no tests/*.test.ts found — discovery is broken");
+  process.exit(1);
+}
+
+console.log(`run-tests: ${files.length} test file(s)\n`);
+
+const failed = [];
+for (const name of files) {
+  const r = spawnSync("tsx", [join("tests", name)], {
+    cwd: webRoot,
+    stdio: "inherit",
+    env: process.env,
+    shell: process.platform === "win32",
+  });
+  if (r.status !== 0) failed.push(name);
+}
+
+if (failed.length > 0) {
+  console.error(`\nrun-tests: ${failed.length} file(s) failed:`);
+  for (const f of failed) console.error(`  tests/${f}`);
+  process.exit(1);
+}
+
+console.log(`\nrun-tests: all ${files.length} file(s) passed`);

--- a/web/src/app/(reader)/app/install/page.mdx
+++ b/web/src/app/(reader)/app/install/page.mdx
@@ -5,7 +5,7 @@ export const metadata = {
 
 # Install
 
-> **Status: beta (`0.4.11`).** Daily-driven on macOS. Linux and
+> **Status: beta (`0.4.12`).** Daily-driven on macOS. Linux and
 > Windows builds are green but less seasoned.
 
 Two paths: grab a signed installer from the latest release (fast,


### PR DESCRIPTION
An audit of the app surfaced seven issues that every existing gate passed over. Each is fixed at its cause; the three that were invisible because nothing checked for them now have a gate that does.

## Fixed

- **Tray Desktop actions were silent.** Four emitted channels had no subscriber, so a Desktop swap left the account cards stale and a *failed* swap or launch produced no signal anywhere. The CLI equivalents had toast + OS banner + Undo the whole time. Three further channels only re-announced what the invoking command already returned, and are deleted.
- **`PRAGMA journal_mode=WAL` returns SQLITE_BUSY despite `busy_timeout`.** SQLite does not run the busy handler for the WAL transition, so racing the first open of a database failed outright with "database is locked" — measured at 2 failures per 320 concurrent opens, against a helper whose docstring asserted the opposite. Affected every store.
- **Four resolvers answered "where is CC's global config", two wrongly.** Effective MCP dropped the legacy `.config.json` branch; the tips ledger hardcoded `$HOME/.claude.json` and recorded zeroes into an append-only log. Collapsed to one.
- **`corpus.db` had no WAL size bound** — the one store that hand-rolled its pragmas, omitting the two caps that exist because `sessions.db-wal` once reached 6.3 GB.
- `boards.db` migrations now decide under the write lock; `usage_snapshot` uses `try_state` instead of the panicking `app.state()` it called from outside its own guard.

## Gates added

Each was verified by breaking the thing it watches and confirming it goes red. Two were inert on the first attempt — the channel check counted a test file, then a doc comment — which is why none of them is trusted for merely being green.

- `verify-docs` fails a `Connection::open` that skips `apply_standard_pragmas`.
- `verify-docs` fails an event channel with no frontend subscriber. Replaces a "wire-contract lock" test whose body compared each constant to its own literal.
- The web suite discovers its tests; three files (45 assertions) had never run anywhere, including `username.test.ts`.
- `check-envvar-layout` gains a `--self-test` and CI-run unit tests for its judgement half.

## Verification

| Gate | Result |
|---|---|
| `cargo test --workspace` | 3966 (was 3949) |
| `pnpm test` | 1265 (was 1248) |
| web suite | 26 files (was 23) |
| clippy `-D warnings`, fmt, tsc (root + web) | pass |
| `verify-docs`, `verify-cc-parity`, `check:catalogs` | pass |
