### PR TITLE
Release 0.4.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,113 @@ Versioning scheme:
 - `0.1.x` — beta
 - `1.0.0+` — stable
 
+## 0.4.15 — beta (unreleased)
+
+An external UX/UI audit, worked through in passes. Most of what follows
+is a defect the audit found or one found while fixing it; several had
+been shipping silently for a long time, because nothing failed when they
+did.
+
+### Fixed
+
+- **The transcript-retention warning did not open the pane it named.**
+  `NotificationTarget` has carried `{ section, sub }` since it was
+  written, and the click router matched on the section and discarded
+  `sub` — one branch handling two shapes, only one of which has a
+  subroute. The sole producer is the boot check that warns Claude Code's
+  `cleanupPeriodDays` is deleting transcript history, the only CC
+  setting that destroys user data. It asked for Settings → Retention and
+  opened whichever pane you last had.
+
+- **View → Agents in the macOS menu bar did nothing.** The menu emitted
+  the label (`agents`) while the section id is `automations`, kept for
+  localStorage compatibility. The item was built, shown, and inert. A
+  menu item that does nothing is indistinguishable from a slow app,
+  which is why it survived.
+
+- **The Dock icon fell back to the generic black executable icon** after
+  turning "hide dock icon" back off. The re-apply for that transition
+  already existed and its comment described the symptom exactly — it
+  just ran on a tokio worker, and `setApplicationIconImage` is
+  main-thread-only, so the guard logged an error and skipped. A written,
+  reviewed fix discarded at runtime on every use.
+
+- **GitHub PR badges had never rendered for anyone.** The helper spawned
+  `git` and called `wait_with_output()`, but `spawn()` inherits stdio —
+  only `output()` implies `piped()`. Nothing was captured, so
+  `current_branch` answered "no branch" for every repository. The
+  visible half was `pnpm tauri dev` printing a bare branch name per
+  project, interleaved with `fatal: not a git repository`.
+
+- **Every card in the Activities live strip was inert.** `LiveSessionCard`
+  draws a `<button>` and takes an optional click handler; the strip
+  passed none. It looked clickable and did nothing.
+
+- **⌘⇧L did nothing while the sidebar was collapsed** — the live strip
+  is unmounted in that state, so the shortcut queried a node that did
+  not exist. It now expands first, then focuses.
+
+- **⌘\ collapsed the sidebar out from under an open modal**, along with
+  three other copies of the shortcut gate that had each re-derived a
+  weaker check.
+
+- **75 of 127 buttons had no focus ring**, the rail's focus indicator was
+  delegated to a class nothing has emitted since the Lucide port, and
+  `prefers-contrast: more` was committed to in the design rules with
+  zero rules implementing it.
+
+- **92 references to 15 tokens that were never declared.** CSS drops a
+  declaration naming an undefined custom property, so each was silently
+  doing nothing and the element inherited instead. A misspelled token is
+  not a raw value — it reads as correct in review and fails invisibly.
+
+- **`tokens.css` had five comment blocks with no opener.** A line-based
+  codemod removing dead tokens had also eaten the line each comment
+  opened on, leaving prose loose inside `:root { }` where CSS parses it
+  as invalid declarations and drops it in silence.
+
+### Changed
+
+- **Global is now Config.** It was an engineering scope promoted to a
+  navigation label, sitting beside nouns the user owns. Saved positions
+  migrate; ⌘8 is unchanged.
+
+- **Live session state has one surface per job.** Five things rendered
+  the same data with no indication which was authoritative: the status
+  bar is now a count and not a control, the sidebar strip owns the list,
+  and Activities owns history and cost.
+
+- **One cursor policy: default everywhere except a real hyperlink.** It
+  had contradicted itself four ways, so two adjacent buttons produced
+  two cursors. `not-allowed` is gone — macOS never displays it, and
+  where a control faked disabled with a `role` it was the only cue the
+  control was dead.
+
+- **The dismissed-toast echo is gone.** It replayed a toast for six
+  seconds as truncated, pointer-inert, `aria-hidden` text, beside the
+  notification bell whose entire job is being the durable record.
+
+- **The Dock icon block is centred.** It sat 48 units low on the 1024
+  canvas — a 256px top margin against 160px at the bottom.
+
+- **The menubar icon renders 16.4pt instead of 13.9pt.** `tray-icon`
+  normalises the tile to 18 points tall, so tile padding is pure loss;
+  measured against neighbours in the same menubar, ours was the small
+  one despite an identical file size.
+
+### Internal
+
+- Guards for the classes above, each verified by planting the defect and
+  watching the check fail: CSS comment balance, cursor policy,
+  menu-navigation targets, layered-icon layer freshness, undeclared
+  tokens, the shared shortcut gate per handler, and the tray's rendered
+  point height rather than a tile fraction the old icon sat comfortably
+  inside while looking small.
+
+- The `xtask` self-tests now run in CI. They were added to prove the
+  guards could fail and then excluded from the test job, so none of them
+  had ever executed on a push.
+
 ## 0.4.14 — beta (released 2026-08-15)
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "claudepot-cli"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-core"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "claudepot-tauri"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8194,7 +8194,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.14"
+version = "0.4.15"
 edition = "2021"
 # Floor set by std file_lock (File::{lock,try_lock,unlock}, 1.89) —
 # the cross-process advisory locks in claudepot-core depend on it.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you use Claude Code or Claude Desktop daily, you've probably hit at least one
 
 ### Install
 
