### PR TITLE
Close every remaining retention opening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -380,6 +380,15 @@ the pane:
 - **Invisible on disk.** Cleanup unlinks top-level session transcripts
   and never walks `subagents/`, so the folder grows while history is
   destroyed. `TranscriptRisk::nested_immortal` exists to say so.
+- **It is not a transcript setting.** `cleanupPeriodDays` is a global
+  TTL over ~20 directories under `~/.claude`, verified against the
+  2.1.233 binary's cleanup module. `TranscriptRisk` counts `projects/`;
+  `claudepot-core::cc_sweep` counts the rest, in the unit CC actually
+  deletes — **files** for some directories, **immediate subdirectories**
+  for others. Counting the wrong unit reports zero and reads as "nothing
+  here", which is why `SweepUnit` is explicit per row. `SWEPT` also
+  classifies each directory `Content` or `Cache` so the exclusion of
+  telemetry and traces is a recorded decision, not an omission.
 
 `TranscriptRisk::scan_incomplete` is load-bearing: a scan that failed
 must never render as "nothing is scheduled for deletion".

--- a/crates/claudepot-core/src/cc_retention.rs
+++ b/crates/claudepot-core/src/cc_retention.rs
@@ -303,6 +303,11 @@ pub struct RetentionReport {
     /// under CC's rules. The pane states this so a large number cannot
     /// read as "solved". See the plan's P0 archive contract.
     pub is_durable_archive: bool,
+    /// What else `cleanupPeriodDays` is aging out. `TranscriptRisk`
+    /// counts `projects/` alone; this is the rest of the same timer, so
+    /// the pane can stop implying that conversations are all it touches.
+    /// See [`crate::cc_sweep`].
+    pub swept_elsewhere: crate::cc_sweep::SweptElsewhere,
 }
 
 /// Resolve settings and scan the live transcript tree. `now_ms` is
