### PR TITLE
fix(test): measure the verify stagger on a paused clock

### DIFF
--- a/crates/claudepot-core/Cargo.toml
+++ b/crates/claudepot-core/Cargo.toml
@@ -80,3 +80,9 @@ caregiver = ["dep:lettre"]
 
 [dev-dependencies]
 claudepot-core = { path = ".", features = ["caregiver"] }
+# `test-util` enables tokio's pausable clock (`#[tokio::test(start_paused
+# = true)]`). Used by the stagger tests, which assert how many 200 ms
+# sleeps a pass performs — a claim about the CODE that a wall-clock
+# measurement cannot make on a shared CI runner without also measuring
+# the runner. Dev-only; the shipped binaries do not carry it.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/claudepot-core/src/services/account_service_tests.rs
+++ b/crates/claudepot-core/src/services/account_service_tests.rs
@@ -1592,9 +1592,34 @@ async fn test_verify_all_with_progress_skips_accounts_without_credentials() {
 }
 
 /// Stagger only fires BETWEEN calls — not before the first or after
-/// the last. With N=3 accounts the total elapsed time should be
-/// >= 2 * 200ms but the first event fires immediately.
-#[tokio::test]
+/// the last. With N=3 accounts that is exactly two 200 ms sleeps.
+///
+/// # Why the clock is paused
+///
+/// This measured `std::time::Instant` around the whole pass and
+/// asserted `elapsed < 900ms`. That bound is not a claim about the
+/// code: the window also contains three `verify_account_identity`
+/// calls, each doing keychain and store work whose cost belongs to
+/// the machine, not to the stagger logic. On a loaded
+/// `windows-latest` runner it measured 981 ms against an expected
+/// ~400 ms of actual sleeping, and failed — while the identical tree
+/// passed on the same workflow minutes earlier. A wall-clock upper
+/// bound cannot distinguish "three sleeps" from "two sleeps on a busy
+/// runner", which is precisely the distinction the test exists to
+/// make.
+///
+/// `start_paused = true` gives tokio a virtual clock that
+/// auto-advances only when the runtime is idle. Every
+/// `tokio::time::sleep` therefore costs its exact nominal duration and
+/// real work costs zero, so `tokio::time::Instant` measures *the sum
+/// of the sleeps* and nothing else. The assertions below are then
+/// exact rather than tolerant, which also makes them stricter: the old
+/// 900 ms ceiling would have accepted a third stagger, the 401 ms one
+/// cannot.
+///
+/// Raising the ceiling instead would have bought green by loosening a
+/// threshold, and the next slow runner would have taken it back.
+#[tokio::test(start_paused = true)]
 async fn test_verify_all_with_progress_uses_200ms_stagger_only_between_calls() {
     let _lock = crate::testing::lock_data_dir();
     let _env = setup_test_data_dir();
@@ -1616,19 +1641,24 @@ async fn test_verify_all_with_progress_uses_200ms_stagger_only_between_calls() {
     let fetcher = VerifyFetcher::new().returns("any", "a1@example.com");
     let sink = RecordingVerifySink::new();
 
-    let start = std::time::Instant::now();
+    // `tokio::time::Instant`, not `std::time::Instant` — only the
+    // former follows the paused clock. Using std here would measure
+    // real time again and reintroduce exactly the flake above.
+    let start = tokio::time::Instant::now();
     verify_all_with_progress(&store, &fetcher, &sink).await;
     let elapsed = start.elapsed();
 
-    // Two stagger gaps for 3 accounts → >= 400ms minimum.
+    // Two stagger gaps for 3 accounts → 400 ms of virtual time.
     assert!(
-        elapsed >= std::time::Duration::from_millis(380),
-        "stagger should add ~400ms; elapsed={elapsed:?}"
+        elapsed >= std::time::Duration::from_millis(400),
+        "stagger should add 400ms of sleeping; elapsed={elapsed:?}"
     );
-    // Sanity upper bound — we shouldn't sleep before the first or
-    // after the last (would push elapsed above 600ms+jitter).
+    // And no sleep before the first call or after the last. Under a
+    // paused clock only sleeps advance time, so a third stagger would
+    // land this at 600 ms — a 1 ms ceiling over the expected value is
+    // now a meaningful assertion rather than a tolerance.
     assert!(
-        elapsed < std::time::Duration::from_millis(900),
+        elapsed < std::time::Duration::from_millis(401),
         "no extra stagger before first / after last; elapsed={elapsed:?}"
     );
 


### PR DESCRIPTION
`test_verify_all_with_progress_uses_200ms_stagger_only_between_calls` failed on `windows-latest` for the v0.4.12 merge commit, having passed on the **identical tree** in the PR run minutes earlier. It blocks tagging v0.4.12.

## Cause

The assertion was `elapsed < 900ms` around the whole pass. Only ~400 ms of that is the two staggers under test; the rest is three `verify_account_identity` calls doing keychain and store work whose cost belongs to the machine. On a loaded runner that reached **981 ms**. A wall-clock upper bound cannot separate "three staggers" from "two staggers on a busy runner" — the only distinction the test exists to draw.

## Fix

`#[tokio::test(start_paused = true)]` + `tokio::time::Instant`. Sleeps cost their exact nominal duration, real work costs zero, so the measurement is the sum of the sleeps and nothing else. Runs in **0.01 s** instead of 400 ms of real sleeping.

Also **stricter**: ceiling drops 900 ms → 401 ms. Verified by moving the sleep before the first call — the new bound catches it at exactly 600 ms; the old 900 ms bound would have passed that defect.

Raising the ceiling was the obvious alternative and the wrong one: it buys green by loosening a threshold and hands the same failure to the next slow runner.

## Class check

The two other wall-clock upper bounds (`config_watch.rs`, on `stop()`) are **not** the same defect — they expect ~0 ms against 1 s / 100 ms ceilings and enclose only a channel signal and a join, so the margin is three orders of magnitude rather than 2.25×. Left alone deliberately.

`tokio`'s `test-util` feature added to dev-dependencies for the pausable clock. Dev-only; `Cargo.lock` unchanged.