-> **Status: beta** (`0.4.14`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
+> **Status: beta** (`0.4.15`). Daily-driven on macOS. Windows and Linux builds are green but less seasoned.
 
 You'll need a recent **Rust toolchain** ([rustup.rs](https://rustup.rs)) and **Node 20+** with **pnpm** ([pnpm.io](https://pnpm.io)). No other system dependencies.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claudepot",
   "private": true,
-  "version": "0.4.14",
+  "version": "0.4.15",
   "license": "ISC",
   "type": "module",
   "engines": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Claudepot",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "identifier": "com.claudepot.app",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/web/src/app/(reader)/app/install/page.mdx
+++ b/web/src/app/(reader)/app/install/page.mdx
@@ -5,7 +5,7 @@ export const metadata = {
 
 # Install
 
-> **Status: beta (`0.4.14`).** Daily-driven on macOS. Linux and
+> **Status: beta (`0.4.15`).** Daily-driven on macOS. Linux and
 > Windows builds are green but less seasoned.
 
 Two paths: grab a signed installer from the latest release (fast,


### PR DESCRIPTION
Version bump plus changelog. Five-site lock-step: `Cargo.toml`, `package.json`, `tauri.conf.json`, README banner, web install banner (`Cargo.lock` follows).

Everything in this release already merged and passed CI on `main` via #78, #79 and #80 — this commit is the bump.

## What shipped since 0.4.14

An external UX/UI audit worked through in passes, plus what fixing it turned up. The common shape: **nothing failed when these broke.**

| | |
|---|---|
| The **retention warning** — that Claude Code is deleting your history — asked for Settings → Retention | and opened whichever pane you last had |
| **View → Agents** in the menu bar | built, shown, inert (emitted the label, not the section id) |
| The **Dock icon** after un-hiding it | fell back to the generic black executable icon |
| **GitHub PR badges** | had never rendered for anyone |
| Every card in the **Activities live strip** | looked clickable, did nothing |
| **`tokens.css`** | five comment blocks with no opener |

Each has a cause worth one line:

- The click router matched the section and dropped the subroute — one branch for two shapes.
- The menu emitted `agents`; the registry id is `automations`, kept for localStorage compatibility.
- A correct, commented fix ran on a tokio worker, and `setApplicationIconImage` is main-thread-only.
- `spawn()` inherits stdio and only `output()` pipes, so git's stdout went to the terminal and the helper read an empty string.
- `LiveSessionCard` takes an *optional* click handler and the strip passed none.
- A line-based codemod removing dead tokens also ate the line each comment opened on.

## Changed

Global → **Config**; live session state has one surface per job; the cursor policy stopped contradicting itself four ways; the dismissed-toast echo is gone; the Dock block is centred (it sat 48 units low); the menubar icon renders **16.4pt instead of 13.9pt** — `tray-icon` normalises the tile to 18pt, so padding was pure loss.

## Internal

Guards for each class, every one verified by planting the defect and watching the check fail. And the `xtask` self-tests now run in CI — they were written to prove the guards could fail, then left out of the test job, so none had ever executed on a push.

## Gate

4061 Rust tests · 1316 React tests · fmt · clippy `-D warnings` · tsc · `check:catalogs` · `verify-docs` · `verify-cc-parity` · 58 icon checks · `pnpm build` with zero warnings.