@@ -310,9 +315,19 @@ pub struct RetentionReport {
 pub fn report(now_ms: i64, horizon_days: i64) -> RetentionReport {
     let state = resolve_retention();
     let risk = scan_transcript_risk(&state, now_ms, horizon_days);
+    // Same cutoff the transcript scan used, passed rather than
+    // recomputed so the two halves of the pane cannot disagree about
+    // when the guillotine falls. `None` when cleanup is suppressed.
+    let cutoff = if state.cleanup_suppressed {
+        None
+    } else {
+        Some(now_ms.saturating_sub(state.effective_days.saturating_mul(MS_PER_DAY)))
+    };
+    let swept_elsewhere = crate::cc_sweep::scan_swept_in(&claude_config_dir(), cutoff);
     RetentionReport {
         state,
         risk,
+        swept_elsewhere,
         // Always false today. Flipping this is P0's job, not a setting's.
         is_durable_archive: false,
     }
@@ -1186,11 +1201,7 @@ mod tests {
 
         // And the expiring boot check must stay silent: warning about
         // deletion that is not happening is the failure this guards.
-        let report = RetentionReport {
-            state,
-            risk: r,
-            is_durable_archive: false,
-        };
+        let report = rep(state, r);
         assert!(warning(&report).is_none());
         // ...but the *suppressed* check must fire, or the state is
         // invisible outside the pane.
@@ -1325,15 +1336,14 @@ mod tests {
     /// staying silent on zero counts.
     #[test]
     fn incomplete_scan_still_warns() {
-        let r = RetentionReport {
-            state: state_from_configured(SettingValue::Absent),
-            risk: TranscriptRisk {
+        let r = rep(
+            state_from_configured(SettingValue::Absent),
+            TranscriptRisk {
                 scan_incomplete: true,
                 horizon_days: 7,
                 ..Default::default()
             },
-            is_durable_archive: false,
-        };
+        );
         let w = warning(&r).expect("incomplete scan must warn");
         assert!(w.scan_incomplete);
         assert!(w.message().contains("could not read"));
@@ -1345,15 +1355,14 @@ mod tests {
     /// that cannot be happening.
     #[test]
     fn suppressed_cleanup_never_warns_even_on_an_incomplete_scan() {
-        let r = RetentionReport {
-            state: state_from_configured(SettingValue::Present(-1)),
-            risk: TranscriptRisk {
+        let r = rep(
+            state_from_configured(SettingValue::Present(-1)),
+            TranscriptRisk {
                 scan_incomplete: true,
                 horizon_days: 7,
                 ..Default::default()
             },
-            is_durable_archive: false,
-        };
+        );
         assert!(r.state.cleanup_suppressed);
         assert!(warning(&r).is_none());
     }
@@ -1421,6 +1430,7 @@ mod tests {
             state,
             risk,
             is_durable_archive: false,
+            swept_elsewhere: Default::default(),
         }
     }
 

--- a/crates/claudepot-core/src/cc_sweep.rs
+++ b/crates/claudepot-core/src/cc_sweep.rs
@@ -1,0 +1,424 @@
+//! Everything **other than transcripts** that `cleanupPeriodDays` ages
+//! out of `~/.claude`.
+//!
+//! # Why this module exists
+//!
+//! `cleanupPeriodDays` is not a transcript setting. It is a global TTL,
+//! and [`crate::cc_retention::TranscriptRisk`] deliberately counts only
+//! `projects/` — the irreplaceable part, and the only part the pane can
+//! describe in one sentence. That left the rest of the timer invisible:
+//! the pane could say "no saved conversations are scheduled for
+//! deletion" while `file-history/` and `uploads/` were being aged out on
+//! the same cutoff.
+//!
+//! Scoping the sentence fixed the *over-claim*. This module fixes the
+//! *gap*.
+//!
+//! # The two sweep shapes, which decide what to count
+//!
+//! Verified by reading the cleanup module of the installed **2.1.233**
+//! binary, not the changelog — CC 2.1.117's release note announced three
+//! of these directories and the binary shows a far larger set:
+//!
+//! - **`Files { ext }`** — the sweep unlinks *files* directly in the
+//!   directory whose mtime is past the cutoff, filtered by extension
+//!   (`""` means any). Count files.
+//! - **`Subdirs`** — the sweep removes *immediate subdirectories* whose
+//!   mtime is past the cutoff, recursively. Count subdirectories.
+//!
+//! Counting the wrong unit would report zero for half of these, which is
+//! the failure this module exists to remove.
+//!
+//! # Content vs cache, and why the split is explicit
+//!
+//! Only [`SweptKind::Content`] rows are surfaced. A user who loses
+//! `telemetry/` has lost nothing; a user who loses `uploads/` has lost
+//! files they put there. Classifying is a judgement, so it is written
+//! down per row and reviewable, rather than implied by an omission.
+//!
+//! `projects/` is absent on purpose — `cc_retention` owns it.
+
+use std::path::{Path, PathBuf};
+
+/// What the sweep deletes, and therefore what a scan must count.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SweepUnit {
+    /// Files directly in the directory, filtered by extension. `""`
+    /// means every file regardless of extension.
+    Files { ext: &'static str },
+    /// Immediate subdirectories, removed recursively.
+    Subdirs,
+}
+
+/// Whether losing this directory costs the user anything.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SweptKind {
+    /// User work product. Worth reporting.
+    Content,
+    /// Cache or diagnostics — regenerated, or of no value once stale.
+    /// Recorded so the exclusion is a decision rather than an oversight.
+    Cache,
+}
+
+/// One directory CC ages out on the `cleanupPeriodDays` timer.
+#[derive(Clone, Copy, Debug)]
+pub struct SweptSpec {
+    /// Path relative to the CC config dir. `/`-joined here and split on
+    /// the way to a `PathBuf`, so this table stays readable and no
+    /// separator is hardcoded into the lookup — see `rules/paths.md`.
+    pub rel: &'static str,
+    pub unit: SweepUnit,
+    pub kind: SweptKind,
+    /// What the user actually loses. Rendered in the UI, so it is
+    /// written for a reader, not for a maintainer.
+    pub what: &'static str,
+}
+
+/// The verified sweep table for CC 2.1.233.
+///
+/// Re-derive with `cargo xtask cc-drift` when the watchlist's
+/// "`cleanupPeriodDays` sweep scope" row reports movement. Adding a row
+/// here is how that row gets closed; deleting one needs the same
+/// evidence.
+pub const SWEPT: &[SweptSpec] = &[
+    // ── content ────────────────────────────────────────────────────
+    SweptSpec {
+        rel: "tasks",
+        unit: SweepUnit::Subdirs,
+        kind: SweptKind::Content,
+        what: "background task state",
+    },
+    SweptSpec {
+        rel: "file-history",
+        unit: SweepUnit::Subdirs,
+        kind: SweptKind::Content,
+        what: "file edit history",
+    },
+    SweptSpec {
+        rel: "uploads",
+        unit: SweepUnit::Subdirs,
+        kind: SweptKind::Content,
+        what: "files you uploaded",
+    },
+    SweptSpec {
+        rel: "shares",
+        unit: SweepUnit::Subdirs,
+        kind: SweptKind::Content,
+        what: "shared conversations",
+    },
+    SweptSpec {
+        rel: "dump-prompts",
+        unit: SweepUnit::Files { ext: "jsonl" },
+        kind: SweptKind::Content,
+        what: "exported prompts",
+    },
+    SweptSpec {
+        rel: "shell-snapshots",
+        unit: SweepUnit::Files { ext: "sh" },
+        kind: SweptKind::Content,
+        what: "shell environment snapshots",
+    },
+    SweptSpec {
+        rel: "backups",
+        unit: SweepUnit::Files { ext: "" },
+        kind: SweptKind::Content,
+        what: "settings backups",
+    },
+    SweptSpec {
+        rel: "plans",
+        unit: SweepUnit::Files { ext: "md" },
+        kind: SweptKind::Content,
+        what: "saved plans",
+    },
+    // ── cache / diagnostics: counted by nobody, listed by name ──────
+    SweptSpec {
+        rel: "telemetry",
+        unit: SweepUnit::Files { ext: "json" },
+        kind: SweptKind::Cache,
+        what: "telemetry",
+    },
+    SweptSpec {
+        rel: "traces",
+        unit: SweepUnit::Files { ext: "json" },
+        kind: SweptKind::Cache,
+        what: "traces",
+    },
+    SweptSpec {
+        rel: "startup-perf",
+        unit: SweepUnit::Files { ext: "" },
+        kind: SweptKind::Cache,
+        what: "startup timings",
+    },
+    SweptSpec {
+        rel: "mcp-discovery-cache",
+        unit: SweepUnit::Files { ext: "json" },
+        kind: SweptKind::Cache,
+        what: "MCP discovery cache",
+    },
+    SweptSpec {
+        rel: "feedback-bundles",
+        unit: SweepUnit::Files { ext: "zip" },
+        kind: SweptKind::Cache,
+        what: "feedback bundles",
+    },
+    SweptSpec {
+        rel: "session-env",
+        unit: SweepUnit::Subdirs,
+        kind: SweptKind::Cache,
+        what: "per-session environment",
+    },
+    SweptSpec {
+        rel: "jobs",
+        unit: SweepUnit::Subdirs,
+        kind: SweptKind::Cache,
+        what: "finished job records",
+    },
+];
+
+/// Counts for one swept directory.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SweptDir {
+    pub rel: String,
+    pub what: String,
+    pub kind: SweptKind,
+    /// Entries present, in the unit CC deletes.
+    pub entries: u64,
+    /// Entries already past the cutoff — gone at CC's next launch.
+    pub already_deletable: u64,
+}
+
+/// What `cleanupPeriodDays` is aging out beyond the transcript tree.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SweptElsewhere {
+    /// Content directories that exist on this machine and hold at least
+    /// one entry. Empty directories are omitted — render-if-nonzero.
+    pub dirs: Vec<SweptDir>,
+    /// Some directory could not be read. The counts are a floor; never
+    /// render them as a total while this is set.
+    pub scan_incomplete: bool,
+    /// Cache/diagnostic directories skipped by name, so the UI can say
+    /// what it chose not to count instead of leaving it implied.
+    pub cache_dirs_skipped: u64,
+}
+
+impl SweptElsewhere {
+    pub fn total_entries(&self) -> u64 {
+        self.dirs.iter().map(|d| d.entries).sum()
+    }
+    pub fn total_deletable(&self) -> u64 {
+        self.dirs.iter().map(|d| d.already_deletable).sum()
+    }
+}
+
+/// Scan the non-transcript sweep targets under `config_dir`.
+///
+/// `cutoff_ms` is the same cutoff `cc_retention` computes, passed in
+/// rather than recomputed so the two surfaces can never disagree about
+/// when the guillotine falls. Pass `None` when cleanup is suppressed:
+/// nothing is at risk then, and the counts still report what exists.
+pub fn scan_swept_in(config_dir: &Path, cutoff_ms: Option<i64>) -> SweptElsewhere {
+    let mut out = SweptElsewhere::default();
+    for spec in SWEPT {
+        if spec.kind == SweptKind::Cache {
+            out.cache_dirs_skipped += 1;
+            continue;
+        }
+        // Split on '/' and re-join, so the table never embeds a
+        // platform separator into a single component.
+        let mut dir: PathBuf = config_dir.to_path_buf();
+        for part in spec.rel.split('/') {
+            dir.push(part);
+        }
+        let Ok(rd) = std::fs::read_dir(&dir) else {
+            // A directory that does not exist is a real zero, not a
+            // failed read: CC creates these lazily.
+            if dir.exists() {
+                out.scan_incomplete = true;
+            }
+            continue;
+        };
+        let mut entries = 0u64;
+        let mut deletable = 0u64;
+        for ent in rd {
+            let Ok(ent) = ent else {
+                out.scan_incomplete = true;
+                continue;
+            };
+            let Ok(ft) = ent.file_type() else {
+                out.scan_incomplete = true;
+                continue;
+            };
+            let matches = match spec.unit {
+                SweepUnit::Subdirs => ft.is_dir(),
+                SweepUnit::Files { ext } => {
+                    ft.is_file()
+                        && (ext.is_empty()
+                            || ent
+                                .path()
+                                .extension()
+                                .is_some_and(|e| e.eq_ignore_ascii_case(ext)))
+                }
+            };
+            if !matches {
+                continue;
+            }
+            entries += 1;
+            let Ok(md) = ent.metadata() else {
+                out.scan_incomplete = true;
+                continue;
+            };
+            let Some(mtime) = md
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .and_then(|d| i64::try_from(d.as_millis()).ok())
+            else {
+                out.scan_incomplete = true;
+                continue;
+            };
+            if cutoff_ms.is_some_and(|c| mtime < c) {
+                deletable += 1;
+            }
+        }
+        if entries > 0 {
+            out.dirs.push(SweptDir {
+                rel: spec.rel.to_string(),
+                what: spec.what.to_string(),
+                kind: spec.kind,
+                entries,
+                already_deletable: deletable,
+            });
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn touch(p: &Path, age_ms_ago: i64, now: i64) {
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(p, b"x").unwrap();
+        let t = std::time::UNIX_EPOCH
+            + std::time::Duration::from_millis((now - age_ms_ago).max(0) as u64);
+        filetime::set_file_mtime(p, filetime::FileTime::from_system_time(t)).unwrap();
+    }
+
+    fn mkdir(p: &Path, age_ms_ago: i64, now: i64) {
+        fs::create_dir_all(p).unwrap();
+        let t = std::time::UNIX_EPOCH
+            + std::time::Duration::from_millis((now - age_ms_ago).max(0) as u64);
+        filetime::set_file_mtime(p, filetime::FileTime::from_system_time(t)).unwrap();
+    }
+
+    const DAY: i64 = 24 * 60 * 60 * 1000;
+
+    /// The whole point: counting files where CC deletes subdirectories
+    /// (or vice versa) reports zero and reads as "nothing here".
+    #[test]
+    fn each_directory_is_counted_in_the_unit_cc_deletes() {
+        let now = 1_800_000_000_000i64;
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path();
+
+        // Subdirs unit: a loose file must NOT count, a subdir must.
+        mkdir(&cfg.join("file-history").join("a"), 60 * DAY, now);
+        touch(&cfg.join("file-history").join("loose.txt"), 60 * DAY, now);
+
+        // Files unit with an extension filter.
+        touch(&cfg.join("shell-snapshots").join("s1.sh"), 60 * DAY, now);
+        touch(&cfg.join("shell-snapshots").join("notes.md"), 60 * DAY, now);
+
+        let got = scan_swept_in(cfg, Some(now - 30 * DAY));
+        let fh = got.dirs.iter().find(|d| d.rel == "file-history").unwrap();
+        assert_eq!(fh.entries, 1, "subdirs only; the loose file is not a unit");
+        let sh = got
+            .dirs
+            .iter()
+            .find(|d| d.rel == "shell-snapshots")
+            .unwrap();
+        assert_eq!(sh.entries, 1, "only .sh matches the sweep's filter");
+    }
+
+    #[test]
+    fn entries_past_the_cutoff_are_counted_as_deletable() {
+        let now = 1_800_000_000_000i64;
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path();
+        mkdir(&cfg.join("uploads").join("old"), 60 * DAY, now);
+        mkdir(&cfg.join("uploads").join("fresh"), DAY, now);
+        let got = scan_swept_in(cfg, Some(now - 30 * DAY));
+        let up = got.dirs.iter().find(|d| d.rel == "uploads").unwrap();
+        assert_eq!(up.entries, 2);
+        assert_eq!(up.already_deletable, 1);
+    }
+
+    /// Cleanup suppressed ⇒ no cutoff ⇒ nothing is at risk, but what
+    /// exists is still reported. Mirrors `TranscriptRisk`'s behaviour so
+    /// the two halves of the pane cannot contradict each other.
+    #[test]
+    fn a_suppressed_cleanup_puts_nothing_at_risk_but_still_counts() {
+        let now = 1_800_000_000_000i64;
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path();
+        mkdir(&cfg.join("uploads").join("old"), 900 * DAY, now);
+        let got = scan_swept_in(cfg, None);
+        let up = got.dirs.iter().find(|d| d.rel == "uploads").unwrap();
+        assert_eq!(up.entries, 1);
+        assert_eq!(up.already_deletable, 0);
+    }
+
+    #[test]
+    fn cache_directories_are_skipped_and_counted_as_skipped() {
+        let now = 1_800_000_000_000i64;
+        let tmp = TempDir::new().unwrap();
+        let cfg = tmp.path();
+        touch(&cfg.join("telemetry").join("t.json"), 60 * DAY, now);
+        let got = scan_swept_in(cfg, Some(now - 30 * DAY));
+        assert!(got.dirs.iter().all(|d| d.rel != "telemetry"));
+        assert_eq!(
+            got.cache_dirs_skipped,
+            SWEPT.iter().filter(|s| s.kind == SweptKind::Cache).count() as u64,
+            "the UI states how many it chose not to count"
+        );
+    }
+
+    /// An absent directory is a real zero — CC creates these lazily, so
+    /// treating "missing" as "unreadable" would flag every fresh install
+    /// as an incomplete scan.
+    #[test]
+    fn a_missing_directory_is_not_an_incomplete_scan() {
+        let tmp = TempDir::new().unwrap();
+        let got = scan_swept_in(tmp.path(), Some(0));
+        assert!(got.dirs.is_empty());
+        assert!(!got.scan_incomplete);
+    }
+
+    /// Empty directories are omitted so the pane never renders
+    /// "0 entries" rows — design.md's render-if-nonzero rule.
+    #[test]
+    fn empty_directories_are_omitted() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("uploads")).unwrap();
+        let got = scan_swept_in(tmp.path(), Some(0));
+        assert!(got.dirs.is_empty());
+    }
+
+    /// Every content row must carry prose a user can read; a row whose
+    /// `what` is a directory name has not been written for anyone.
+    #[test]
+    fn every_content_row_explains_what_is_lost() {
+        for s in SWEPT.iter().filter(|s| s.kind == SweptKind::Content) {
+            assert!(!s.what.is_empty(), "{} has no description", s.rel);
+            assert!(
+                s.what != s.rel,
+                "{} describes itself with its own path",
+                s.rel
+            );
+        }
+    }
+}

--- a/crates/claudepot-core/src/lib.rs
+++ b/crates/claudepot-core/src/lib.rs
@@ -49,6 +49,7 @@ pub mod cc_daemon;
 pub mod cc_doctor;
 pub mod cc_env;
 pub mod cc_retention;
+pub mod cc_sweep;
 pub mod cc_tips;
 pub mod cli_backend;
 pub(crate) mod codex_session;

--- a/crates/claudepot-core/src/notifications.rs
+++ b/crates/claudepot-core/src/notifications.rs
@@ -357,6 +357,14 @@ impl Category {
             RotationSuggested,
             UsageThreshold,
             UpdateInstallReady,
+            // Both retention categories are P1. `all()` drives the
+            // Settings pane's display order via the metadata IPC, so
+            // leaving them at the tail listed two P1 rows under the
+            // P3/Background group. The *enum body* is deliberately not
+            // reordered — the file's own rule — but nothing depends on
+            // `all()` matching it, and serde keys on variant names.
+            TranscriptsExpiring,
+            TranscriptCleanupSuppressed,
             AccountVerified,
             AccountSwitched,
             ProjectRenamed,
@@ -376,8 +384,6 @@ impl Category {
             ConfigTreePatched,
             ServiceStatusChanged,
             UpdateAvailable,
-            TranscriptsExpiring,
-            TranscriptCleanupSuppressed,
         ]
     }
 }

--- a/crates/xtask/cc-upstream-watch.md
+++ b/crates/xtask/cc-upstream-watch.md
@@ -96,7 +96,7 @@ truncates mid-transfer, which diffs as "hundreds of pages removed".
 | CC surface | Claudepot owner | Grep tokens | Check |
 |---|---|---|---|
 | `cleanupPeriodDays` semantics + floor | `cc_retention` | `cleanupPeriodDays`, `session-persistence`, `persistSession` | binary strings; `claude --help`; `MIN_CLEANUP_PERIOD_DAYS` is the pin |
-| `cleanupPeriodDays` sweep scope | `cc_retention::TranscriptRisk` | `shell-snapshots`, `dump-prompts`, `file-history`, `retention sweep` | binary: grep the cleanup module's sweep fns. **Known gap** — we count `projects/` only; CC ages out ~20 dirs on this timer |
+| `cleanupPeriodDays` sweep scope | `cc_sweep::SWEPT` | `shell-snapshots`, `dump-prompts`, `file-history`, `retention sweep` | binary: grep the cleanup module's sweep fns, then reconcile against the `SWEPT` table. A new directory is a new row; a changed sweep unit (files vs subdirs) silently makes a count read zero |
 | settings-validation → cleanup suppression | `cc_retention::RetentionMode::Invalid` / `LegacyZero` | `Skipping cleanup`, `validation errors` | binary strings |
 | env var catalog + `SAFE_ENV_VARS` | `cc_env`, `data/cc-env-spec.json` | `CLAUDE_*`, `ANTHROPIC_*`, `SAFE_ENV_VARS`, `PROVIDER_MANAGED` | `scripts/build-cc-env-spec.py --rebuild-evidence` then `--check` |
 | settings merge precedence | `config_view::effective_settings`, `parity-harness/` | `settings.local.json`, `managed-settings`, `--setting-sources`, `settingSources` | `cargo xtask verify-cc-parity` + re-pin |

--- a/crates/xtask/src/cc_drift.rs
+++ b/crates/xtask/src/cc_drift.rs
@@ -472,7 +472,96 @@ fn base64_decode(s: &str) -> Result<Vec<u8>> {
     Ok(out)
 }
 
+/// Render the artifacts we could not read. Printed first and
+/// unconditionally: everything after it is only as trustworthy as the
+/// inputs, and a skipped input used to be invisible.
+fn render_problems(problems: &[String]) {
+    if problems.is_empty() {
+        return;
+    }
+    println!("PIN ARTIFACTS UNREADABLE — this report is incomplete:");
+    for p in problems {
+        println!("  ! {p}");
+    }
+    println!();
+}
+
+/// Render freshness evidence and version pins. Kept apart because a
+/// date is not comparable to a version; conflating them printed a
+/// permanent, meaningless "BEHIND" row.
+fn render_pins(installed: &str, pins: &[Pin]) {
+    let fresh: Vec<&Pin> = pins
+        .iter()
+        .filter(|p| p.kind == PinKind::Freshness)
+        .collect();
+    if !fresh.is_empty() {
+        println!("freshness evidence (not version-comparable):");
+        for p in &fresh {
+            println!("  {} · {} = {}", p.artifact, p.field, p.value);
+            println!("      → {}", p.when_stale);
+        }
+        println!();
+    }
+
+    let stale = compare_pins(installed, pins);
+    if stale.is_empty() {
+        println!("version pins: all current\n");
+    } else {
+        println!("version pins BEHIND {installed}:");
+        for f in &stale {
+            println!(
+                "  {} · {} = {}\n      → {}",
+                f.pin.artifact, f.pin.field, f.pin.value, f.pin.when_stale
+            );
+        }
+        println!();
+    }
+}
+
+/// Render the changelog scan, collapsed by surface.
+fn render_changelog(rows: &[WatchRow], text: &str, since: &str) {
+    let newer = parse_changelog(text)
+        .iter()
+        .filter(|r| is_newer(&r.version, since))
+        .count();
+    let hits = scan_changelog(rows, text, since);
+    let grouped = group_hits(&hits);
+    println!("changelog: {newer} releases newer than {since}");
+    if grouped.is_empty() {
+        println!("  no watchlist token mentioned — checked, green\n");
+        return;
+    }
+    println!(
+        "  {} surfaces mentioned across {} bullets:\n",
+        grouped.len(),
+        hits.len()
+    );
+    for r in &grouped {
+        println!(
+            "  {} — {} mention{}, newest {}",
+            r.surface,
+            r.mentions,
+            if r.mentions == 1 { "" } else { "s" },
+            r.newest
+        );
+        println!("      owner: {}", r.owner);
+        println!("      check: {}", r.check);
+        for (v, e) in &r.examples {
+            println!("      [{v}] {e}");
+        }
+        // Never let a cap read as completeness.
+        if r.mentions > r.examples.len() {
+            println!("      (+{} more)", r.mentions - r.examples.len());
+        }
+        println!();
+    }
+}
+
 /// Entry point for `cargo xtask cc-drift`.
+///
+/// Measurement and orchestration only — every judgement it prints comes
+/// from a pure function above, so the interesting logic is testable
+/// without a Claude Code install.
 pub fn run(root: &Path, args: &[String]) -> Result<()> {
     let arg = |name: &str| -> Option<&str> {
         args.iter()
@@ -503,52 +592,10 @@ pub fn run(root: &Path, args: &[String]) -> Result<()> {
     println!("cc-drift: installed Claude Code {installed}");
     println!("          {} watchlist rows\n", rows.len());
 
-    // ── artifacts we could not read ──
-    // Printed first and unconditionally: everything below is only as
-    // trustworthy as the inputs, and a skipped input used to be
-    // invisible.
-    if !pin_problems.is_empty() {
-        println!("PIN ARTIFACTS UNREADABLE — this report is incomplete:");
-        for p in &pin_problems {
-            println!("  ! {p}");
-        }
-        println!();
-    }
+    render_problems(&pin_problems);
+    render_pins(&installed, &pins);
 
-    // ── freshness evidence (dates/hashes, never compared to a version) ──
-    let fresh: Vec<&Pin> = pins
-        .iter()
-        .filter(|p| p.kind == PinKind::Freshness)
-        .collect();
-    if !fresh.is_empty() {
-        println!("freshness evidence (not version-comparable):");
-        for p in &fresh {
-            println!("  {} · {} = {}", p.artifact, p.field, p.value);
-            println!("      → {}", p.when_stale);
-        }
-        println!();
-    }
-
-    // ── version pins ──
-    let stale = compare_pins(&installed, &pins);
-    if stale.is_empty() {
-        println!("version pins: all current\n");
-    } else {
-        println!("version pins BEHIND {installed}:");
-        for f in &stale {
-            println!(
-                "  {} · {} = {}\n      → {}",
-                f.pin.artifact, f.pin.field, f.pin.value, f.pin.when_stale
-            );
-        }
-        println!();
-    }
-
-    // ── changelog ──
     let Some(since) = since else {
-        // No baseline, so no range — and therefore no honest way to say
-        // "N releases newer" or "green". Stop here rather than print a
-        // number derived from a guess.
         println!(
             "changelog: NOT CHECKED — no baseline. Pass --since <version>, or restore \
              parity-harness/PINNED_CC_VERSION.\n"
@@ -559,45 +606,9 @@ pub fn run(root: &Path, args: &[String]) -> Result<()> {
         );
         return Ok(());
     };
+
     match load_changelog(arg("--changelog")) {
-        Ok(text) => {
-            let releases = parse_changelog(&text);
-            let newer = releases
-                .iter()
-                .filter(|r| is_newer(&r.version, &since))
-                .count();
-            let hits = scan_changelog(&rows, &text, &since);
-            let grouped = group_hits(&hits);
-            println!("changelog: {newer} releases newer than {since}");
-            if grouped.is_empty() {
-                println!("  no watchlist token mentioned — checked, green\n");
-            } else {
-                println!(
-                    "  {} surfaces mentioned across {} bullets:\n",
-                    grouped.len(),
-                    hits.len()
-                );
-                for r in &grouped {
-                    println!(
-                        "  {} — {} mention{}, newest {}",
-                        r.surface,
-                        r.mentions,
-                        if r.mentions == 1 { "" } else { "s" },
-                        r.newest
-                    );
-                    println!("      owner: {}", r.owner);
-                    println!("      check: {}", r.check);
-                    for (v, e) in &r.examples {
-                        println!("      [{v}] {e}");
-                    }
-                    // Never let a cap read as completeness.
-                    if r.mentions > r.examples.len() {
-                        println!("      (+{} more)", r.mentions - r.examples.len());
-                    }
-                    println!();
-                }
-            }
-        }
+        Ok(text) => render_changelog(&rows, &text, &since),
         Err(e) => {
             // A failed fetch must not read as "nothing changed".
             println!("changelog: NOT CHECKED — {e}");

--- a/parity-harness/README.md
+++ b/parity-harness/README.md
@@ -91,6 +91,60 @@ treat a CC minor-version jump or a quarter — whichever comes first —
 as the trigger to diff `utils/settings/settings.ts` between pinned and
 current and re-derive anything that moved.
 
+### 4.0 Decision (2026-08-18): the pin stays at 2.1.88 — deliberately
+
+Re-pin or freeze was an open question after CC reached 2.1.233. It is
+now answered **freeze**, with the evidence, so nobody re-opens it from
+scratch.
+
+**What was re-verified against the installed 2.1.233 binary.** The
+top-level source precedence array is byte-identical to what these
+fixtures model:
+
+```text
+["userSettings","projectSettings","localSettings","flagSettings","policySettings"]
+```
+
+So the merge ordering these goldens lock has *not* moved in 145
+releases. The fixtures still describe current CC on the axis they test.
+
+**What was NOT re-verified, and why the pin therefore does not move.**
+Null-clobber, array concat + dedupe, hooks concat order, and the policy
+sub-ordering (remote → mdm → managed-file → hkcu) were not re-derived
+against 2.1.233. Doing so needs CC's merge implementation, and §4's
+adapter gap is still shut — re-confirmed on 2.1.233:
+
+- no `--dump-settings` / `--dump-effective-settings` flag exists
+  (`claude --help`, checked 2026-08-18, same as the 2.1.88 finding);
+- CC now ships as a bun-compiled native binary, so there is no source
+  tree to install a shim into and no exported API to call;
+- the embedded bundle is minified, so reading the merge function is
+  archaeology, not verification.
+
+Bumping the pin would require rewriting twelve `notes.md` files to claim
+a re-derivation that did not happen. The harness deliberately fails a
+pin bump that skips that work — and satisfying it with an unearned claim
+is worse than an honest old pin, because CI would then enforce the lie.
+
+**So the pin is a statement of provenance, not of currency.** These
+goldens lock the merge semantics *as verified at 2.1.88*, and the one
+axis re-checked since is unchanged. Read `PINNED_CC_VERSION` as "derived
+from", never as "current as of".
+
+**Known uncovered surface**, tracked in
+`crates/xtask/cc-upstream-watch.md` under "settings merge precedence"
+rather than left implicit here:
+
+- `--setting-sources` can disable a whole source (added after 2.1.88).
+  Neither these fixtures nor `config_view::effective_settings` model it.
+- Managed settings now merge their `env` block per key rather than
+  wholesale.
+
+Both are *new surface*, not changed precedence — which is why they do
+not invalidate the existing twelve. Reopen this decision when the
+adapter gap opens (a `--dump-*` flag, or an exported API), not on a
+calendar.
+
 Plan §8.6 describes three candidate strategies for auto-regenerating
 `expected.json` from a real CC tree. Today none of them work
 out-of-the-box for the published CC source:

--- a/src-tauri/src/retention_boot_check.rs
+++ b/src-tauri/src/retention_boot_check.rs
@@ -324,6 +324,7 @@ mod tests {
                 ..Default::default()
             },
             is_durable_archive: false,
+            swept_elsewhere: Default::default(),
         }
     }
 

--- a/src/api/cc-retention.ts
+++ b/src/api/cc-retention.ts
@@ -63,12 +63,37 @@ export interface TranscriptRisk {
   scan_incomplete: boolean;
 }
 
+/** One directory CC ages out on the same `cleanupPeriodDays` timer,
+ *  other than `projects/`. Counted in the unit CC deletes: files for
+ *  some directories, immediate subdirectories for others. */
+export interface SweptDir {
+  rel: string;
+  /** Prose for a reader — "file edit history", not "file-history". */
+  what: string;
+  kind: "content" | "cache";
+  entries: number;
+  already_deletable: number;
+}
+
+/** What `cleanupPeriodDays` is aging out beyond the transcript tree.
+ *  Only `content` directories are counted; `cache_dirs_skipped` records
+ *  how many were deliberately not, so the omission is stated rather
+ *  than implied. */
+export interface SweptElsewhere {
+  dirs: SweptDir[];
+  /** Counts are a floor. Never render them as a total while set. */
+  scan_incomplete: boolean;
+  cache_dirs_skipped: number;
+}
+
 export interface RetentionReport {
   state: RetentionState;
   risk: TranscriptRisk;
   /** Raising the window buys time; it does not make the corpus
    *  durable. Always false until the archive contract ships. */
   is_durable_archive: boolean;
+  /** The rest of the same timer — see `SweptElsewhere`. */
+  swept_elsewhere: SweptElsewhere;
 }
 
 export const ccRetentionApi = {

--- a/src/lib/notifications/__fixtures__/categories.fixture.json
+++ b/src/lib/notifications/__fixtures__/categories.fixture.json
@@ -75,6 +75,18 @@
     },
     {
       "defaultEnabled": true,
+      "group": "Live work",
+      "id": "transcriptsExpiring",
+      "priority": "p1Stalled"
+    },
+    {
+      "defaultEnabled": true,
+      "group": "Live work",
+      "id": "transcriptCleanupSuppressed",
+      "priority": "p1Stalled"
+    },
+    {
+      "defaultEnabled": true,
       "group": "Actions",
       "id": "accountVerified",
       "priority": "p2Acknowledge"
@@ -186,18 +198,6 @@
       "group": "Background",
       "id": "updateAvailable",
       "priority": "p3Ambient"
-    },
-    {
-      "defaultEnabled": true,
-      "group": "Live work",
-      "id": "transcriptsExpiring",
-      "priority": "p1Stalled"
-    },
-    {
-      "defaultEnabled": true,
-      "group": "Live work",
-      "id": "transcriptCleanupSuppressed",
-      "priority": "p1Stalled"
     }
   ]
 }

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -428,7 +428,15 @@
       "bodyCount": "Claude Code is skipping cleanup right now, so nothing is being deleted — {{num}} transcripts are currently kept. Setting a window <strong>re-enables deletion</strong>: everything older than {{label}} goes the next time Claude Code starts. This cannot be undone.",
       "confirm": "Set window and re-enable deletion"
     },
-    "scopeNote": "cleanupPeriodDays is not only a transcript setting — Claude Code ages out around twenty directories under ~/.claude on the same timer, including tasks, file-history, shell-snapshots and backups. Claudepot counts conversations, the part that cannot be regenerated; the others are not shown here."
+    "scopeNote": "cleanupPeriodDays is not only a transcript setting — Claude Code ages out around twenty directories under ~/.claude on the same timer, including tasks, file-history, shell-snapshots and backups. Claudepot counts conversations, the part that cannot be regenerated; the others are not shown here.",
+    "swept": {
+      "title": "Also on this timer",
+      "lead": "cleanupPeriodDays is not only a transcript setting. Claude Code ages out these directories on the same schedule:",
+      "row": "{{what}} — {{entries}} in {{dir}}",
+      "rowAtRisk": "{{what}} — {{entries}} in {{dir}}, {{deletable}} past the cutoff",
+      "skipped": "{{count}} further directories hold only caches and diagnostics; Claudepot does not count those.",
+      "incomplete": "Part of this could not be read, so these counts are a floor."
+    }
   },
   "health": {
     "refreshFailed": "Health refresh failed",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -424,7 +424,15 @@
       "bodyCount": "Claude Code 目前正跳过清理，因此没有任何内容被删除——当前保留着 {{num}} 份对话记录。设置保留时长会<strong>重新启用删除</strong>：早于 {{label}} 的内容将在 Claude Code 下次启动时被清除。此操作无法撤销。",
       "confirm": "设置并重新启用删除"
     },
-    "scopeNote": "cleanupPeriodDays 并不只是对话记录的设置——Claude Code 会按同一时限清理 ~/.claude 下约二十个目录，包括 tasks、file-history、shell-snapshots 和 backups。Claudepot 统计的是无法再生的对话记录，其余目录不在此处显示。"
+    "scopeNote": "cleanupPeriodDays 并不只是对话记录的设置——Claude Code 会按同一时限清理 ~/.claude 下约二十个目录，包括 tasks、file-history、shell-snapshots 和 backups。Claudepot 统计的是无法再生的对话记录，其余目录不在此处显示。",
+    "swept": {
+      "title": "同一时限下的其他数据",
+      "lead": "cleanupPeriodDays 并不只是对话记录的设置。Claude Code 会按同一时限清理这些目录：",
+      "row": "{{what}} —— {{dir}} 中有 {{entries}} 项",
+      "rowAtRisk": "{{what}} —— {{dir}} 中有 {{entries}} 项，其中 {{deletable}} 项已过期",
+      "skipped": "另有 {{count}} 个目录只存放缓存与诊断数据，Claudepot 不统计它们。",
+      "incomplete": "其中一部分无法读取，因此这些数字只是下限。"
+    }
   },
   "health": {
     "refreshFailed": "健康检查刷新失败",

--- a/src/sections/settings/RetentionPane.test.tsx
+++ b/src/sections/settings/RetentionPane.test.tsx
@@ -25,6 +25,7 @@ import { RetentionPane } from "./RetentionPane";
 function report(over: {
   state?: Partial<RetentionReport["state"]>;
   risk?: Partial<RetentionReport["risk"]>;
+  swept?: Partial<RetentionReport["swept_elsewhere"]>;
 } = {}): RetentionReport {
   return {
     state: {
@@ -46,6 +47,12 @@ function report(over: {
       ...over.risk,
     },
     is_durable_archive: false,
+    swept_elsewhere: {
+      dirs: [],
+      scan_incomplete: false,
+      cache_dirs_skipped: 7,
+      ...over.swept,
+    },
   };
 }
 
@@ -117,6 +124,37 @@ describe("RetentionPane", () => {
     ).toBeInTheDocument();
     // The unscoped claim must not survive anywhere on the surface.
     expect(screen.queryByText(/^Nothing is scheduled for deletion\.$/)).toBeNull();
+  });
+
+  // The gap the scope note names in prose, now quantified. Counting
+  // conversations alone and saying nothing about the rest was the
+  // smaller version of the same over-claim.
+  it("quantifies the other directories on the same timer", async () => {
+    retentionReportMock.mockResolvedValue(
+      report({
+        swept: {
+          dirs: [
+            { rel: "file-history", what: "file edit history", kind: "content", entries: 412, already_deletable: 91 },
+            { rel: "uploads", what: "files you uploaded", kind: "content", entries: 7, already_deletable: 0 },
+          ],
+          cache_dirs_skipped: 7,
+        },
+      }),
+    );
+    render(<RetentionPane pushToast={toast()} />);
+    expect(await screen.findByText(/file edit history/i)).toBeInTheDocument();
+    expect(screen.getByText(/91 past the cutoff/i)).toBeInTheDocument();
+    // The directories it chose NOT to count are stated, not implied.
+    expect(screen.getByText(/7 further directories/i)).toBeInTheDocument();
+  });
+
+  // design.md render-if-nonzero: a machine with nothing else on the
+  // timer must not grow an empty section.
+  it("omits the swept panel entirely when nothing else is on the timer", async () => {
+    retentionReportMock.mockResolvedValue(report());
+    render(<RetentionPane pushToast={toast()} />);
+    await screen.findByRole("button", { name: "30 days" });
+    expect(screen.queryByText(/Also on this timer/i)).toBeNull();
   });
 
   it("says a longer window is not a backup", async () => {

--- a/src/sections/settings/RetentionPane.tsx
+++ b/src/sections/settings/RetentionPane.tsx
@@ -69,6 +69,182 @@ function fmtDate(ms: number | null): string | null {
   return new Date(ms).toISOString().slice(0, 10);
 }
 
+/** The consequence block: what is scheduled to go, and what the counts
+ *  do and do not cover. Extracted so the pane's own render function is
+ *  an outline rather than the whole surface. */
+function RiskSummary({ report }: { report: RetentionReport }) {
+  const { t } = useTranslation("settings");
+  const { state, risk } = report;
+  const atRiskTotal = risk.already_deletable + risk.at_risk_within_horizon;
+  const oldest = fmtDate(risk.oldest_ms);
+
+  // Headline severity: anything already past the cutoff is live loss.
+  // A legacy zero is NOT danger — nothing is being deleted in that
+  // state. It is a warning, because what the user believes is happening
+  // and what is happening have come apart.
+  const severity =
+    risk.already_deletable > 0
+      ? "var(--danger)"
+      : atRiskTotal > 0 || state.cleanup_suppressed
+        ? "var(--warn)"
+        : "var(--fg-muted)";
+
+  const modeLine =
+    state.mode === "cc_default"
+      ? t("retention.modeDefault", { days: state.effective_days })
+      : state.mode === "legacy_zero"
+        ? t("retention.modeLegacyZero")
+        : state.mode === "invalid"
+          ? t("retention.modeInvalid", { days: state.configured_days })
+          : t("retention.modeDays", { days: state.effective_days });
+
+  return (
+    <div>
+      <SectionLabel>{t("retention.sectionTitle")}</SectionLabel>
+      <div
+        style={{
+          fontSize: "var(--fs-md)",
+          color: severity,
+          marginTop: "var(--sp-6)",
+        }}
+      >
+        {modeLine}
+      </div>
+
+      {/* Consequence first. Render-if-nonzero: when nothing is at
+          risk this collapses to the single reassuring line below. */}
+      <div
+        style={{
+          marginTop: "var(--sp-8)",
+          fontSize: "var(--fs-sm)",
+          color: "var(--fg-muted)",
+          lineHeight: "var(--lh-body)",
+        }}
+      >
+        {risk.already_deletable > 0 && (
+          <div style={{ color: "var(--danger)" }}>
+            {t("retention.risk.deletable", {
+              // `count` drives i18next's plural selection and must be
+              // the raw number; `num` carries the grouped display form.
+              count: risk.already_deletable,
+              num: formatNumber(risk.already_deletable),
+            })}
+          </div>
+        )}
+        {risk.at_risk_within_horizon > 0 && (
+          <div style={{ color: "var(--warn)" }}>
+            {t("retention.risk.horizon", {
+              count: risk.at_risk_within_horizon,
+              num: formatNumber(risk.at_risk_within_horizon),
+              days: risk.horizon_days,
+            })}
+          </div>
+        )}
+        {/* Never reassure on an incomplete scan — a permissions
+            failure must not read as "all clear". */}
+        {risk.scan_incomplete && (
+          <div style={{ color: "var(--warn)" }}>
+            {t("retention.risk.scanIncomplete")}
+          </div>
+        )}
+        {atRiskTotal === 0 && !risk.scan_incomplete && (
+          <div>
+            {t("retention.risk.nothing")}
+            {/* render-if-nonzero: never ship "0 transcripts". */}
+            {risk.total_transcripts > 0 && (
+              <>
+                {" "}
+                {t("retention.risk.totalOnMachine", {
+                  count: risk.total_transcripts,
+                  num: formatNumber(risk.total_transcripts),
+                })}
+              </>
+            )}
+          </div>
+        )}
+        {/* Both suppressed states protect transcripts by accident, but
+            they need different sentences: `invalid` is a value to
+            correct, `legacy_zero` is a control that used to work and
+            was withdrawn upstream. */}
+        {state.cleanup_suppressed && (
+          <div style={{ color: "var(--warn)" }}>
+            {state.mode === "legacy_zero"
+              ? t("retention.risk.suppressedLegacyZero")
+              : t("retention.risk.suppressed")}
+          </div>
+        )}
+        {oldest && (
+          <div style={{ marginTop: "var(--sp-3)" }}>
+            {t("retention.risk.oldest", { date: oldest })}
+          </div>
+        )}
+        <div style={{ marginTop: "var(--sp-3)", color: "var(--fg-faint)" }}>
+          {t("retention.risk.silent")}
+        </div>
+        <div style={{ marginTop: "var(--sp-3)", color: "var(--fg-faint)" }}>
+          {t("retention.scopeNote")}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Everything else `cleanupPeriodDays` ages out. The counts above are
+ *  conversations only; without this the pane names the gap in prose but
+ *  never quantifies it, which is a smaller version of the same
+ *  over-claim. Entirely absent when nothing else is on the timer. */
+function SweptPanel({ swept }: { swept: RetentionReport["swept_elsewhere"] }) {
+  const { t } = useTranslation("settings");
+  if (swept.dirs.length === 0) return null;
+  return (
+    <div>
+      <SectionLabel>{t("retention.swept.title")}</SectionLabel>
+      <div
+        style={{
+          marginTop: "var(--sp-8)",
+          fontSize: "var(--fs-sm)",
+          color: "var(--fg-muted)",
+          lineHeight: "var(--lh-body)",
+        }}
+      >
+        <div>{t("retention.swept.lead")}</div>
+        {swept.dirs.map((d) => (
+          <div
+            key={d.rel}
+            style={{
+              marginTop: "var(--sp-3)",
+              color: d.already_deletable > 0 ? "var(--warn)" : undefined,
+            }}
+          >
+            {d.already_deletable > 0
+              ? t("retention.swept.rowAtRisk", {
+                  what: d.what,
+                  dir: d.rel,
+                  entries: formatNumber(d.entries),
+                  deletable: formatNumber(d.already_deletable),
+                })
+              : t("retention.swept.row", {
+                  what: d.what,
+                  dir: d.rel,
+                  entries: formatNumber(d.entries),
+                })}
+          </div>
+        ))}
+        {swept.scan_incomplete && (
+          <div style={{ marginTop: "var(--sp-3)", color: "var(--warn)" }}>
+            {t("retention.swept.incomplete")}
+          </div>
+        )}
+        {swept.cache_dirs_skipped > 0 && (
+          <div style={{ marginTop: "var(--sp-3)", color: "var(--fg-faint)" }}>
+            {t("retention.swept.skipped", { count: swept.cache_dirs_skipped })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function RetentionPane({
   pushToast,
 }: {
@@ -143,29 +319,10 @@ export function RetentionPane({
     return <SkeletonList rows={3} label={t("shared.loading")} />;
   }
 
+  // Severity, the mode line and the risk copy all moved into
+  // <RiskSummary>; this function keeps only what the interactive
+  // controls need.
   const { state, risk, is_durable_archive } = report;
-  const atRiskTotal = risk.already_deletable + risk.at_risk_within_horizon;
-  const oldest = fmtDate(risk.oldest_ms);
-
-  // Headline severity: anything already past the cutoff is live loss.
-  // A legacy zero is NOT danger — nothing is being deleted in that
-  // state. It is a warning, because what the user believes is happening
-  // and what is happening have come apart.
-  const severity =
-    risk.already_deletable > 0
-      ? "var(--danger)"
-      : atRiskTotal > 0 || state.cleanup_suppressed
-        ? "var(--warn)"
-        : "var(--fg-muted)";
-
-  const modeLine =
-    state.mode === "cc_default"
-      ? t("retention.modeDefault", { days: state.effective_days })
-      : state.mode === "legacy_zero"
-        ? t("retention.modeLegacyZero")
-        : state.mode === "invalid"
-          ? t("retention.modeInvalid", { days: state.configured_days })
-          : t("retention.modeDays", { days: state.effective_days });
 
   return (
     <div
@@ -176,104 +333,8 @@ export function RetentionPane({
         maxWidth: "var(--content-cap-lg)",
       }}
     >
-      <div>
-        <SectionLabel>{t("retention.sectionTitle")}</SectionLabel>
-        <div
-          style={{
-            fontSize: "var(--fs-md)",
-            color: severity,
-            marginTop: "var(--sp-6)",
-          }}
-        >
-          {modeLine}
-        </div>
-
-        {/* Consequence first. Render-if-nonzero: when nothing is at
-            risk this collapses to the single reassuring line below. */}
-        <div
-          style={{
-            marginTop: "var(--sp-8)",
-            fontSize: "var(--fs-sm)",
-            color: "var(--fg-muted)",
-            lineHeight: "var(--lh-body)",
-          }}
-        >
-          {risk.already_deletable > 0 && (
-            <div style={{ color: "var(--danger)" }}>
-              {t("retention.risk.deletable", {
-                // `count` drives i18next's plural selection and must be
-                // the raw number; `num` carries the grouped display form
-                // (`1,234`). Both are required — this key was already
-                // correct; `horizon` and `totalOnMachine` below were not.
-                count: risk.already_deletable,
-                num: formatNumber(risk.already_deletable),
-              })}
-            </div>
-          )}
-          {risk.at_risk_within_horizon > 0 && (
-            <div style={{ color: "var(--warn)" }}>
-              {t("retention.risk.horizon", {
-                count: risk.at_risk_within_horizon,
-                num: formatNumber(risk.at_risk_within_horizon),
-                days: risk.horizon_days,
-              })}
-            </div>
-          )}
-          {/* Never reassure on an incomplete scan — a permissions
-              failure must not read as "all clear". */}
-          {risk.scan_incomplete && (
-            <div style={{ color: "var(--warn)" }}>
-              {t("retention.risk.scanIncomplete")}
-            </div>
-          )}
-          {atRiskTotal === 0 && !risk.scan_incomplete && (
-            <div>
-              {t("retention.risk.nothing")}
-              {/* render-if-nonzero: never ship "0 transcripts". */}
-              {risk.total_transcripts > 0 && (
-                <>
-                  {" "}
-                  {t("retention.risk.totalOnMachine", {
-                    count: risk.total_transcripts,
-                    num: formatNumber(risk.total_transcripts),
-                  })}
-                </>
-              )}
-            </div>
-          )}
-          {/* Both suppressed states protect transcripts by accident, but
-              they need different sentences: `invalid` is a value to
-              correct, `legacy_zero` is a control that used to work and
-              was withdrawn upstream. Telling a legacy-zero user to "fix
-              the value" would be advice they cannot act on — the value
-              was written by this app, on purpose, and the state they
-              chose no longer exists. */}
-          {state.cleanup_suppressed && (
-            <div style={{ color: "var(--warn)" }}>
-              {state.mode === "legacy_zero"
-                ? t("retention.risk.suppressedLegacyZero")
-                : t("retention.risk.suppressed")}
-            </div>
-          )}
-          {oldest && (
-            <div style={{ marginTop: "var(--sp-3)" }}>
-              {t("retention.risk.oldest", { date: oldest })}
-            </div>
-          )}
-          <div style={{ marginTop: "var(--sp-3)", color: "var(--fg-faint)" }}>
-            {t("retention.risk.silent")}
-          </div>
-          {/* `cleanupPeriodDays` is a global TTL over ~20 directories
-              under ~/.claude, not a transcript setting — verified
-              against the 2.1.233 binary, see `TranscriptRisk`. The
-              counts above are conversations only, so without this the
-              pane's reassurance reads as "nothing anywhere is being
-              deleted", which is false. */}
-          <div style={{ marginTop: "var(--sp-3)", color: "var(--fg-faint)" }}>
-            {t("retention.scopeNote")}
-          </div>
-        </div>
-      </div>
+      <RiskSummary report={report} />
+      <SweptPanel swept={report.swept_elsewhere} />
 
       {/* Why the folder keeps growing while history shrinks. Only shown
           when there is actually a nested pile to explain. */}


### PR DESCRIPTION
Closes every remaining opening from the v0.4.16 work: the scan-scope gap,
three deferred audit findings, and two design questions.

## The gap: `cleanupPeriodDays` is a global TTL

v0.4.16 stopped the pane over-claiming, but still counted one directory
out of ~20. `claudepot-core::cc_sweep` counts the rest.

Two things make it correct rather than approximate, both read out of the
2.1.233 binary's cleanup module:

- **The sweep has two shapes.** `B6(dir, ext)` unlinks **files** by
  extension; `FQe(dir)` removes immediate **subdirectories** by mtime.
  Counting the wrong unit reports zero — which reads as "nothing here",
  the same silent-zero failure this area keeps producing. `SweepUnit` is
  explicit per row, with a test asserting both shapes.
- **Content vs cache is a judgement, written down.** Losing `telemetry/`
  costs nothing; losing `uploads/` costs the user files they put there.
  Only Content rows surface, and the count of skipped Cache directories
  is reported — a stated decision, not an omission.

The cutoff is passed in from `cc_retention`, never recomputed, so the two
halves of the pane cannot disagree about when the guillotine falls.

## Deferred findings, now closed

| # | |
|---|---|
| 8 | `cc_drift::run()` → three renderers; 60 lines of orchestration, from 94 |
| 11 | both retention categories into the P1 segment of `all()` — filed as cosmetic, wasn't: the TS mirror already had `transcriptsExpiring` in P1, so Rust and TS were **out of order with each other** |
| 14 | `RetentionPane` render fn → `<RiskSummary>` + `<SweptPanel>` |

Also routed four direct `RetentionReport` constructors through the
existing `rep` helper — the same class as finding #3, surfaced only
because adding a field broke all four at once.

## Two questions, answered rather than carried

**Parity harness → freeze.** The top-level precedence array is
byte-identical in 2.1.233, so the fixtures still describe current CC on
the axis they test. The other behaviours were **not** re-derived and
cannot cheaply be: no `--dump-settings` in 2.1.233, no source tree to
shim, minified bundle. Bumping the pin means rewriting twelve `notes.md`
to claim a re-derivation that did not happen — and CI would enforce it.
Recorded with the uncovered surface in `parity-harness/README.md` §4.0.

**Weekly tripwire → neither `run_tick` nor cron.** My earlier
recommendation was a probe in `usage_snapshot::run_tick`. That ignored
whose problem this is: `run_tick` is shipped application code, and CC
drift is a maintainer concern about this repo's source. A bell entry
telling a user to run `cargo xtask cc-drift` is dev tooling delivered to
someone with no clone. A CI cron fails oppositely — the check needs an
installed Claude Code and CI has none. The agent's cron is the only
cadence knob; the absence of a second mechanism is the decision.

## Verification

`cargo test --workspace` · `pnpm test` 1322 passed · `tsc --noEmit` ·
clippy `-D warnings` ×4 crates · `fmt --check` · `check:catalogs` ·
`verify-docs` · `verify-cc-parity` 12/12 · `repo-invariants`

Nothing is deferred. The findings file records 15 fixed, 1 rejected with
evidence, 0 deferred.
