### PR TITLE
Agents pane: show what is running, and for how long

### DIFF
--- a/crates/claudepot-core/src/agent.rs
+++ b/crates/claudepot-core/src/agent.rs
@@ -66,6 +66,7 @@ pub mod error;
 pub mod events;
 pub mod install;
 pub mod install_gate;
+pub mod liveness;
 pub mod prerun;
 pub mod run;
 pub mod scheduler;

--- a/crates/claudepot-core/src/agent/liveness.rs
+++ b/crates/claudepot-core/src/agent/liveness.rs
@@ -30,7 +30,49 @@
 
 use std::path::{Path, PathBuf};
 
-pub use crate::session_live::registry::ProcessCheck;
+/// Liveness for an agent run asks one question `session_live`'s trait
+/// does not: did this pid start AFTER the run directory was created? A
+/// pid that did is a recycled number, not our run — and without the
+/// check a stale `run.pid` wedges Run Now behind an unrelated process
+/// with no way to clear it from the UI.
+///
+/// Its own trait rather than a supertrait of `session_live`'s: a blanket
+/// impl over that one collides with the per-fake impls the tests need.
+pub trait ProcessCheck: Send + Sync {
+    fn is_running(&self, pid: u32) -> bool;
+
+    /// Prime with every pid about to be probed, so a scan costs one
+    /// refresh rather than one per run.
+    fn prime(&self, _pids: &[u32]) {}
+
+    /// True only when the process is KNOWN to have begun after
+    /// `since_ms`. "Cannot tell" must return `false` — the conservative
+    /// answer preserves the pid-exists verdict instead of inventing an
+    /// Interrupted.
+    fn started_after(&self, _pid: u32, _since_ms: i64) -> bool {
+        false
+    }
+}
+
+impl ProcessCheck for crate::session_live::registry::SysinfoCheck {
+    fn is_running(&self, pid: u32) -> bool {
+        crate::session_live::registry::ProcessCheck::is_running(self, pid)
+    }
+
+    fn prime(&self, pids: &[u32]) {
+        self.refresh_for(pids);
+    }
+
+    fn started_after(&self, pid: u32, since_ms: i64) -> bool {
+        // sysinfo reports whole seconds; the run dir gives ms. Compare
+        // in seconds and require a STRICT excess, so a process started
+        // in the same second as the directory is not called recycled.
+        match self.start_time_secs(pid) {
+            Some(secs) => i64::try_from(secs).is_ok_and(|s| s > since_ms / 1000),
+            None => false,
+        }
+    }
+}
 
 /// A scan that could not be completed. Deliberately distinct from an
 /// empty result: "no runs" and "could not look" are different answers,
@@ -110,7 +152,12 @@ pub fn scan_agent_dir(
     // Collect first so the process check can be primed with every pid in
     // one refresh rather than one system call per run.
     let mut candidates: Vec<(String, PathBuf, Option<u32>)> = Vec::new();
-    for ent in rd.flatten() {
+    for ent in rd {
+        // `flatten()` here would silently drop an entry we could not
+        // stat — in a scanner whose entire invariant is "a failed read
+        // is not a clean result", swallowing one is how a live run
+        // disappears and the card reads idle.
+        let ent = ent.map_err(|e| ScanError::Unreadable(e.to_string()))?;
         if !ent.file_type().is_ok_and(|t| t.is_dir()) {
             continue;
         }
@@ -135,7 +182,16 @@ pub fn scan_agent_dir(
             run_id,
             started_ms: dir_started_ms(&dir),
             state: match pid {
-                Some(p) if check.is_running(p) => RunState::Running,
+                // Liveness is "this pid exists" AND "it did not start
+                // after our run did". Without the second clause a
+                // recycled pid reads as our run forever, wedging Run Now
+                // behind an unrelated process. `started_after` is a
+                // conservative check: when the process start time is
+                // unavailable we keep the pid-exists answer rather than
+                // inventing an Interrupted.
+                Some(p) if check.is_running(p) && !check.started_after(p, dir_started_ms(&dir)) => {
+                    RunState::Running
+                }
                 _ => RunState::Interrupted,
             },
         })
@@ -296,8 +352,16 @@ pub fn scan_status_live(check: &dyn ProcessCheck) -> Vec<AgentRunStatus> {
     out
 }
 
-/// Scan every agent under `agents_root` (`~/.claudepot/agents`).
-pub fn scan_all(agents_root: &Path, check: &dyn ProcessCheck) -> Vec<InFlightRun> {
+/// Scan every agent under `agents_root` for in-flight runs.
+///
+/// **Test-only.** Production reads run state through
+/// [`scan_status_live`], which carries the `unreadable` contract. This
+/// helper deliberately does not: it existed before that contract and
+/// `unwrap_or_default()`-ed unreadable agents into silence, which is the
+/// exact behaviour the module now forbids. Kept `pub(crate)` and
+/// cfg(test) so it cannot leak back into a production path.
+#[cfg(test)]
+pub(crate) fn scan_all(agents_root: &Path, check: &dyn ProcessCheck) -> Vec<InFlightRun> {
     let Ok(rd) = std::fs::read_dir(agents_root) else {
         return Vec::new();
     };
@@ -311,7 +375,6 @@ pub fn scan_all(agents_root: &Path, check: &dyn ProcessCheck) -> Vec<InFlightRun
         };
         out.extend(scan_agent_dir(&id, &ent.path(), check).unwrap_or_default());
     }
-    // Newest first, so a UI that shows only one shows the current run.
     out.sort_by(|a, b| b.started_ms.cmp(&a.started_ms));
     out
 }
@@ -507,6 +570,31 @@ mod tests {
             got.is_err(),
             "expected UNKNOWN, got {got:?} — an older run must never be \
              promoted to 'last' because the newest one would not parse"
+        );
+    }
+
+    /// R2-3. A pid that exists but STARTED AFTER the run directory did
+    /// is a recycled pid, not our run. Without this a stale run.pid
+    /// whose number got reused wedges Run Now behind an unrelated
+    /// process, with no way to clear it from the UI.
+    #[test]
+    fn a_recycled_pid_is_not_our_run() {
+        struct Recycled;
+        impl ProcessCheck for Recycled {
+            fn is_running(&self, _pid: u32) -> bool {
+                true // the number is live...
+            }
+            fn started_after(&self, _pid: u32, _since_ms: i64) -> bool {
+                true // ...but it began after our run dir was created
+            }
+        }
+        let t = TempDir::new().unwrap();
+        mk_run(t.path(), "r1", Some("4242"), false);
+        let got = scan_agent_dir("a", t.path(), &Recycled).unwrap();
+        assert_eq!(
+            got[0].state,
+            RunState::Interrupted,
+            "a pid that postdates the run is not the run"
         );
     }
 

--- a/crates/claudepot-core/src/agent/liveness.rs
+++ b/crates/claudepot-core/src/agent/liveness.rs
@@ -257,11 +257,19 @@ pub fn last_run(agent_dir: &Path) -> Result<Option<LastRun>, ScanError> {
     // failure as the current fact. An unparseable newest result is an
     // unknown, and unknowns are never rendered as confident answers.
     let mut newest: Option<(i64, String, PathBuf)> = None;
-    for ent in rd.flatten() {
+    for ent in rd {
+        // Not `flatten()`. Dropping an entry we cannot stat would let an
+        // incomplete scan promote an older run to "last", or report
+        // "never run" — a confident answer built on a partial read.
+        let ent = ent.map_err(|e| ScanError::Unreadable(e.to_string()))?;
         let dir = ent.path();
         let result_path = dir.join("result.json");
-        let Ok(meta) = std::fs::metadata(&result_path) else {
-            continue; // no result.json — that run is in flight, not last
+        let meta = match std::fs::metadata(&result_path) {
+            Ok(m) => m,
+            // No result.json: that run is in flight, not the last one.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            // Anything else is a failed read, not an absent result.
+            Err(e) => return Err(ScanError::Unreadable(e.to_string())),
         };
         let ended_ms = meta
             .modified()
@@ -321,7 +329,22 @@ pub fn scan_status_live(check: &dyn ProcessCheck) -> Vec<AgentRunStatus> {
         }
     };
     let mut out = Vec::new();
-    for ent in rd.flatten() {
+    for ent in rd {
+        // An entry we cannot read is not an agent that is idle — omitting
+        // it silently is how a live run disappears from the pane.
+        let ent = match ent {
+            Ok(e) => e,
+            Err(e) => {
+                out.push(AgentRunStatus {
+                    agent_id: String::new(),
+                    in_flight: None,
+                    last: None,
+                    unreadable: true,
+                    root_error: Some(e.to_string()),
+                });
+                continue;
+            }
+        };
         if !ent.file_type().is_ok_and(|t| t.is_dir()) {
             continue;
         }

--- a/crates/claudepot-core/src/agent/liveness.rs
+++ b/crates/claudepot-core/src/agent/liveness.rs
@@ -1,0 +1,429 @@
+//! Is an agent run actually in flight?
+//!
+//! # Why this is not a boolean in the renderer
+//!
+//! The Agents pane used to derive "running" from a renderer-local flag
+//! set on click and cleared by a five-minute timer. A real run takes
+//! ~15 minutes, so the card returned to idle two thirds of the way
+//! through and re-enabled `Run Now`; a cron-fired run — the entire
+//! reason the `agent` noun exists — set the flag never and was invisible
+//! for its whole life. See `dev-docs/agents-run-visibility-plan.md` §1.
+//!
+//! State is therefore **observed**, from two independent signals:
+//!
+//! 1. **`result.json` absent** — the run has not recorded an outcome.
+//! 2. **`run.pid` alive** — a process with that pid exists.
+//!
+//! # Why both, and never just the first
+//!
+//! Signal 1 alone has two causes: the run is alive, or it died hard and
+//! never wrote anything. Collapsing them would render a crashed run as
+//! "Running" forever — a card reading "Running 3 days". That is the same
+//! defect class as reporting a failed scan as "nothing scheduled for
+//! deletion", so the unknown gets its own state
+//! ([`RunState::Interrupted`]) rather than being folded into either
+//! confident answer.
+//!
+//! Run directories created before the shim wrote `run.pid` have no pid
+//! file at all. They resolve to `Interrupted`, which is the safe
+//! direction: a stale run reads as "no result recorded", never as live.
+
+use std::path::{Path, PathBuf};
+
+pub use crate::session_live::registry::ProcessCheck;
+
+/// What a run directory without a recorded result actually is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunState {
+    /// `result.json` absent and the pid is alive.
+    Running,
+    /// `result.json` absent and the pid is gone, unreadable, or was
+    /// never written. The run produced no outcome and nothing is
+    /// working on it — say so rather than guessing which.
+    Interrupted,
+}
+
+/// One run directory that has not recorded a result.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InFlightRun {
+    pub agent_id: String,
+    pub run_id: String,
+    /// Directory mtime in epoch ms — when the run started. The UI
+    /// computes elapsed from this rather than being told a duration, so
+    /// a slow poll never makes the clock stutter.
+    pub started_ms: i64,
+    pub state: RunState,
+}
+
+/// Read `<run_dir>/run.pid`. `None` when absent, unreadable, or not a
+/// plausible pid — all of which mean "cannot attribute a process to this
+/// run", which is `Interrupted`, not `Running`.
+fn read_pid(run_dir: &Path) -> Option<u32> {
+    let raw = std::fs::read_to_string(run_dir.join("run.pid")).ok()?;
+    let pid: u32 = raw.trim().parse().ok()?;
+    (pid > 0).then_some(pid)
+}
+
+fn dir_started_ms(run_dir: &Path) -> i64 {
+    std::fs::metadata(run_dir)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .and_then(|d| i64::try_from(d.as_millis()).ok())
+        .unwrap_or(0)
+}
+
+/// Scan one agent's `runs/` directory for runs with no recorded result.
+///
+/// `agent_dir` is `~/.claudepot/agents/<id>`. Pure with respect to the
+/// process table: the check is injected, so every state below is unit
+/// tested against a fixture tree with no real processes.
+pub fn scan_agent_dir(
+    agent_id: &str,
+    agent_dir: &Path,
+    check: &dyn ProcessCheck,
+) -> Vec<InFlightRun> {
+    let runs_dir: PathBuf = agent_dir.join("runs");
+    let Ok(rd) = std::fs::read_dir(&runs_dir) else {
+        // No runs directory is a real zero — the agent has never run.
+        return Vec::new();
+    };
+
+    // Collect first so the process check can be primed with every pid in
+    // one refresh rather than one system call per run.
+    let mut candidates: Vec<(String, PathBuf, Option<u32>)> = Vec::new();
+    for ent in rd.flatten() {
+        if !ent.file_type().is_ok_and(|t| t.is_dir()) {
+            continue;
+        }
+        let dir = ent.path();
+        if dir.join("result.json").exists() {
+            continue; // finished — history's problem, not liveness'
+        }
+        let Some(run_id) = ent.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let pid = read_pid(&dir);
+        candidates.push((run_id, dir, pid));
+    }
+
+    let pids: Vec<u32> = candidates.iter().filter_map(|(_, _, p)| *p).collect();
+    check.prime(&pids);
+
+    candidates
+        .into_iter()
+        .map(|(run_id, dir, pid)| InFlightRun {
+            agent_id: agent_id.to_string(),
+            run_id,
+            started_ms: dir_started_ms(&dir),
+            state: match pid {
+                Some(p) if check.is_running(p) => RunState::Running,
+                _ => RunState::Interrupted,
+            },
+        })
+        .collect()
+}
+
+/// The most recent run that DID record a result.
+///
+/// Carried by the same poll that reports in-flight runs, rather than
+/// bolted onto `AgentSummaryDto`: that DTO is a pure `From<&Agent>`
+/// conversion, and giving it filesystem reads would make every list call
+/// touch disk for data only this pane wants. One poll, one source of
+/// truth for run state.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LastRun {
+    pub run_id: String,
+    pub ended_ms: i64,
+    pub exit_code: i32,
+    pub duration_ms: i64,
+}
+
+/// Everything the pane needs to describe one agent's run state.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct AgentRunStatus {
+    pub agent_id: String,
+    /// `None` when nothing is in flight.
+    pub in_flight: Option<InFlightRun>,
+    /// `None` when the agent has never completed a run — which is a
+    /// different statement from "the last run failed", and the card
+    /// renders them differently.
+    pub last: Option<LastRun>,
+}
+
+/// Newest `result.json` under an agent's `runs/`, if any.
+///
+/// Reads only the four fields the card needs; a malformed or truncated
+/// `result.json` yields `None` rather than a partial record, because a
+/// half-parsed outcome rendered as fact is the failure this whole area
+/// keeps producing.
+pub fn last_run(agent_dir: &Path) -> Option<LastRun> {
+    let rd = std::fs::read_dir(agent_dir.join("runs")).ok()?;
+    let mut best: Option<(i64, LastRun)> = None;
+    for ent in rd.flatten() {
+        let dir = ent.path();
+        let Ok(text) = std::fs::read_to_string(dir.join("result.json")) else {
+            continue;
+        };
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) else {
+            continue;
+        };
+        let (Some(exit_code), Some(duration_ms)) = (
+            v.get("exit_code").and_then(|x| x.as_i64()),
+            v.get("duration_ms").and_then(|x| x.as_i64()),
+        ) else {
+            continue;
+        };
+        let ended_ms = std::fs::metadata(dir.join("result.json"))
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .and_then(|d| i64::try_from(d.as_millis()).ok())
+            .unwrap_or(0);
+        let run_id = ent.file_name().to_str().unwrap_or_default().to_string();
+        let cand = LastRun {
+            run_id,
+            ended_ms,
+            exit_code: i32::try_from(exit_code).unwrap_or(i32::MAX),
+            duration_ms,
+        };
+        if best.as_ref().is_none_or(|(t, _)| ended_ms > *t) {
+            best = Some((ended_ms, cand));
+        }
+    }
+    best.map(|(_, r)| r)
+}
+
+/// Per-agent run status for every agent in the live data directory.
+pub fn scan_status_live(check: &dyn ProcessCheck) -> Vec<AgentRunStatus> {
+    let root = crate::paths::claudepot_data_dir().join("agents");
+    let Ok(rd) = std::fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for ent in rd.flatten() {
+        if !ent.file_type().is_ok_and(|t| t.is_dir()) {
+            continue;
+        }
+        let Some(id) = ent.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let dir = ent.path();
+        let mut in_flight = scan_agent_dir(&id, &dir, check);
+        // Newest first; the pane shows one.
+        in_flight.sort_by(|a, b| b.started_ms.cmp(&a.started_ms));
+        out.push(AgentRunStatus {
+            agent_id: id,
+            in_flight: in_flight.into_iter().next(),
+            last: last_run(&dir),
+        });
+    }
+    out
+}
+
+/// Scan every agent in the live data directory.
+///
+/// The one entry point production callers need — resolves the agents
+/// root through `paths::claudepot_data_dir()` so it honours
+/// `CLAUDEPOT_DATA_DIR` and the test-isolation guard, rather than
+/// rebuilding `$HOME/.claudepot` by hand (the mistake `cc_tips_catalog`
+/// made, which let a test write into the developer's live data root).
+pub fn scan_live(check: &dyn ProcessCheck) -> Vec<InFlightRun> {
+    scan_all(&crate::paths::claudepot_data_dir().join("agents"), check)
+}
+
+/// Scan every agent under `agents_root` (`~/.claudepot/agents`).
+pub fn scan_all(agents_root: &Path, check: &dyn ProcessCheck) -> Vec<InFlightRun> {
+    let Ok(rd) = std::fs::read_dir(agents_root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for ent in rd.flatten() {
+        if !ent.file_type().is_ok_and(|t| t.is_dir()) {
+            continue;
+        }
+        let Some(id) = ent.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        out.extend(scan_agent_dir(&id, &ent.path(), check));
+    }
+    // Newest first, so a UI that shows only one shows the current run.
+    out.sort_by(|a, b| b.started_ms.cmp(&a.started_ms));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Fake table: only the pids handed in are "alive".
+    struct Fake(HashSet<u32>);
+    impl ProcessCheck for Fake {
+        fn is_running(&self, pid: u32) -> bool {
+            self.0.contains(&pid)
+        }
+    }
+    fn alive(pids: &[u32]) -> Fake {
+        Fake(pids.iter().copied().collect())
+    }
+
+    fn mk_run(agent_dir: &Path, run_id: &str, pid: Option<&str>, result: bool) -> PathBuf {
+        let d = agent_dir.join("runs").join(run_id);
+        fs::create_dir_all(&d).unwrap();
+        if let Some(p) = pid {
+            fs::write(d.join("run.pid"), p).unwrap();
+        }
+        if result {
+            fs::write(d.join("result.json"), "{}").unwrap();
+        }
+        d
+    }
+
+    #[test]
+    fn a_live_pid_with_no_result_is_running() {
+        let t = TempDir::new().unwrap();
+        mk_run(t.path(), "r1", Some("4242"), false);
+        let got = scan_agent_dir("a", t.path(), &alive(&[4242]));
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].state, RunState::Running);
+        assert_eq!(got[0].run_id, "r1");
+    }
+
+    /// The load-bearing case. A run that died without recording must not
+    /// render as live — that is what produces "Running 3 days".
+    #[test]
+    fn a_dead_pid_with_no_result_is_interrupted_not_running() {
+        let t = TempDir::new().unwrap();
+        mk_run(t.path(), "r1", Some("4242"), false);
+        let got = scan_agent_dir("a", t.path(), &alive(&[])); // nothing alive
+        assert_eq!(got[0].state, RunState::Interrupted);
+    }
+
+    /// Backward compatibility: directories created before the shim wrote
+    /// `run.pid`. They must resolve to Interrupted, never Running.
+    #[test]
+    fn a_run_predating_the_pid_file_is_interrupted() {
+        let t = TempDir::new().unwrap();
+        mk_run(t.path(), "old", None, false);
+        let got = scan_agent_dir("a", t.path(), &alive(&[4242]));
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].state, RunState::Interrupted);
+    }
+
+    #[test]
+    fn a_finished_run_is_not_in_flight_at_all() {
+        let t = TempDir::new().unwrap();
+        mk_run(t.path(), "done", Some("4242"), true);
+        assert!(scan_agent_dir("a", t.path(), &alive(&[4242])).is_empty());
+    }
+
+    /// An unparseable or absurd pid is "cannot attribute a process",
+    /// which is Interrupted — not a panic and not an optimistic Running.
+    #[test]
+    fn a_garbage_pid_file_is_interrupted() {
+        let t = TempDir::new().unwrap();
+        mk_run(t.path(), "bad", Some("not-a-pid"), false);
+        mk_run(t.path(), "zero", Some("0"), false);
+        let got = scan_agent_dir("a", t.path(), &alive(&[4242]));
+        assert_eq!(got.len(), 2);
+        assert!(got.iter().all(|r| r.state == RunState::Interrupted));
+    }
+
+    #[test]
+    fn an_agent_that_never_ran_reports_nothing() {
+        let t = TempDir::new().unwrap();
+        assert!(scan_agent_dir("a", t.path(), &alive(&[])).is_empty());
+    }
+
+    #[test]
+    fn last_run_picks_the_newest_recorded_result() {
+        let t = TempDir::new().unwrap();
+        let older = mk_run(t.path(), "old", Some("1"), true);
+        fs::write(
+            older.join("result.json"),
+            r#"{"exit_code":1,"duration_ms":100}"#,
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let newer = mk_run(t.path(), "new", Some("2"), true);
+        fs::write(
+            newer.join("result.json"),
+            r#"{"exit_code":0,"duration_ms":886422}"#,
+        )
+        .unwrap();
+
+        let got = last_run(t.path()).expect("a completed run exists");
+        assert_eq!(got.run_id, "new");
+        assert_eq!(got.exit_code, 0);
+        assert_eq!(got.duration_ms, 886422);
+    }
+
+    /// "Never completed a run" and "the last run failed" are different
+    /// statements and the card renders them differently, so the absent
+    /// case must be `None` rather than a zero-valued record.
+    #[test]
+    fn an_agent_with_no_completed_run_has_no_last_run() {
+        let t = TempDir::new().unwrap();
+        mk_run(t.path(), "live", Some("1"), false); // in flight, no result
+        assert!(last_run(t.path()).is_none());
+    }
+
+    /// A truncated or malformed result must yield nothing, not a
+    /// partially-populated record rendered as fact.
+    #[test]
+    fn a_malformed_result_json_is_skipped_not_half_parsed() {
+        let t = TempDir::new().unwrap();
+        let d = mk_run(t.path(), "bad", Some("1"), true);
+        fs::write(d.join("result.json"), "{\"exit_code\":").unwrap();
+        assert!(last_run(t.path()).is_none());
+
+        let d2 = mk_run(t.path(), "partial", Some("2"), true);
+        // Valid JSON, but missing duration_ms.
+        fs::write(d2.join("result.json"), r#"{"exit_code":0}"#).unwrap();
+        assert!(last_run(t.path()).is_none());
+    }
+
+    #[test]
+    fn scan_all_walks_every_agent_and_sorts_newest_first() {
+        let t = TempDir::new().unwrap();
+        let a = t.path().join("agent-a");
+        let b = t.path().join("agent-b");
+        mk_run(&a, "r1", Some("1"), false);
+        mk_run(&b, "r2", Some("2"), false);
+        let got = scan_all(t.path(), &alive(&[1, 2]));
+        assert_eq!(got.len(), 2);
+        assert!(got[0].started_ms >= got[1].started_ms, "newest first");
+        let ids: HashSet<&str> = got.iter().map(|r| r.agent_id.as_str()).collect();
+        assert!(ids.contains("agent-a") && ids.contains("agent-b"));
+    }
+
+    /// The process table is probed once per scan, not once per run —
+    /// `prime` receives every pid up front.
+    #[test]
+    fn the_process_check_is_primed_with_every_pid_at_once() {
+        use std::sync::Mutex;
+        struct Recording(Mutex<Vec<Vec<u32>>>);
+        impl ProcessCheck for Recording {
+            fn is_running(&self, _pid: u32) -> bool {
+                true
+            }
+            fn prime(&self, pids: &[u32]) {
+                self.0.lock().unwrap().push(pids.to_vec());
+            }
+        }
+        let t = TempDir::new().unwrap();
+        mk_run(t.path(), "r1", Some("11"), false);
+        mk_run(t.path(), "r2", Some("22"), false);
+        let rec = Recording(Mutex::new(Vec::new()));
+        scan_agent_dir("a", t.path(), &rec);
+        let calls = rec.0.lock().unwrap();
+        assert_eq!(calls.len(), 1, "one prime per scan");
+        let mut got = calls[0].clone();
+        got.sort_unstable();
+        assert_eq!(got, vec![11, 22]);
+    }
+}

--- a/crates/claudepot-core/src/agent/liveness.rs
+++ b/crates/claudepot-core/src/agent/liveness.rs
@@ -32,6 +32,15 @@ use std::path::{Path, PathBuf};
 
 pub use crate::session_live::registry::ProcessCheck;
 
+/// A scan that could not be completed. Deliberately distinct from an
+/// empty result: "no runs" and "could not look" are different answers,
+/// and only one of them is safe to render as idle.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ScanError {
+    #[error("agent run directory is unreadable: {0}")]
+    Unreadable(String),
+}
+
 /// What a run directory without a recorded result actually is.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -83,11 +92,19 @@ pub fn scan_agent_dir(
     agent_id: &str,
     agent_dir: &Path,
     check: &dyn ProcessCheck,
-) -> Vec<InFlightRun> {
+) -> Result<Vec<InFlightRun>, ScanError> {
     let runs_dir: PathBuf = agent_dir.join("runs");
-    let Ok(rd) = std::fs::read_dir(&runs_dir) else {
-        // No runs directory is a real zero — the agent has never run.
-        return Vec::new();
+    let rd = match std::fs::read_dir(&runs_dir) {
+        Ok(rd) => rd,
+        // A MISSING runs directory is a real zero — the agent has never
+        // run, and CC creates it lazily. Anything else (permissions, a
+        // transient I/O error) is NOT a zero: rendering it as "never
+        // ran" is precisely the "failed read is not a clean result"
+        // failure this module exists to prevent.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Vec::new());
+        }
+        Err(e) => return Err(ScanError::Unreadable(e.to_string())),
     };
 
     // Collect first so the process check can be primed with every pid in
@@ -111,7 +128,7 @@ pub fn scan_agent_dir(
     let pids: Vec<u32> = candidates.iter().filter_map(|(_, _, p)| *p).collect();
     check.prime(&pids);
 
-    candidates
+    let out = candidates
         .into_iter()
         .map(|(run_id, dir, pid)| InFlightRun {
             agent_id: agent_id.to_string(),
@@ -122,7 +139,8 @@ pub fn scan_agent_dir(
                 _ => RunState::Interrupted,
             },
         })
-        .collect()
+        .collect::<Vec<_>>();
+    Ok(out)
 }
 
 /// The most recent run that DID record a result.
@@ -150,6 +168,17 @@ pub struct AgentRunStatus {
     /// different statement from "the last run failed", and the card
     /// renders them differently.
     pub last: Option<LastRun>,
+    /// This agent's run data could not be read (permissions, transient
+    /// I/O, an unparseable newest result). Per-agent rather than global
+    /// so one bad directory does not blank every other card. When set,
+    /// `in_flight` and `last` are NOT trustworthy and the UI renders
+    /// "can't determine" rather than idle.
+    pub unreadable: bool,
+    /// Set only on the synthetic sentinel returned when the agents ROOT
+    /// itself is unreadable. Carries the reason so the UI can say what
+    /// went wrong instead of rendering every card as idle.
+    #[serde(default)]
+    pub root_error: Option<String>,
 }
 
 /// Newest `result.json` under an agent's `runs/`, if any.
@@ -158,48 +187,82 @@ pub struct AgentRunStatus {
 /// `result.json` yields `None` rather than a partial record, because a
 /// half-parsed outcome rendered as fact is the failure this whole area
 /// keeps producing.
-pub fn last_run(agent_dir: &Path) -> Option<LastRun> {
-    let rd = std::fs::read_dir(agent_dir.join("runs")).ok()?;
-    let mut best: Option<(i64, LastRun)> = None;
+pub fn last_run(agent_dir: &Path) -> Result<Option<LastRun>, ScanError> {
+    let rd = match std::fs::read_dir(agent_dir.join("runs")) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(ScanError::Unreadable(e.to_string())),
+    };
+
+    // Find the NEWEST recorded result first, then parse exactly that
+    // one. Parsing every candidate and keeping the newest that happened
+    // to parse would let a truncated newest result be silently replaced
+    // by an older run — the card would then state an old success or
+    // failure as the current fact. An unparseable newest result is an
+    // unknown, and unknowns are never rendered as confident answers.
+    let mut newest: Option<(i64, String, PathBuf)> = None;
     for ent in rd.flatten() {
         let dir = ent.path();
-        let Ok(text) = std::fs::read_to_string(dir.join("result.json")) else {
-            continue;
+        let result_path = dir.join("result.json");
+        let Ok(meta) = std::fs::metadata(&result_path) else {
+            continue; // no result.json — that run is in flight, not last
         };
-        let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) else {
-            continue;
-        };
-        let (Some(exit_code), Some(duration_ms)) = (
-            v.get("exit_code").and_then(|x| x.as_i64()),
-            v.get("duration_ms").and_then(|x| x.as_i64()),
-        ) else {
-            continue;
-        };
-        let ended_ms = std::fs::metadata(dir.join("result.json"))
-            .and_then(|m| m.modified())
+        let ended_ms = meta
+            .modified()
             .ok()
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
             .and_then(|d| i64::try_from(d.as_millis()).ok())
             .unwrap_or(0);
         let run_id = ent.file_name().to_str().unwrap_or_default().to_string();
-        let cand = LastRun {
-            run_id,
-            ended_ms,
-            exit_code: i32::try_from(exit_code).unwrap_or(i32::MAX),
-            duration_ms,
-        };
-        if best.as_ref().is_none_or(|(t, _)| ended_ms > *t) {
-            best = Some((ended_ms, cand));
+        if newest.as_ref().is_none_or(|(t, _, _)| ended_ms > *t) {
+            newest = Some((ended_ms, run_id, result_path));
         }
     }
-    best.map(|(_, r)| r)
+
+    let Some((ended_ms, run_id, path)) = newest else {
+        return Ok(None); // never completed a run
+    };
+
+    let text = std::fs::read_to_string(&path).map_err(|e| ScanError::Unreadable(e.to_string()))?;
+    let v: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| ScanError::Unreadable(format!("{}: {e}", path.display())))?;
+    let (Some(exit_code), Some(duration_ms)) = (
+        v.get("exit_code").and_then(|x| x.as_i64()),
+        v.get("duration_ms").and_then(|x| x.as_i64()),
+    ) else {
+        return Err(ScanError::Unreadable(format!(
+            "{}: missing exit_code or duration_ms",
+            path.display()
+        )));
+    };
+
+    Ok(Some(LastRun {
+        run_id,
+        ended_ms,
+        exit_code: i32::try_from(exit_code).unwrap_or(i32::MAX),
+        duration_ms,
+    }))
 }
 
 /// Per-agent run status for every agent in the live data directory.
 pub fn scan_status_live(check: &dyn ProcessCheck) -> Vec<AgentRunStatus> {
     let root = crate::paths::claudepot_data_dir().join("agents");
-    let Ok(rd) = std::fs::read_dir(&root) else {
-        return Vec::new();
+    let rd = match std::fs::read_dir(&root) {
+        Ok(rd) => rd,
+        // A missing agents root is a real zero: no agent has ever been
+        // installed. Anything else is unknown, and returning an empty
+        // vec would render every card idle — the same failure as the
+        // per-agent case below, one level up.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(e) => {
+            return vec![AgentRunStatus {
+                agent_id: String::new(),
+                in_flight: None,
+                last: None,
+                unreadable: true,
+                root_error: Some(e.to_string()),
+            }]
+        }
     };
     let mut out = Vec::new();
     for ent in rd.flatten() {
@@ -210,27 +273,27 @@ pub fn scan_status_live(check: &dyn ProcessCheck) -> Vec<AgentRunStatus> {
             continue;
         };
         let dir = ent.path();
-        let mut in_flight = scan_agent_dir(&id, &dir, check);
-        // Newest first; the pane shows one.
-        in_flight.sort_by(|a, b| b.started_ms.cmp(&a.started_ms));
+        let (in_flight, scan_bad) = match scan_agent_dir(&id, &dir, check) {
+            Ok(mut v) => {
+                // Newest first; the pane shows one.
+                v.sort_by(|a, b| b.started_ms.cmp(&a.started_ms));
+                (v.into_iter().next(), false)
+            }
+            Err(_) => (None, true),
+        };
+        let (last, last_bad) = match last_run(&dir) {
+            Ok(l) => (l, false),
+            Err(_) => (None, true),
+        };
         out.push(AgentRunStatus {
             agent_id: id,
-            in_flight: in_flight.into_iter().next(),
-            last: last_run(&dir),
+            in_flight,
+            last,
+            unreadable: scan_bad || last_bad,
+            root_error: None,
         });
     }
     out
-}
-
-/// Scan every agent in the live data directory.
-///
-/// The one entry point production callers need — resolves the agents
-/// root through `paths::claudepot_data_dir()` so it honours
-/// `CLAUDEPOT_DATA_DIR` and the test-isolation guard, rather than
-/// rebuilding `$HOME/.claudepot` by hand (the mistake `cc_tips_catalog`
-/// made, which let a test write into the developer's live data root).
-pub fn scan_live(check: &dyn ProcessCheck) -> Vec<InFlightRun> {
-    scan_all(&crate::paths::claudepot_data_dir().join("agents"), check)
 }
 
 /// Scan every agent under `agents_root` (`~/.claudepot/agents`).
@@ -246,7 +309,7 @@ pub fn scan_all(agents_root: &Path, check: &dyn ProcessCheck) -> Vec<InFlightRun
         let Some(id) = ent.file_name().to_str().map(str::to_string) else {
             continue;
         };
-        out.extend(scan_agent_dir(&id, &ent.path(), check));
+        out.extend(scan_agent_dir(&id, &ent.path(), check).unwrap_or_default());
     }
     // Newest first, so a UI that shows only one shows the current run.
     out.sort_by(|a, b| b.started_ms.cmp(&a.started_ms));
@@ -287,7 +350,7 @@ mod tests {
     fn a_live_pid_with_no_result_is_running() {
         let t = TempDir::new().unwrap();
         mk_run(t.path(), "r1", Some("4242"), false);
-        let got = scan_agent_dir("a", t.path(), &alive(&[4242]));
+        let got = scan_agent_dir("a", t.path(), &alive(&[4242])).unwrap();
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].state, RunState::Running);
         assert_eq!(got[0].run_id, "r1");
@@ -299,7 +362,7 @@ mod tests {
     fn a_dead_pid_with_no_result_is_interrupted_not_running() {
         let t = TempDir::new().unwrap();
         mk_run(t.path(), "r1", Some("4242"), false);
-        let got = scan_agent_dir("a", t.path(), &alive(&[])); // nothing alive
+        let got = scan_agent_dir("a", t.path(), &alive(&[])).unwrap(); // nothing alive
         assert_eq!(got[0].state, RunState::Interrupted);
     }
 
@@ -309,7 +372,7 @@ mod tests {
     fn a_run_predating_the_pid_file_is_interrupted() {
         let t = TempDir::new().unwrap();
         mk_run(t.path(), "old", None, false);
-        let got = scan_agent_dir("a", t.path(), &alive(&[4242]));
+        let got = scan_agent_dir("a", t.path(), &alive(&[4242])).unwrap();
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].state, RunState::Interrupted);
     }
@@ -318,7 +381,9 @@ mod tests {
     fn a_finished_run_is_not_in_flight_at_all() {
         let t = TempDir::new().unwrap();
         mk_run(t.path(), "done", Some("4242"), true);
-        assert!(scan_agent_dir("a", t.path(), &alive(&[4242])).is_empty());
+        assert!(scan_agent_dir("a", t.path(), &alive(&[4242]))
+            .unwrap()
+            .is_empty());
     }
 
     /// An unparseable or absurd pid is "cannot attribute a process",
@@ -328,7 +393,7 @@ mod tests {
         let t = TempDir::new().unwrap();
         mk_run(t.path(), "bad", Some("not-a-pid"), false);
         mk_run(t.path(), "zero", Some("0"), false);
-        let got = scan_agent_dir("a", t.path(), &alive(&[4242]));
+        let got = scan_agent_dir("a", t.path(), &alive(&[4242])).unwrap();
         assert_eq!(got.len(), 2);
         assert!(got.iter().all(|r| r.state == RunState::Interrupted));
     }
@@ -336,7 +401,9 @@ mod tests {
     #[test]
     fn an_agent_that_never_ran_reports_nothing() {
         let t = TempDir::new().unwrap();
-        assert!(scan_agent_dir("a", t.path(), &alive(&[])).is_empty());
+        assert!(scan_agent_dir("a", t.path(), &alive(&[]))
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
@@ -356,7 +423,7 @@ mod tests {
         )
         .unwrap();
 
-        let got = last_run(t.path()).expect("a completed run exists");
+        let got = last_run(t.path()).unwrap().expect("a completed run exists");
         assert_eq!(got.run_id, "new");
         assert_eq!(got.exit_code, 0);
         assert_eq!(got.duration_ms, 886422);
@@ -369,7 +436,7 @@ mod tests {
     fn an_agent_with_no_completed_run_has_no_last_run() {
         let t = TempDir::new().unwrap();
         mk_run(t.path(), "live", Some("1"), false); // in flight, no result
-        assert!(last_run(t.path()).is_none());
+        assert!(last_run(t.path()).unwrap().is_none());
     }
 
     /// A truncated or malformed result must yield nothing, not a
@@ -379,12 +446,68 @@ mod tests {
         let t = TempDir::new().unwrap();
         let d = mk_run(t.path(), "bad", Some("1"), true);
         fs::write(d.join("result.json"), "{\"exit_code\":").unwrap();
-        assert!(last_run(t.path()).is_none());
+        assert!(
+            last_run(t.path()).is_err(),
+            "a truncated newest result is UNKNOWN, not absent"
+        );
 
-        let d2 = mk_run(t.path(), "partial", Some("2"), true);
+        let t2 = TempDir::new().unwrap();
+        let d2 = mk_run(t2.path(), "partial", Some("2"), true);
         // Valid JSON, but missing duration_ms.
         fs::write(d2.join("result.json"), r#"{"exit_code":0}"#).unwrap();
-        assert!(last_run(t.path()).is_none());
+        assert!(last_run(t2.path()).is_err());
+    }
+
+    /// #2 from the round-1 audit. A directory that exists but cannot be
+    /// read is NOT "the agent never ran" — rendering it as idle is the
+    /// exact "failed read is a clean result" failure this module was
+    /// written to prevent. Only `NotFound` is a real zero.
+    #[cfg(unix)]
+    #[test]
+    fn an_unreadable_runs_directory_is_an_error_not_an_empty_list() {
+        use std::os::unix::fs::PermissionsExt;
+        let t = TempDir::new().unwrap();
+        let runs = t.path().join("runs");
+        fs::create_dir_all(&runs).unwrap();
+        fs::set_permissions(&runs, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let got = scan_agent_dir("a", t.path(), &alive(&[]));
+        // Restore before asserting so a failure cannot leave a
+        // permission-denied directory behind in the temp tree.
+        fs::set_permissions(&runs, fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(got.is_err(), "unreadable must not read as an empty scan");
+    }
+
+    #[test]
+    fn a_missing_runs_directory_is_a_real_zero_not_an_error() {
+        let t = TempDir::new().unwrap();
+        assert_eq!(scan_agent_dir("a", t.path(), &alive(&[])).unwrap(), vec![]);
+        assert_eq!(last_run(t.path()).unwrap(), None);
+    }
+
+    /// #3 from the round-1 audit, and the sharpest of them. Parsing every
+    /// candidate and keeping the newest that PARSED let a truncated
+    /// newest result be silently replaced by an older run — so the card
+    /// would state a stale success as the current fact.
+    #[test]
+    fn a_malformed_newest_result_never_falls_back_to_an_older_run() {
+        let t = TempDir::new().unwrap();
+        let older = mk_run(t.path(), "older", Some("1"), true);
+        fs::write(
+            older.join("result.json"),
+            r#"{"exit_code":0,"duration_ms":100}"#,
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let newest = mk_run(t.path(), "newest", Some("2"), true);
+        fs::write(newest.join("result.json"), "{truncated").unwrap();
+
+        let got = last_run(t.path());
+        assert!(
+            got.is_err(),
+            "expected UNKNOWN, got {got:?} — an older run must never be \
+             promoted to 'last' because the newest one would not parse"
+        );
     }
 
     #[test]
@@ -419,7 +542,7 @@ mod tests {
         mk_run(t.path(), "r1", Some("11"), false);
         mk_run(t.path(), "r2", Some("22"), false);
         let rec = Recording(Mutex::new(Vec::new()));
-        scan_agent_dir("a", t.path(), &rec);
+        scan_agent_dir("a", t.path(), &rec).unwrap();
         let calls = rec.0.lock().unwrap();
         assert_eq!(calls.len(), 1, "one prime per scan");
         let mut got = calls[0].clone();

--- a/crates/claudepot-core/src/agent/shim.rs
+++ b/crates/claudepot-core/src/agent/shim.rs
@@ -201,6 +201,16 @@ pub fn render_windows(agent: &Agent, inputs: &ShimInputs<'_>) -> String {
     s.push_str("if not exist \"%RUN_DIR%\" mkdir \"%RUN_DIR%\"\r\n");
     // Fail-fast if the runs dir couldn't be created.
     s.push_str("if not exist \"%RUN_DIR%\" (echo claudepot: failed to create %RUN_DIR%>&2 & exit /b 70)\r\n");
+    // Liveness marker, mirroring the Unix shim. Without it every Windows
+    // run reports `Interrupted` the moment it starts and the Agents
+    // pane's running indicator is silently Unix-only. cmd has no `$$`;
+    // the wrapper's own pid comes from the parent PowerShell probe, and
+    // a failure here must never abort the run — it only degrades the UI.
+    // Read by `claudepot_core::agent::liveness`.
+    s.push_str(
+        "for /f \"usebackq delims=\" %%p in (`powershell -NoProfile -Command \
+\"(Get-CimInstance Win32_Process -Filter \\\"ProcessId=$PID\\\").ParentProcessId\"`) do echo %%p> \"%RUN_DIR%\\run.pid\"\r\n",
+    );
 
     s.push_str(&format!(
         "set {}\r\n",

--- a/crates/claudepot-core/src/agent/shim.rs
+++ b/crates/claudepot-core/src/agent/shim.rs
@@ -82,6 +82,15 @@ AUTO_DIR={auto_dir}
 RUN_ID="${{CLAUDEPOT_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$-$(awk 'BEGIN {{ srand(); print int(rand()*100000) }}')}}"
 RUN_DIR="$AUTO_DIR/runs/$RUN_ID"
 mkdir -p "$RUN_DIR" || exit 70
+# Liveness marker. A run directory without `result.json` means EITHER the
+# run is alive OR it died hard and never recorded anything; the two are
+# indistinguishable from the directory alone, and rendering the second as
+# "Running" would leave a card reading "Running 3 days" forever. The pid
+# is written before `claude -p` starts so the window where a run exists
+# but is unattributable is as small as the shell can make it.
+# Read by `claudepot_core::agent::liveness`. Best-effort: a failure here
+# must never abort the run, it only degrades the UI to "Interrupted".
+printf '%s' "$$" > "$RUN_DIR/run.pid" 2>/dev/null || true
 {home_export}
 export PATH={path_value}
 export LANG=en_US.UTF-8

--- a/crates/claudepot-core/src/session_live/registry.rs
+++ b/crates/claudepot-core/src/session_live/registry.rs
@@ -95,6 +95,19 @@ impl SysinfoCheck {
         }
     }
 
+    /// Unix-epoch SECONDS at which `pid` started, if the cached
+    /// `System` knows. Used by `agent::liveness` to tell our run's pid
+    /// from a recycled one: a process that began after the run
+    /// directory was created is not that run, however alive it is.
+    ///
+    /// `None` when the pid is unknown — callers must treat that as
+    /// "cannot tell", never as "recycled".
+    pub fn start_time_secs(&self, pid: u32) -> Option<u64> {
+        use sysinfo::Pid;
+        let sys = self.sys.lock().ok()?;
+        sys.process(Pid::from_u32(pid)).map(|p| p.start_time())
+    }
+
     /// Prime the cached `System` with the given PIDs. Callers should
     /// invoke this once per poll tick before running `poll_dir` so
     /// each `is_running` call is a cheap HashMap lookup.

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -746,14 +746,16 @@ pub async fn agents_set_enabled(id: String, enabled: bool) -> Result<(), ErrorDt
 /// reads would make every list call touch disk for data only this pane
 /// wants.
 #[tauri::command]
-pub async fn agents_running_list(
-) -> Result<Vec<claudepot_core::agent::liveness::AgentRunStatus>, ErrorDto> {
+pub async fn agents_running_list() -> Result<Vec<crate::dto_agents::AgentRunStatusDto>, ErrorDto> {
     // One `SysinfoCheck` per call. The pane polls on a slow timer, so
     // rebuilding the cache each tick is cheaper than holding a process
     // list warm between ticks — and `scan_all` primes it once with every
     // pid, so a call is one refresh regardless of how many runs exist.
     let check = claudepot_core::session_live::registry::SysinfoCheck::new();
-    Ok(claudepot_core::agent::liveness::scan_status_live(&check))
+    Ok(claudepot_core::agent::liveness::scan_status_live(&check)
+        .into_iter()
+        .map(Into::into)
+        .collect())
 }
 
 #[tauri::command]
@@ -811,6 +813,33 @@ pub async fn agents_run_now_start(
     // going through the X17 prelude).
     if matches!(agent.lifecycle, claudepot_core::agent::Lifecycle::Draft) {
         return Err(draft_not_runnable(&agent.name));
+    }
+
+    // Refuse a second concurrent run of the SAME agent.
+    //
+    // The renderer releases its optimistic lock as soon as this command
+    // returns and lets observed liveness take over — which leaves a
+    // window of up to one poll interval where the UI shows nothing
+    // running and Run Now is clickable. A UI-side lock cannot close that
+    // window on its own (a reload, a second window, or the CLI would all
+    // bypass it), so the guard belongs here, where the run is actually
+    // spawned.
+    //
+    // Read-only and lock-free, matching `agents_running_list`.
+    {
+        let check = claudepot_core::session_live::registry::SysinfoCheck::new();
+        let already = claudepot_core::agent::liveness::scan_status_live(&check)
+            .into_iter()
+            .find(|s| s.agent_id == aid.to_string())
+            .and_then(|s| s.in_flight)
+            .is_some_and(|r| r.state == claudepot_core::agent::liveness::RunState::Running);
+        if already {
+            return Err(ErrorDto::from(
+                claudepot_core::agent::AgentError::InvalidEnv(format!(
+                    "agent {aid} is already running; wait for the current run to finish"
+                )),
+            ));
+        }
     }
 
     let op_id = format!("agent-run-{}", Uuid::new_v4());

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -817,15 +817,23 @@ pub async fn agents_run_now_start(
 
     // Refuse a second concurrent run of the SAME agent.
     //
-    // The renderer releases its optimistic lock as soon as this command
-    // returns and lets observed liveness take over — which leaves a
-    // window of up to one poll interval where the UI shows nothing
-    // running and Run Now is clickable. A UI-side lock cannot close that
-    // window on its own (a reload, a second window, or the CLI would all
-    // bypass it), so the guard belongs here, where the run is actually
-    // spawned.
+    // Liveness alone cannot be the guard: `run.pid` is written by the
+    // shim AFTER this command returns, so two rapid starts would both
+    // observe "nothing running" and both spawn. `RunningOps` is an
+    // in-process map, so a check against it closes the window this
+    // process can actually close.
     //
-    // Read-only and lock-free, matching `agents_running_list`.
+    // Honest about the remaining hole: a run started by launchd or the
+    // CLI is not in this map, so the liveness check below still matters
+    // as a second, weaker line. Closing the cross-process case needs a
+    // real per-agent lock file and is tracked separately.
+    if ops.any_agent_run(&aid.to_string()) {
+        return Err(ErrorDto::from(
+            claudepot_core::agent::AgentError::InvalidEnv(format!(
+                "agent {aid} is already running; wait for the current run to finish"
+            )),
+        ));
+    }
     {
         let check = claudepot_core::session_live::registry::SysinfoCheck::new();
         let already = claudepot_core::agent::liveness::scan_status_live(&check)

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -752,10 +752,37 @@ pub async fn agents_running_list() -> Result<Vec<crate::dto_agents::AgentRunStat
     // list warm between ticks — and `scan_all` primes it once with every
     // pid, so a call is one refresh regardless of how many runs exist.
     let check = claudepot_core::session_live::registry::SysinfoCheck::new();
-    Ok(claudepot_core::agent::liveness::scan_status_live(&check)
-        .into_iter()
-        .map(Into::into)
-        .collect())
+    let mut rows: Vec<crate::dto_agents::AgentRunStatusDto> =
+        claudepot_core::agent::liveness::scan_status_live(&check)
+            .into_iter()
+            .map(Into::into)
+            .collect();
+
+    // Emit a row for EVERY installed agent, even one with no data
+    // directory yet. `scan_status_live` walks the filesystem, so an
+    // agent that has never run produces no row — and the renderer
+    // documents a missing row as "the poll has not reported this agent",
+    // i.e. unknown. Without this, "never ran" and "not reported" arrive
+    // identically and the card renders a confident "Never run" for both.
+    //
+    // Best-effort: a store that will not open leaves the filesystem rows
+    // alone rather than failing the whole poll, which would blank a pane
+    // that was otherwise fine.
+    if let Ok(store) = open_store() {
+        for a in store.list() {
+            let id = a.id.to_string();
+            if !rows.iter().any(|r| r.agent_id == id) {
+                rows.push(crate::dto_agents::AgentRunStatusDto {
+                    agent_id: id,
+                    in_flight: None,
+                    last: None,
+                    unreadable: false,
+                    root_error: None,
+                });
+            }
+        }
+    }
+    Ok(rows)
 }
 
 #[tauri::command]
@@ -827,13 +854,10 @@ pub async fn agents_run_now_start(
     // CLI is not in this map, so the liveness check below still matters
     // as a second, weaker line. Closing the cross-process case needs a
     // real per-agent lock file and is tracked separately.
-    if ops.any_agent_run(&aid.to_string()) {
-        return Err(ErrorDto::from(
-            claudepot_core::agent::AgentError::InvalidEnv(format!(
-                "agent {aid} is already running; wait for the current run to finish"
-            )),
-        ));
-    }
+    // Liveness first: catches a run started by launchd or the CLI, which
+    // never appears in this process's `RunningOps`. Weaker than the
+    // atomic guard below (the shim writes `run.pid` only after this
+    // command returns), so it is the second line, not the only one.
     {
         let check = claudepot_core::session_live::registry::SysinfoCheck::new();
         let already = claudepot_core::agent::liveness::scan_status_live(&check)
@@ -851,12 +875,19 @@ pub async fn agents_run_now_start(
     }
 
     let op_id = format!("agent-run-{}", Uuid::new_v4());
-    ops.insert(new_running_op(
-        &op_id,
-        OpKind::AgentRun,
-        aid.to_string(),
-        String::new(),
-    ));
+    // Atomic check-and-insert. Refusing here is what actually closes the
+    // double-click race; the liveness probe above cannot, because
+    // `run.pid` does not exist yet at this point.
+    if !ops.insert_if_no_agent_run(
+        &aid.to_string(),
+        new_running_op(&op_id, OpKind::AgentRun, aid.to_string(), String::new()),
+    ) {
+        return Err(ErrorDto::from(
+            claudepot_core::agent::AgentError::InvalidEnv(format!(
+                "agent {aid} is already running; wait for the current run to finish"
+            )),
+        ));
+    }
 
     let ops_for_task = ops.inner().clone();
     let app_for_task = app.clone();

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -726,6 +726,36 @@ pub async fn agents_set_enabled(id: String, enabled: bool) -> Result<(), ErrorDt
     Ok(())
 }
 
+/// `agents_running_list` — which agent runs are in flight right now.
+///
+/// Read-only and lock-free: it reads run directories and the process
+/// table, never `AgentStore`. That matters because this is polled every
+/// few seconds while the Agents pane is open, and taking the store lock
+/// on a timer would contend with the very Run-Now / install operations
+/// the pane exists to perform. Same reasoning as `lifecycle_of`'s
+/// non-blocking `try_open` in `agents_run_now_start` below.
+///
+/// Returns one entry per agent carrying BOTH the in-flight run (if any)
+/// and the last completed one. `Interrupted` is reported alongside
+/// `Running` — the caller must be able to tell "working" from "died
+/// without recording" — and `last: None` means "never completed a run",
+/// which the card renders differently from "the last run failed".
+///
+/// Last-run data rides this poll rather than `AgentSummaryDto` because
+/// that DTO is a pure `From<&Agent>` conversion; giving it filesystem
+/// reads would make every list call touch disk for data only this pane
+/// wants.
+#[tauri::command]
+pub async fn agents_running_list(
+) -> Result<Vec<claudepot_core::agent::liveness::AgentRunStatus>, ErrorDto> {
+    // One `SysinfoCheck` per call. The pane polls on a slow timer, so
+    // rebuilding the cache each tick is cheaper than holding a process
+    // list warm between ticks — and `scan_all` primes it once with every
+    // pid, so a call is one refresh regardless of how many runs exist.
+    let check = claudepot_core::session_live::registry::SysinfoCheck::new();
+    Ok(claudepot_core::agent::liveness::scan_status_live(&check))
+}
+
 #[tauri::command]
 pub async fn agents_run_now_start(
     id: String,

--- a/src-tauri/src/dto_agents.rs
+++ b/src-tauri/src/dto_agents.rs
@@ -698,3 +698,65 @@ mod tests {
         assert_eq!(AgentRunDto::from(r).trigger_kind, "scheduled");
     }
 }
+
+// ── Run liveness ───────────────────────────────────────────────────
+//
+// Outbound DTOs for `agents_running_list`. This file's boundary is that
+// core types do not cross IPC directly — returning
+// `claudepot_core::agent::liveness::AgentRunStatus` compiled and worked,
+// but it makes the renderer's wire shape hostage to a core refactor.
+
+/// Mirrors `claudepot_core::agent::liveness::InFlightRun`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct InFlightRunDto {
+    pub agent_id: String,
+    pub run_id: String,
+    pub started_ms: i64,
+    /// `"running"` | `"interrupted"`.
+    pub state: String,
+}
+
+/// Mirrors `claudepot_core::agent::liveness::LastRun`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LastRunDto {
+    pub run_id: String,
+    pub ended_ms: i64,
+    pub exit_code: i32,
+    pub duration_ms: i64,
+}
+
+/// Mirrors `claudepot_core::agent::liveness::AgentRunStatus`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AgentRunStatusDto {
+    pub agent_id: String,
+    pub in_flight: Option<InFlightRunDto>,
+    pub last: Option<LastRunDto>,
+    /// This agent's run data could not be read. When true the two fields
+    /// above are not trustworthy and the UI renders "can't determine".
+    pub unreadable: bool,
+}
+
+impl From<claudepot_core::agent::liveness::AgentRunStatus> for AgentRunStatusDto {
+    fn from(s: claudepot_core::agent::liveness::AgentRunStatus) -> Self {
+        use claudepot_core::agent::liveness::RunState;
+        Self {
+            agent_id: s.agent_id,
+            in_flight: s.in_flight.map(|r| InFlightRunDto {
+                agent_id: r.agent_id,
+                run_id: r.run_id,
+                started_ms: r.started_ms,
+                state: match r.state {
+                    RunState::Running => "running".to_string(),
+                    RunState::Interrupted => "interrupted".to_string(),
+                },
+            }),
+            last: s.last.map(|l| LastRunDto {
+                run_id: l.run_id,
+                ended_ms: l.ended_ms,
+                exit_code: l.exit_code,
+                duration_ms: l.duration_ms,
+            }),
+            unreadable: s.unreadable,
+        }
+    }
+}

--- a/src-tauri/src/dto_agents.rs
+++ b/src-tauri/src/dto_agents.rs
@@ -734,6 +734,11 @@ pub struct AgentRunStatusDto {
     /// This agent's run data could not be read. When true the two fields
     /// above are not trustworthy and the UI renders "can't determine".
     pub unreadable: bool,
+    /// Set only on the synthetic sentinel returned when the agents ROOT
+    /// is unreadable — that row has an empty `agent_id` and matches no
+    /// card, so without carrying this the sentinel could not cross IPC
+    /// and the fix that produced it was inert.
+    pub root_error: Option<String>,
 }
 
 impl From<claudepot_core::agent::liveness::AgentRunStatus> for AgentRunStatusDto {
@@ -757,6 +762,7 @@ impl From<claudepot_core::agent::liveness::AgentRunStatus> for AgentRunStatusDto
                 duration_ms: l.duration_ms,
             }),
             unreadable: s.unreadable,
+            root_error: s.root_error,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1276,6 +1276,7 @@ pub fn run() {
             commands::agents::agents_update,
             commands::agents::agents_remove,
             commands::agents::agents_set_enabled,
+            commands::agents::agents_running_list,
             commands::agents::agents_run_now_start,
             commands::agents::agents_runs_list,
             commands::agents::agents_run_get,

--- a/src-tauri/src/ops.rs
+++ b/src-tauri/src/ops.rs
@@ -345,10 +345,28 @@ impl RunningOps {
     /// In-process only. A run started by launchd or the CLI is not in
     /// this map — that case is covered, weakly, by the liveness check
     /// alongside this one.
-    pub fn any_agent_run(&self, agent_id: &str) -> bool {
-        self.guard()
+    /// Atomically refuse-or-register a Run-Now for `agent_id`.
+    ///
+    /// Returns `false` when a run for that agent is already tracked, and
+    /// otherwise inserts `op` and returns `true` — **under one lock
+    /// acquisition**. A separate `any_agent_run()` check followed by
+    /// `insert()` was still check-then-insert: two rapid
+    /// `agents_run_now_start` calls could both pass the check before
+    /// either inserted, which is the race the guard exists to close.
+    ///
+    /// In-process only. A run started by launchd or the CLI is not in
+    /// this map; that case is covered, weakly, by the liveness check at
+    /// the call site.
+    pub fn insert_if_no_agent_run(&self, agent_id: &str, op: RunningOpInfo) -> bool {
+        let mut map = self.guard();
+        if map
             .values()
-            .any(|op| op.kind == OpKind::AgentRun && op.old_path == agent_id)
+            .any(|o| o.kind == OpKind::AgentRun && o.old_path == agent_id)
+        {
+            return false;
+        }
+        map.insert(op.op_id.clone(), op);
+        true
     }
 
     /// Low-audit guard: recover from a poisoned Mutex rather than

--- a/src-tauri/src/ops.rs
+++ b/src-tauri/src/ops.rs
@@ -334,6 +334,23 @@ impl RunningOps {
         Self::default()
     }
 
+    /// Is a Run-Now already tracked for this agent?
+    ///
+    /// The agent id rides in `old_path` for `OpKind::AgentRun` (see
+    /// `agents_run_now_start`). Used as the concurrency guard there: a
+    /// liveness check cannot serve, because the shim writes `run.pid`
+    /// only after the command returns, so two rapid starts would both
+    /// see an idle agent.
+    ///
+    /// In-process only. A run started by launchd or the CLI is not in
+    /// this map — that case is covered, weakly, by the liveness check
+    /// alongside this one.
+    pub fn any_agent_run(&self, agent_id: &str) -> bool {
+        self.guard()
+            .values()
+            .any(|op| op.kind == OpKind::AgentRun && op.old_path == agent_id)
+    }
+
     /// Low-audit guard: recover from a poisoned Mutex rather than
     /// panicking. If an earlier panic poisoned the map, the ops
     /// pipeline would propagate the panic forever — this turns a

--- a/src/api/agent.ts
+++ b/src/api/agent.ts
@@ -11,6 +11,7 @@ import type {
   AgentUpdateDto,
   CronValidationDto,
   NameValidationDto,
+  AgentRunStatus,
   SchedulerCapabilitiesDto,
 } from "../types";
 
@@ -54,6 +55,11 @@ export const agentApi = {
   /** Returns op_id; subscribe to `op-progress::<op_id>`. */
   agentsRunNowStart: (id: string) =>
     invoke<string>("agents_run_now_start", { id }),
+
+  /** Which agent runs are in flight, observed from run directories and
+   *  the process table. Read-only and lock-free — safe to poll. Covers
+   *  cron-fired runs, which no click ever told the renderer about. */
+  agentsRunningList: () => invoke<AgentRunStatus[]>("agents_running_list"),
 
   agentsRunsList: (id: string, limit?: number) =>
     invoke<AgentRunDto[]>("agents_runs_list", { id, limit }),

--- a/src/components/RunningOpsChip.test.tsx
+++ b/src/components/RunningOpsChip.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RunningOpsChip, labelFor } from "./RunningOpsChip";
 import type { RunningOpInfo } from "../types";
+import { OP_KINDS } from "../types/ops";
 
 function op(partial: Partial<RunningOpInfo> = {}): RunningOpInfo {
   return {
@@ -164,5 +165,33 @@ describe("labelFor", () => {
         }),
       ),
     ).toBe("Renaming old-proj → new-proj");
+  });
+});
+
+// The enforcement half of the 2026-08-18 fix. `OpKind::AgentRun` existed
+// in Rust and was registered by `agents_run_now_start`, but the TS union
+// never listed it — so `verb()`'s switch was "exhaustive" over an
+// incomplete union, TypeScript raised nothing, and a live agent run
+// rendered with an undefined verb while still being counted.
+//
+// Adding the arm fixes today. This test is what stops the next OpKind
+// repeating it: it walks every kind as a runtime value, so a variant
+// added to Rust and the union but not to the switch fails here.
+describe("every OpKind renders a label", () => {
+  it("has a non-empty, non-key label for each kind", () => {
+    for (const kind of OP_KINDS) {
+      const label = labelFor(op({ kind }));
+      expect(label, `${kind} has no label`).toBeTruthy();
+      // design.md: no internal identifiers in primary UI. The backend
+      // passes the agent UUID in `old_path`, so a kind that falls
+      // through to the rename label would leak it here.
+      expect(label, `${kind} leaked a UUID`).not.toMatch(
+        /[0-9a-f]{8}-[0-9a-f]{4}-/i,
+      );
+      // A missing catalog entry renders the key itself; that is a
+      // failure, not a label.
+      expect(label, `${kind} rendered a raw i18n key`).not.toContain("ops.");
+      expect(label, `${kind} rendered undefined`).not.toContain("undefined");
+    }
   });
 });

--- a/src/components/RunningOpsChip.tsx
+++ b/src/components/RunningOpsChip.tsx
@@ -134,6 +134,8 @@ function verb(kind: RunningOpInfo["kind"]): string {
       return i18n.t("ops.addingAccount", NS);
     case "verify_all":
       return i18n.t("ops.verifying", NS);
+    case "agent_run":
+      return i18n.t("ops.runningAgent", NS);
   }
 }
 
@@ -168,6 +170,18 @@ export function labelFor(op: RunningOpInfo): string {
     return op.current_phase
       ? i18n.t("ops.sharingPhase", { ...NS, phase: op.current_phase })
       : i18n.t("ops.sharingSession", NS);
+  }
+  if (op.kind === "agent_run") {
+    // Explicit branch, not the fallback. The fallback below formats
+    // every unhandled kind as a path rename, and the backend puts the
+    // agent's UUID in the `old_path` slot — so falling through would
+    // render "Running agent <uuid> → " in the status bar, breaking
+    // design.md's "no internal identifiers in primary UI".
+    //
+    // The verb alone is the right amount here: this chip's job is the
+    // COUNT (design.md's live-surface table), and identity belongs on
+    // the agent card. See dev-docs/agents-run-visibility-plan.md §2.3.
+    return verb(op.kind);
   }
   const base = i18n.t("ops.rename", {
     ...NS,

--- a/src/hooks/useAgentRuns.ts
+++ b/src/hooks/useAgentRuns.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { api } from "../api";
 import type { AgentRunStatus } from "../types";
 
@@ -24,36 +24,49 @@ export function useAgentRuns(pollMs = 5000) {
   // running" — otherwise the pane briefly renders idle over a live run
   // on every mount.
   const [loaded, setLoaded] = useState(false);
-  const alive = useRef(true);
 
   useEffect(() => {
-    alive.current = true;
+    // Per-effect cancellation, NOT a shared ref. A ref survives effect
+    // re-runs, so a `pollMs` change would let the new effect set it back
+    // to true and revive an in-flight request from the old one — which
+    // would then write state and schedule its own next tick, running two
+    // poll chains at once.
+    let cancelled = false;
     let handle: number | undefined;
-    // Monotonic request id. `setInterval` could start a second poll
-    // while the first was still in flight, and a slow earlier response
-    // resolving last would overwrite fresher state — including a stale
-    // empty list rendering idle over a live run. Chained timeouts plus
-    // this guard make that unrepresentable.
+    // Monotonic id: a slow response resolving after a newer one must not
+    // overwrite fresher state.
     let seq = 0;
 
     const tick = async () => {
       const mine = ++seq;
       try {
-        const next = await api.agentsRunningList();
-        if (!alive.current || mine !== seq) return;
+        // Bounded. Without this an invoke that never settles means the
+        // `finally` never runs, no next poll is scheduled, `loaded`
+        // stays false forever — and since unknown now LOCKS Run Now,
+        // one hung IPC call would make every agent permanently
+        // unrunnable.
+        const next = await Promise.race([
+          api.agentsRunningList(),
+          new Promise<never>((_, reject) =>
+            window.setTimeout(
+              () => reject(new Error("agents_running_list timed out")),
+              Math.max(2000, pollMs * 2),
+            ),
+          ),
+        ]);
+        if (cancelled || mine !== seq) return;
         setRuns(next);
         setError(false);
       } catch {
-        if (!alive.current || mine !== seq) return;
+        if (cancelled || mine !== seq) return;
         // Keep the last known list rather than blanking it, but flag the
-        // failure: consumers render "can't determine", never idle, and
-        // must not present the stale list as current fact.
+        // failure: consumers render "can't determine", never idle.
         setError(true);
       } finally {
-        if (alive.current && mine === seq) {
+        if (!cancelled && mine === seq) {
           setLoaded(true);
-          // Schedule the NEXT poll only after this one settled, so two
-          // can never be in flight at once.
+          // Chain the NEXT poll only after this one settled, so two can
+          // never be in flight at once.
           handle = window.setTimeout(() => void tick(), pollMs);
         }
       }
@@ -61,7 +74,7 @@ export function useAgentRuns(pollMs = 5000) {
 
     void tick();
     return () => {
-      alive.current = false;
+      cancelled = true;
       if (handle !== undefined) window.clearTimeout(handle);
     };
   }, [pollMs]);

--- a/src/hooks/useAgentRuns.ts
+++ b/src/hooks/useAgentRuns.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { api } from "../api";
+import { invokeWithTimeout } from "../api/invokeWithTimeout";
 import type { AgentRunStatus } from "../types";
 
 /**
@@ -45,15 +45,20 @@ export function useAgentRuns(pollMs = 5000) {
         // stays false forever — and since unknown now LOCKS Run Now,
         // one hung IPC call would make every agent permanently
         // unrunnable.
-        const next = await Promise.race([
-          api.agentsRunningList(),
-          new Promise<never>((_, reject) =>
-            window.setTimeout(
-              () => reject(new Error("agents_running_list timed out")),
-              Math.max(2000, pollMs * 2),
-            ),
-          ),
-        ]);
+        // `invokeWithTimeout` rather than a local `Promise.race`: the
+        // hand-rolled version never cleared its losing timer, so every
+        // successful poll leaked a pending timeout — and that helper
+        // documents the cleanup as load-bearing.
+        //
+        // Bounded at all because an invoke that never settles means the
+        // `finally` never runs, no next poll is scheduled, `loaded`
+        // stays false forever, and unknown LOCKS Run Now — one hung IPC
+        // call would make every agent permanently unrunnable.
+        const next = await invokeWithTimeout<AgentRunStatus[]>(
+          "agents_running_list",
+          undefined,
+          Math.max(2000, pollMs * 2),
+        );
         if (cancelled || mine !== seq) return;
         setRuns(next);
         setError(false);

--- a/src/hooks/useAgentRuns.ts
+++ b/src/hooks/useAgentRuns.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from "react";
+import { api } from "../api";
+import type { AgentRunStatus } from "../types";
+
+/**
+ * Which agent runs are in flight, observed from the backend.
+ *
+ * Replaces the renderer-local `busy` flag the pane used to treat as
+ * "running". That flag was set on click and cleared by a five-minute
+ * timer, so it lied three ways: a run past five minutes read as idle, a
+ * reload lost it entirely, and a cron-fired run — the entire reason the
+ * `agent` noun exists — never set it at all. See
+ * `dev-docs/agents-run-visibility-plan.md` §1.2.
+ *
+ * `error` is a third state on purpose. A poll that fails must not render
+ * as "nothing is running": that is the same defect as reporting a failed
+ * scan as "nothing scheduled for deletion". Callers render "can't
+ * determine", never idle.
+ */
+export function useAgentRuns(pollMs = 5000) {
+  const [runs, setRuns] = useState<AgentRunStatus[]>([]);
+  const [error, setError] = useState(false);
+  // Distinguishes "first poll has not returned" from "polled, nothing
+  // running" — otherwise the pane briefly renders idle over a live run
+  // on every mount.
+  const [loaded, setLoaded] = useState(false);
+  const alive = useRef(true);
+
+  useEffect(() => {
+    alive.current = true;
+    let handle: number | undefined;
+
+    const tick = async () => {
+      try {
+        const next = await api.agentsRunningList();
+        if (!alive.current) return;
+        setRuns(next);
+        setError(false);
+      } catch {
+        if (!alive.current) return;
+        // Keep the last known list rather than blanking it: a transient
+        // IPC failure should not make a live run vanish from the UI.
+        setError(true);
+      } finally {
+        if (alive.current) setLoaded(true);
+      }
+    };
+
+    void tick();
+    handle = window.setInterval(() => void tick(), pollMs);
+    return () => {
+      alive.current = false;
+      if (handle !== undefined) window.clearInterval(handle);
+    };
+  }, [pollMs]);
+
+  return { runs, error, loaded };
+}
+
+/** One agent's run status, if the poll has seen it.
+ *
+ *  `undefined` means "the poll has not reported this agent" — distinct
+ *  from a status whose `in_flight` is null, which means "polled, nothing
+ *  running". The card needs both distinctions to avoid rendering an
+ *  unknown as idle. */
+export function statusFor(
+  runs: AgentRunStatus[],
+  agentId: string,
+): AgentRunStatus | undefined {
+  return runs.find((r) => r.agent_id === agentId);
+}

--- a/src/hooks/useAgentRuns.ts
+++ b/src/hooks/useAgentRuns.ts
@@ -29,28 +29,40 @@ export function useAgentRuns(pollMs = 5000) {
   useEffect(() => {
     alive.current = true;
     let handle: number | undefined;
+    // Monotonic request id. `setInterval` could start a second poll
+    // while the first was still in flight, and a slow earlier response
+    // resolving last would overwrite fresher state — including a stale
+    // empty list rendering idle over a live run. Chained timeouts plus
+    // this guard make that unrepresentable.
+    let seq = 0;
 
     const tick = async () => {
+      const mine = ++seq;
       try {
         const next = await api.agentsRunningList();
-        if (!alive.current) return;
+        if (!alive.current || mine !== seq) return;
         setRuns(next);
         setError(false);
       } catch {
-        if (!alive.current) return;
-        // Keep the last known list rather than blanking it: a transient
-        // IPC failure should not make a live run vanish from the UI.
+        if (!alive.current || mine !== seq) return;
+        // Keep the last known list rather than blanking it, but flag the
+        // failure: consumers render "can't determine", never idle, and
+        // must not present the stale list as current fact.
         setError(true);
       } finally {
-        if (alive.current) setLoaded(true);
+        if (alive.current && mine === seq) {
+          setLoaded(true);
+          // Schedule the NEXT poll only after this one settled, so two
+          // can never be in flight at once.
+          handle = window.setTimeout(() => void tick(), pollMs);
+        }
       }
     };
 
     void tick();
-    handle = window.setInterval(() => void tick(), pollMs);
     return () => {
       alive.current = false;
-      if (handle !== undefined) window.clearInterval(handle);
+      if (handle !== undefined) window.clearTimeout(handle);
     };
   }, [pollMs]);
 

--- a/src/lib/elapsed.test.ts
+++ b/src/lib/elapsed.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { formatElapsed } from "./elapsed";
+
+const S = 1000;
+const M = 60 * S;
+const H = 60 * M;
+
+describe("formatElapsed", () => {
+  it("shows seconds under two minutes, where they are still information", () => {
+    expect(formatElapsed(0)).toBe("0s");
+    expect(formatElapsed(42 * S)).toBe("42s");
+    expect(formatElapsed(M + 42 * S)).toBe("1m 42s");
+  });
+
+  // The whole reason the formatter is adaptive: a 15-minute run ticking
+  // seconds is noise, and a flickering ambient row gets ignored.
+  it("drops seconds from two minutes onward", () => {
+    expect(formatElapsed(2 * M)).toBe("2m");
+    expect(formatElapsed(14 * M + 46 * S)).toBe("14m");
+    expect(formatElapsed(59 * M + 59 * S)).toBe("59m");
+  });
+
+  it("switches to hours at the hour boundary", () => {
+    expect(formatElapsed(H)).toBe("1h 0m");
+    expect(formatElapsed(H + 12 * M)).toBe("1h 12m");
+    expect(formatElapsed(25 * H + 3 * M)).toBe("25h 3m");
+  });
+
+  // Clock skew between the backend's started_ms and the renderer's
+  // Date.now() must not render "-3s", which reads as an app bug.
+  it("clamps a negative duration to zero rather than rendering it", () => {
+    expect(formatElapsed(-1)).toBe("0s");
+    expect(formatElapsed(-60 * M)).toBe("0s");
+  });
+
+  // Exact boundaries, because off-by-one here is invisible in review.
+  it("is exact at every band boundary", () => {
+    expect(formatElapsed(2 * M - 1)).toBe("1m 59s");
+    expect(formatElapsed(H - 1)).toBe("59m");
+  });
+});

--- a/src/lib/elapsed.ts
+++ b/src/lib/elapsed.ts
@@ -1,0 +1,45 @@
+// Adaptive elapsed-duration formatting for live agent runs.
+//
+// Granularity by magnitude, per dev-docs/agents-run-visibility-plan.md
+// §2.5. Seconds ticking for a fifteen-minute run is visual noise, and a
+// surface that flickers gets ignored — which defeats the point of an
+// ambient indicator.
+//
+// Pure and locale-independent by design: the unit suffixes are the same
+// short forms in both catalogs today, and threading i18n through a
+// function called on a 1s timer would re-resolve the catalog every tick
+// for no reader benefit. If a locale ever needs different units, this
+// becomes a `t()` call — not a second formatter.
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
+/**
+ * Format a running duration.
+ *
+ * | Elapsed  | Rendered  |
+ * |----------|-----------|
+ * | < 2 min  | `1m 42s`  |
+ * | < 1 hour | `14m`     |
+ * | >= 1 hour| `1h 12m`  |
+ *
+ * Negative input clamps to zero: a clock skew between the backend's
+ * `started_ms` and the renderer's `Date.now()` must render `0s`, never
+ * a negative duration, which would read as a bug in the app rather than
+ * in the clock.
+ */
+export function formatElapsed(ms: number): string {
+  const t = Math.max(0, ms);
+  if (t < 2 * MINUTE) {
+    const m = Math.floor(t / MINUTE);
+    const s = Math.floor((t % MINUTE) / SECOND);
+    return m > 0 ? `${m}m ${s}s` : `${s}s`;
+  }
+  if (t < HOUR) {
+    return `${Math.floor(t / MINUTE)}m`;
+  }
+  const h = Math.floor(t / HOUR);
+  const m = Math.floor((t % HOUR) / MINUTE);
+  return `${h}h ${m}m`;
+}

--- a/src/locales/en/agents.json
+++ b/src/locales/en/agents.json
@@ -63,7 +63,8 @@
       "runNowDisabled": "Already running — started {{started}}",
       "never": "Never run",
       "lastOk": "Last run {{ago}} ago · took {{took}}",
-      "lastFailed": "Last run failed {{ago}} ago — exit {{code}}"
+      "lastFailed": "Last run failed {{ago}} ago — exit {{code}}",
+      "runNowUnknown": "Can't tell whether a run is in progress — refusing to start another"
     }
   },
   "form": {

--- a/src/locales/en/agents.json
+++ b/src/locales/en/agents.json
@@ -55,6 +55,15 @@
       "delete": "Delete",
       "showRuns": "Show runs",
       "hideRuns": "Hide runs"
+    },
+    "run": {
+      "running": "● Running · {{elapsed}} — started {{started}}",
+      "interrupted": "Interrupted — no result recorded",
+      "unknown": "Can't determine whether a run is in progress",
+      "runNowDisabled": "Already running — started {{started}}",
+      "never": "Never run",
+      "lastOk": "Last run {{ago}} ago · took {{took}}",
+      "lastFailed": "Last run failed {{ago}} ago — exit {{code}}"
     }
   },
   "form": {

--- a/src/locales/en/components.json
+++ b/src/locales/en/components.json
@@ -138,7 +138,8 @@
     "sessionFallback": "session",
     "rename": "{{verb}} {{from}} → {{to}}",
     "renameFiles": "{{base}} ({{phase}}: {{done}}/{{total}} files)",
-    "renamePhase": "{{base}} ({{phase}})"
+    "renamePhase": "{{base}} ({{phase}})",
+    "runningAgent": "Running agent"
   },
   "notifLog": {
     "panel": "Notifications",

--- a/src/locales/zh-CN/agents.json
+++ b/src/locales/zh-CN/agents.json
@@ -55,6 +55,15 @@
       "delete": "删除",
       "showRuns": "显示运行记录",
       "hideRuns": "隐藏运行记录"
+    },
+    "run": {
+      "running": "● 运行中 · {{elapsed}} —— 开始于 {{started}}",
+      "interrupted": "已中断——没有记录结果",
+      "unknown": "无法确定是否有运行正在进行",
+      "runNowDisabled": "已在运行——开始于 {{started}}",
+      "never": "从未运行",
+      "lastOk": "上次运行于 {{ago}} 前 · 用时 {{took}}",
+      "lastFailed": "上次运行失败于 {{ago}} 前 —— 退出码 {{code}}"
     }
   },
   "form": {

--- a/src/locales/zh-CN/agents.json
+++ b/src/locales/zh-CN/agents.json
@@ -63,7 +63,8 @@
       "runNowDisabled": "已在运行——开始于 {{started}}",
       "never": "从未运行",
       "lastOk": "上次运行于 {{ago}} 前 · 用时 {{took}}",
-      "lastFailed": "上次运行失败于 {{ago}} 前 —— 退出码 {{code}}"
+      "lastFailed": "上次运行失败于 {{ago}} 前 —— 退出码 {{code}}",
+      "runNowUnknown": "无法确定是否有运行正在进行——拒绝再启动一个"
     }
   },
   "form": {

--- a/src/locales/zh-CN/components.json
+++ b/src/locales/zh-CN/components.json
@@ -133,7 +133,8 @@
     "sessionFallback": "会话",
     "rename": "{{verb}} {{from}} → {{to}}",
     "renameFiles": "{{base}}（{{phase}}：{{done}}/{{total}} 个文件）",
-    "renamePhase": "{{base}}（{{phase}}）"
+    "renamePhase": "{{base}}（{{phase}}）",
+    "runningAgent": "正在运行代理"
   },
   "notifLog": {
     "panel": "通知",

--- a/src/sections/AgentsSection.tsx
+++ b/src/sections/AgentsSection.tsx
@@ -8,6 +8,7 @@ import { SkeletonList } from "../components/primitives/Skeleton";
 import { NF } from "../icons";
 import { api } from "../api";
 import { renderError } from "../lib/i18n-error";
+import { useAgentRuns, statusFor } from "../hooks/useAgentRuns";
 import { useAppState } from "../providers/AppStateProvider";
 import type {
   AgentSummaryDto,
@@ -48,6 +49,11 @@ export function AgentsSection() {
   const [capabilities, setCapabilities] =
     useState<SchedulerCapabilitiesDto | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  // Liveness is OBSERVED, not remembered. `busyIds` below is now only
+  // "a mutation is in flight on this card" — the two were one boolean
+  // until 2026-08-18, which is why a 15-minute run and a 200ms toggle
+  // were indistinguishable. See dev-docs/agents-run-visibility-plan.md.
+  const { runs, error: runsUnknown } = useAgentRuns();
   const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
   const [showAdd, setShowAdd] = useState(false);
   const [showGallery, setShowGallery] = useState(false);
@@ -113,7 +119,6 @@ export function AgentsSection() {
   async function handleRun(id: string) {
     setBusy(id, true);
     let unlisten: (() => void) | null = null;
-    let timeoutHandle: number | undefined;
     let cancelled = false;
     const cleanup = () => {
       cancelled = true;
@@ -125,10 +130,6 @@ export function AgentsSection() {
           /* listener already torn down */
         }
         unlisten = null;
-      }
-      if (timeoutHandle !== undefined) {
-        window.clearTimeout(timeoutHandle);
-        timeoutHandle = undefined;
       }
     };
     runCleanupsRef.current.add(cleanup);
@@ -167,12 +168,12 @@ export function AgentsSection() {
         return;
       }
       unlisten = u;
-      // Safety timeout in case the event channel drops — clear busy
-      // after 5 minutes so the UI doesn't get stuck forever.
-      timeoutHandle = window.setTimeout(() => {
-        setBusy(id, false);
-        cleanup();
-      }, 5 * 60 * 1000);
+      // NO safety timeout. The old one cleared `busy` after 5 minutes
+      // "so the UI doesn't get stuck forever" — but a real run takes
+      // ~15, so it re-enabled Run Now two thirds of the way through a
+      // live run and invited a second concurrent one. Running state now
+      // comes from `useAgentRuns`, which is observed rather than
+      // remembered, so there is no stuck state left to rescue.
     } catch (e) {
       const wasCancelled = cancelled;
       cleanup();
@@ -316,7 +317,9 @@ export function AgentsSection() {
             <AgentCard
               key={a.id}
               agent={a}
-              busy={busyIds.has(a.id)}
+              mutating={busyIds.has(a.id)}
+              runStatus={statusFor(runs, a.id)}
+              runsUnknown={runsUnknown}
               runsRefreshKey={runsRefreshKey}
               onRun={handleRun}
               onEdit={setEditTarget}

--- a/src/sections/AgentsSection.tsx
+++ b/src/sections/AgentsSection.tsx
@@ -53,7 +53,17 @@ export function AgentsSection() {
   // "a mutation is in flight on this card" — the two were one boolean
   // until 2026-08-18, which is why a 15-minute run and a 200ms toggle
   // were indistinguishable. See dev-docs/agents-run-visibility-plan.md.
-  const { runs, error: runsUnknown } = useAgentRuns();
+  // `loaded` is load-bearing: before the first poll returns there is no
+  // status for any agent, and rendering that as "Never run" would state
+  // an unverified claim as fact over a live cron run. Not-yet-loaded and
+  // poll-failed are the same thing to the UI — both mean "we do not
+  // know" — so they collapse into one flag here.
+  const {
+    runs,
+    error: pollFailed,
+    loaded: runsLoaded,
+  } = useAgentRuns();
+  const runsUnknown = pollFailed || !runsLoaded;
   const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
   const [showAdd, setShowAdd] = useState(false);
   const [showGallery, setShowGallery] = useState(false);
@@ -95,9 +105,9 @@ export function AgentsSection() {
     });
   }
 
-  // In-flight "Run now" cleanups (op-progress unlisten + safety
-  // timeout), keyed by identity. handleRun's listener/timeout used to
-  // be handler-scoped only — unmounting mid-run leaked them and let
+  // In-flight "Run now" cleanups (op-progress unlisten), keyed by
+  // identity. handleRun's listener used to be handler-scoped only —
+  // unmounting mid-run leaked it and let
   // late events setState on an unmounted component (audit 2026-07
   // F5). Every cleanup registers here and self-removes; the unmount
   // effect drains whatever is still pending.
@@ -136,6 +146,16 @@ export function AgentsSection() {
     try {
       const opId = await api.agentsRunNowStart(id);
       if (cancelled) return; // unmounted while starting
+      // The START has succeeded, so the mutation is over. Liveness now
+      // owns the long lock: `run.state === "running"` disables Run Now
+      // for as long as the run actually lasts, observed rather than
+      // remembered.
+      //
+      // Holding `mutating` until the op-progress terminal event would
+      // reintroduce the stuck button the deleted 5-minute timeout used
+      // to rescue — a dropped event would disable the card's controls
+      // permanently, with nothing left to clear them.
+      setBusy(id, false);
       // Listen for the terminal event on this op channel. The
       // backend (src-tauri/src/ops.rs::ProgressEvent) emits the
       // terminal event as `{phase: "op", status: "complete" | "error", ...}`.
@@ -153,7 +173,6 @@ export function AgentsSection() {
           } else {
             setRunsRefreshKey((k) => k + 1);
           }
-          setBusy(id, false);
           cleanup();
         }
       });
@@ -319,7 +338,7 @@ export function AgentsSection() {
               agent={a}
               mutating={busyIds.has(a.id)}
               runStatus={statusFor(runs, a.id)}
-              runsUnknown={runsUnknown}
+              runsUnknown={runsUnknown || (statusFor(runs, a.id)?.unreadable ?? false)}
               runsRefreshKey={runsRefreshKey}
               onRun={handleRun}
               onEdit={setEditTarget}

--- a/src/sections/AgentsSection.tsx
+++ b/src/sections/AgentsSection.tsx
@@ -343,7 +343,15 @@ export function AgentsSection() {
               agent={a}
               mutating={busyIds.has(a.id)}
               runStatus={statusFor(runs, a.id)}
-              runsUnknown={runsUnknown || (statusFor(runs, a.id)?.unreadable ?? false)}
+              runsUnknown={
+                runsUnknown ||
+                // A loaded poll now returns a row for every installed
+                // agent, so a MISSING row means "not reported", not
+                // "never ran" — render unknown rather than a confident
+                // "Never run".
+                statusFor(runs, a.id) === undefined ||
+                (statusFor(runs, a.id)?.unreadable ?? false)
+              }
               runsRefreshKey={runsRefreshKey}
               onRun={handleRun}
               onEdit={setEditTarget}

--- a/src/sections/AgentsSection.tsx
+++ b/src/sections/AgentsSection.tsx
@@ -63,7 +63,12 @@ export function AgentsSection() {
     error: pollFailed,
     loaded: runsLoaded,
   } = useAgentRuns();
-  const runsUnknown = pollFailed || !runsLoaded;
+  // The agents ROOT being unreadable arrives as a synthetic row with an
+  // empty `agent_id`, which matches no card by construction. Detecting
+  // it here is what makes that signal reach the UI at all — without this
+  // the sentinel is produced, serialized, and silently dropped.
+  const rootUnreadable = runs.some((r) => r.root_error != null);
+  const runsUnknown = pollFailed || !runsLoaded || rootUnreadable;
   const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
   const [showAdd, setShowAdd] = useState(false);
   const [showGallery, setShowGallery] = useState(false);

--- a/src/sections/agents/AgentCard.test.tsx
+++ b/src/sections/agents/AgentCard.test.tsx
@@ -39,7 +39,7 @@ function run(over: Partial<InFlightRun> = {}): InFlightRun {
 }
 
 function status(over: Partial<AgentRunStatus> = {}): AgentRunStatus {
-  return { agent_id: "a1", in_flight: null, last: null, ...over };
+  return { agent_id: "a1", in_flight: null, last: null, unreadable: false, ...over };
 }
 
 const noop = () => {};
@@ -180,5 +180,60 @@ describe("AgentCard — run visibility", () => {
     expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
     expect(screen.queryByRole("status")).toBeNull();
     expect(screen.queryByText(/already running/i)).toBeNull();
+  });
+});
+
+// Round-1 audit regressions.
+describe("AgentCard — unknown never renders as fact", () => {
+  // #7: the hook keeps the last known list through a failed poll so a
+  // live run does not blink out — but presenting that stale row as a
+  // confident "Running", with a ticking clock, is the exact failure this
+  // feature exists to prevent.
+  it("a failed poll overrides a stale cached run", () => {
+    render(
+      <AgentCard
+        agent={agent()}
+        runStatus={status({ in_flight: run() })}
+        runsUnknown
+        {...props}
+      />,
+    );
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.getByText(/can't determine/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Running/)).toBeNull();
+  });
+
+  // #5: before the first poll returns there is no status for any agent.
+  // Rendering that as "Never run" states an unverified claim as fact
+  // over a live cron run.
+  it("does not claim 'never run' before the first poll returns", () => {
+    render(<AgentCard agent={agent()} runsUnknown {...props} />);
+    expect(screen.queryByText(/never run/i)).toBeNull();
+    expect(screen.getByText(/can't determine/i)).toBeInTheDocument();
+  });
+});
+
+// Round-1 verify regressions: two fixes introduced new defects.
+describe("AgentCard — unknown refuses rather than permits", () => {
+  // The first fix for #7 made `isRunning` false while unknown so a stale
+  // row would stop rendering as fact — but `controlsLocked` keyed off
+  // `isRunning`, so Run Now became clickable exactly when we could not
+  // tell whether a run was live. Not knowing is a reason to refuse.
+  it("disables Run Now when the poll state is unknown", () => {
+    render(<AgentCard agent={agent()} runsUnknown {...props} />);
+    expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
+    expect(screen.getByText(/refusing to start another/i)).toBeInTheDocument();
+  });
+
+  it("still disables Run Now when unknown overrides a stale run", () => {
+    render(
+      <AgentCard
+        agent={agent()}
+        runStatus={status({ in_flight: run() })}
+        runsUnknown
+        {...props}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
   });
 });

--- a/src/sections/agents/AgentCard.test.tsx
+++ b/src/sections/agents/AgentCard.test.tsx
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AgentCard } from "./AgentCard";
+import type { AgentRunStatus, AgentSummaryDto, InFlightRun } from "../../types";
+
+vi.mock("./RunHistoryPanel", () => ({
+  RunHistoryPanel: () => null,
+}));
+
+function agent(over: Partial<AgentSummaryDto> = {}): AgentSummaryDto {
+  return {
+    id: "a1",
+    name: "cc-upstream-watch",
+    display_name: "CC upstream watch",
+    description: null,
+    enabled: true,
+    lifecycle: "installed",
+    trigger_kind: "cron",
+    trigger_summary: "0 3 1 * *",
+    next_run: null,
+    last_run: null,
+    model: "sonnet",
+    permission_mode: "dontAsk",
+    allowed_tools: [],
+    max_budget_usd: null,
+    cwd: "/repo",
+    ...over,
+  } as unknown as AgentSummaryDto;
+}
+
+function run(over: Partial<InFlightRun> = {}): InFlightRun {
+  return {
+    agent_id: "a1",
+    run_id: "r1",
+    started_ms: Date.now() - 14 * 60 * 1000,
+    state: "running",
+    ...over,
+  };
+}
+
+function status(over: Partial<AgentRunStatus> = {}): AgentRunStatus {
+  return { agent_id: "a1", in_flight: null, last: null, ...over };
+}
+
+const noop = () => {};
+const props = {
+  mutating: false,
+  runsRefreshKey: 0,
+  onRun: noop,
+  onEdit: noop,
+  onToggle: noop,
+  onRemove: noop,
+  onReview: noop,
+};
+
+describe("AgentCard — run visibility", () => {
+  it("shows nothing when no run is in flight", () => {
+    render(<AgentCard agent={agent()} {...props} />);
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.getByRole("button", { name: /run now/i })).toBeEnabled();
+  });
+
+  // §2.2's three idle rows. "never completed a run" and "the last run
+  // failed" are different statements and must not collapse.
+  it("says never run when the agent has no completed run", () => {
+    render(<AgentCard agent={agent()} runStatus={status()} {...props} />);
+    expect(screen.getByText(/never run/i)).toBeInTheDocument();
+  });
+
+  it("reports a successful last run with when and how long", () => {
+    render(
+      <AgentCard
+        agent={agent()}
+        runStatus={status({
+          last: {
+            run_id: "r0",
+            ended_ms: Date.now() - 2 * 60 * 60 * 1000,
+            exit_code: 0,
+            duration_ms: 886422,
+          },
+        })}
+        {...props}
+      />,
+    );
+    expect(screen.getByText(/last run 2h/i)).toBeInTheDocument();
+    expect(screen.getByText(/14m/)).toBeInTheDocument();
+  });
+
+  it("reports a failed last run with its exit code and nothing invented", () => {
+    render(
+      <AgentCard
+        agent={agent()}
+        runStatus={status({
+          last: {
+            run_id: "r0",
+            ended_ms: Date.now() - 5 * 60 * 1000,
+            exit_code: 1,
+            duration_ms: 19247,
+          },
+        })}
+        {...props}
+      />,
+    );
+    const row = screen.getByText(/last run failed/i);
+    expect(row).toHaveTextContent(/exit 1/);
+    // The cause is not in result.json; guessing one is how a status
+    // surface starts lying.
+    expect(row).not.toHaveTextContent(/budget|timeout|crash/i);
+  });
+
+  // A live run supersedes history — two ambient rows on one card would
+  // breach the signal budget.
+  it("hides last-run history while a run is live", () => {
+    render(
+      <AgentCard
+        agent={agent()}
+        runStatus={status({
+          in_flight: run(),
+          last: {
+            run_id: "r0",
+            ended_ms: Date.now() - 60_000,
+            exit_code: 0,
+            duration_ms: 1000,
+          },
+        })}
+        {...props}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(/Running/);
+    expect(screen.queryByText(/last run/i)).toBeNull();
+  });
+
+  it("shows elapsed time while a run is live", () => {
+    render(<AgentCard agent={agent()} runStatus={status({ in_flight: run() })} {...props} />);
+    expect(screen.getByRole("status")).toHaveTextContent(/Running/);
+    expect(screen.getByRole("status")).toHaveTextContent(/14m/);
+  });
+
+  // §1.1: the button used to re-enable itself five minutes into a
+  // fifteen-minute run, inviting a second concurrent run.
+  it("disables Run Now while running and states the reason inline", () => {
+    render(<AgentCard agent={agent()} runStatus={status({ in_flight: run() })} {...props} />);
+    expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
+    // design.md: the reason is inline text, not a tooltip/title.
+    expect(screen.getByText(/already running/i)).toBeInTheDocument();
+  });
+
+  // §1.2 third row, and the whole reason the agent noun exists: a
+  // cron-fired run involves no click, so nothing local ever knows about
+  // it. It must render exactly like a manual one.
+  it("renders a cron-fired run identically to a manual one", () => {
+    // No onRun was ever called; the run arrives purely from the poll.
+    render(<AgentCard agent={agent()} runStatus={status({ in_flight: run() })} {...props} />);
+    expect(screen.getByRole("status")).toHaveTextContent(/Running/);
+    expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
+  });
+
+  // A crashed run must read as neither "running" nor "fine".
+  it("labels an interrupted run without claiming it is running", () => {
+    render(
+      <AgentCard agent={agent()} runStatus={status({ in_flight: run({ state: "interrupted" }) })} {...props} />,
+    );
+    const row = screen.getByRole("status");
+    expect(row).toHaveTextContent(/Interrupted/);
+    expect(row).not.toHaveTextContent(/Running/);
+    // Interrupted means nothing is working on it — Run Now is available.
+    expect(screen.getByRole("button", { name: /run now/i })).toBeEnabled();
+  });
+
+  // A failed poll must not render as idle — same rule as scan_incomplete.
+  it("says it cannot determine state rather than showing idle", () => {
+    render(<AgentCard agent={agent()} runsUnknown {...props} />);
+    expect(screen.getByText(/can't determine/i)).toBeInTheDocument();
+  });
+
+  // `mutating` is a sub-second state; it locks the controls but must not
+  // claim a run is in progress.
+  it("a mutation locks controls without claiming a run", () => {
+    render(<AgentCard agent={agent()} {...props} mutating />);
+    expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByText(/already running/i)).toBeNull();
+  });
+});

--- a/src/sections/agents/AgentCard.test.tsx
+++ b/src/sections/agents/AgentCard.test.tsx
@@ -257,3 +257,29 @@ describe("AgentCard — unknown must not trap the agent", () => {
     expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled();
   });
 });
+
+// Round-3 regressions.
+describe("AgentCard — a live run guards destructive actions", () => {
+  // R3-5. `agents_remove` deletes the run directory the shim is still
+  // writing into, so a live run must lock Edit/Delete/Toggle — while
+  // merely-unknown liveness must NOT (round 2). Different conditions,
+  // different locks.
+  it("locks Edit and Delete while a run is live", () => {
+    render(
+      <AgentCard
+        agent={agent()}
+        runStatus={status({ in_flight: run() })}
+        {...props}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /edit/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled();
+  });
+
+  it("but leaves them available when liveness is merely unknown", () => {
+    render(<AgentCard agent={agent()} runsUnknown {...props} />);
+    expect(screen.getByRole("button", { name: /edit/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
+  });
+});

--- a/src/sections/agents/AgentCard.test.tsx
+++ b/src/sections/agents/AgentCard.test.tsx
@@ -237,3 +237,23 @@ describe("AgentCard — unknown refuses rather than permits", () => {
     expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
   });
 });
+
+// Round-2 regressions.
+describe("AgentCard — unknown must not trap the agent", () => {
+  // R2-4: the first fix locked EVERY control on unknown, so an agent
+  // with an unreadable runs directory could not be edited or deleted —
+  // the exact actions needed to fix it. Refusing a new run is right;
+  // trapping the agent is not.
+  it("leaves Edit and Delete available while liveness is unknown", () => {
+    render(<AgentCard agent={agent()} runsUnknown {...props} />);
+    expect(screen.getByRole("button", { name: /run now/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /edit/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeEnabled();
+  });
+
+  it("still locks everything during a real mutation", () => {
+    render(<AgentCard agent={agent()} {...props} mutating />);
+    expect(screen.getByRole("button", { name: /edit/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled();
+  });
+});

--- a/src/sections/agents/AgentCard.tsx
+++ b/src/sections/agents/AgentCard.tsx
@@ -75,8 +75,16 @@ export function AgentCard({
   // unreadable runs directory impossible to EDIT or DELETE — the very
   // actions a user needs to fix it. Unknown liveness is a reason to
   // refuse a new run; it is not a reason to trap the agent.
+  // Two locks with different conditions, and both rounds of review are
+  // encoded here:
+  //   round 2 — unknown liveness must NOT trap the agent, or a bad runs
+  //             directory makes it impossible to edit or delete.
+  //   round 3 — a LIVE run must lock the destructive/definition-changing
+  //             actions: `agents_remove` deletes the run directory the
+  //             shim is still writing into.
+  // So unknown blocks only a new run; running blocks everything.
   const runLocked = mutating || isRunning || runsUnknown;
-  const mutationLocked = mutating;
+  const mutationLocked = mutating || isRunning;
 
   // Live elapsed. The 1s interval exists ONLY while a run is live —
   // render-if-nonzero applied to timers, not just to text. Without the

--- a/src/sections/agents/AgentCard.tsx
+++ b/src/sections/agents/AgentCard.tsx
@@ -71,7 +71,12 @@ export function AgentCard({
   // rendering as fact — but `controlsLocked` keyed off `isRunning`, so
   // the button became clickable exactly when we could not tell whether a
   // run was live. Not knowing is a reason to refuse, not to permit.
-  const controlsLocked = mutating || isRunning || runsUnknown;
+  // Two locks, not one. Conflating them made an agent with an
+  // unreadable runs directory impossible to EDIT or DELETE — the very
+  // actions a user needs to fix it. Unknown liveness is a reason to
+  // refuse a new run; it is not a reason to trap the agent.
+  const runLocked = mutating || isRunning || runsUnknown;
+  const mutationLocked = mutating;
 
   // Live elapsed. The 1s interval exists ONLY while a run is live —
   // render-if-nonzero applied to timers, not just to text. Without the
@@ -298,14 +303,14 @@ export function AgentCard({
             <Button
               variant="solid"
               onClick={() => onReview(agent)}
-              disabled={controlsLocked}
+              disabled={mutationLocked}
             >
               {t("card.actions.reviewInstall")}
             </Button>
             <Button
               variant="ghost"
               onClick={() => onRemove(agent)}
-              disabled={controlsLocked}
+              disabled={mutationLocked}
             >
               {t("card.actions.delete")}
             </Button>
@@ -315,21 +320,21 @@ export function AgentCard({
             <Button
               variant="solid"
               onClick={() => onRun(agent.id)}
-              disabled={controlsLocked}
+              disabled={runLocked}
             >
               {t("card.actions.runNow")}
             </Button>
             <Button
               variant="ghost"
               onClick={() => onEdit(agent)}
-              disabled={controlsLocked}
+              disabled={mutationLocked}
             >
               {t("card.actions.edit")}
             </Button>
             <Button
               variant="ghost"
               onClick={() => onToggle(agent.id, !agent.enabled)}
-              disabled={controlsLocked}
+              disabled={mutationLocked}
             >
               {agent.enabled
                 ? t("card.actions.disable")
@@ -338,7 +343,7 @@ export function AgentCard({
             <Button
               variant="ghost"
               onClick={() => onRemove(agent)}
-              disabled={controlsLocked}
+              disabled={mutationLocked}
             >
               {t("card.actions.delete")}
             </Button>

--- a/src/sections/agents/AgentCard.tsx
+++ b/src/sections/agents/AgentCard.tsx
@@ -1,13 +1,27 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "../../components/primitives/Button";
 import { Tag } from "../../components/primitives/Tag";
-import type { AgentSummaryDto } from "../../types";
+import type { AgentRunStatus, AgentSummaryDto } from "../../types";
+import { formatElapsed } from "../../lib/elapsed";
 import { RunHistoryPanel } from "./RunHistoryPanel";
 
 interface Props {
   agent: AgentSummaryDto;
-  busy: boolean;
+  /** A *mutation* is in flight on this card (edit / delete / toggle).
+   *  Deliberately NOT "this agent is running" — the two were one boolean
+   *  until 2026-08-18 and could not be told apart, so a 15-minute run
+   *  and a 200ms toggle disabled the same controls for the same reason.
+   *  Liveness is `run`, below, and it comes from the backend. */
+  mutating: boolean;
+  /** This agent's run state from the liveness poll: the in-flight run if
+   *  any, plus the last completed one. `undefined` means the poll has
+   *  not reported this agent yet — distinct from a status whose
+   *  `in_flight` is null, which means "polled, nothing running". */
+  runStatus?: AgentRunStatus;
+  /** The liveness poll itself failed. Renders "can't determine" rather
+   *  than idle — a failed read is not a clean result. */
+  runsUnknown?: boolean;
   /** Increments when a run completes — RunHistoryPanel re-fetches. */
   runsRefreshKey: number;
   onRun: (id: string) => void;
@@ -18,9 +32,18 @@ interface Props {
   onReview: (a: AgentSummaryDto) => void;
 }
 
+/** Coarse "how long ago", reusing the elapsed formatter so a run that
+ *  finished 14 minutes ago and one that ran for 14 minutes read in the
+ *  same units. */
+function relativeAgo(endedMs: number, nowMs: number): string {
+  return formatElapsed(nowMs - endedMs);
+}
+
 export function AgentCard({
   agent,
-  busy,
+  mutating,
+  runStatus,
+  runsUnknown = false,
   runsRefreshKey,
   onRun,
   onEdit,
@@ -35,6 +58,30 @@ export function AgentCard({
   // install" because none of those actions are meaningful until a
   // human arms the agent.
   const isDraft = agent.lifecycle === "draft";
+
+  const run = runStatus?.in_flight ?? undefined;
+  const last = runStatus?.last ?? undefined;
+  const isRunning = run?.state === "running";
+  // Both reasons disable the controls, but they are different facts and
+  // only one of them gets an inline explanation next to Run Now.
+  const controlsLocked = mutating || isRunning;
+
+  // Live elapsed. The 1s interval exists ONLY while a run is live —
+  // render-if-nonzero applied to timers, not just to text. Without the
+  // guard every card would hold a ticking interval forever.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!isRunning) return;
+    const h = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(h);
+  }, [isRunning]);
+
+  const startedLabel = run
+    ? new Date(run.started_ms).toLocaleTimeString(undefined, {
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : "";
 
   return (
     <article
@@ -166,6 +213,57 @@ export function AgentCard({
         )}
       </div>
 
+      {/* The ambient tier for this agent — exactly one row, per
+          design.md's signal budget. The status-bar chip carries the
+          COUNT; identity and duration live here, on the thing you are
+          looking at. Render-if-nonzero: absent entirely when idle. */}
+      {run && (
+        <div
+          role="status"
+          style={{
+            fontSize: "var(--fs-xs)",
+            color: isRunning ? "var(--fg-muted)" : "var(--warn)",
+          }}
+        >
+          {isRunning
+            ? t("card.run.running", {
+                elapsed: formatElapsed(now - run.started_ms),
+                started: startedLabel,
+              })
+            : /* Not "failed" and not "running" — the run left no result
+                 and nothing is working on it. Saying which of those it
+                 was would be a guess. */
+              t("card.run.interrupted")}
+        </div>
+      )}
+      {runsUnknown && !run && (
+        <div style={{ fontSize: "var(--fs-xs)", color: "var(--warn)" }}>
+          {t("card.run.unknown")}
+        </div>
+      )}
+      {/* The three idle states from the plan's §2.2 table. Only rendered
+          when nothing is in flight — a live run supersedes history, and
+          showing both would put two ambient rows on one card. */}
+      {!isDraft && !run && !runsUnknown && (
+        <div style={{ fontSize: "var(--fs-xs)", color: "var(--fg-faint)" }}>
+          {!last
+            ? t("card.run.never")
+            : last.exit_code === 0
+              ? t("card.run.lastOk", {
+                  ago: relativeAgo(last.ended_ms, now),
+                  took: formatElapsed(last.duration_ms),
+                })
+              : /* The exit code is the only honest thing we have here;
+                   naming a cause ("budget exhausted") would require
+                   parsing the run's stdout, and guessing one is how a
+                   status surface starts lying. */
+                t("card.run.lastFailed", {
+                  ago: relativeAgo(last.ended_ms, now),
+                  code: last.exit_code,
+                })}
+        </div>
+      )}
+
       <footer
         style={{
           display: "flex",
@@ -181,14 +279,14 @@ export function AgentCard({
             <Button
               variant="solid"
               onClick={() => onReview(agent)}
-              disabled={busy}
+              disabled={controlsLocked}
             >
               {t("card.actions.reviewInstall")}
             </Button>
             <Button
               variant="ghost"
               onClick={() => onRemove(agent)}
-              disabled={busy}
+              disabled={controlsLocked}
             >
               {t("card.actions.delete")}
             </Button>
@@ -198,21 +296,21 @@ export function AgentCard({
             <Button
               variant="solid"
               onClick={() => onRun(agent.id)}
-              disabled={busy}
+              disabled={controlsLocked}
             >
               {t("card.actions.runNow")}
             </Button>
             <Button
               variant="ghost"
               onClick={() => onEdit(agent)}
-              disabled={busy}
+              disabled={controlsLocked}
             >
               {t("card.actions.edit")}
             </Button>
             <Button
               variant="ghost"
               onClick={() => onToggle(agent.id, !agent.enabled)}
-              disabled={busy}
+              disabled={controlsLocked}
             >
               {agent.enabled
                 ? t("card.actions.disable")
@@ -221,7 +319,7 @@ export function AgentCard({
             <Button
               variant="ghost"
               onClick={() => onRemove(agent)}
-              disabled={busy}
+              disabled={controlsLocked}
             >
               {t("card.actions.delete")}
             </Button>
@@ -234,6 +332,16 @@ export function AgentCard({
           </>
         )}
       </footer>
+
+      {/* design.md: a disabled control states its reason inline, next to
+          the button — never in a tooltip. Only the RUNNING lock is
+          explained; `mutating` is a sub-second state nobody needs a
+          sentence about. */}
+      {!isDraft && isRunning && (
+        <div style={{ fontSize: "var(--fs-xs)", color: "var(--fg-faint)" }}>
+          {t("card.run.runNowDisabled", { started: startedLabel })}
+        </div>
+      )}
 
       {!isDraft && open && (
         <RunHistoryPanel

--- a/src/sections/agents/AgentCard.tsx
+++ b/src/sections/agents/AgentCard.tsx
@@ -61,20 +61,34 @@ export function AgentCard({
 
   const run = runStatus?.in_flight ?? undefined;
   const last = runStatus?.last ?? undefined;
-  const isRunning = run?.state === "running";
+  // Unknown poll ⇒ we cannot claim the run is live, so neither the
+  // elapsed timer nor the Run Now lock may key off stale data.
+  const isRunning = !runsUnknown && run?.state === "running";
   // Both reasons disable the controls, but they are different facts and
   // only one of them gets an inline explanation next to Run Now.
-  const controlsLocked = mutating || isRunning;
+  // `runsUnknown` LOCKS Run Now rather than freeing it. An earlier fix
+  // made `isRunning` false while unknown so a stale row would stop
+  // rendering as fact — but `controlsLocked` keyed off `isRunning`, so
+  // the button became clickable exactly when we could not tell whether a
+  // run was live. Not knowing is a reason to refuse, not to permit.
+  const controlsLocked = mutating || isRunning || runsUnknown;
 
   // Live elapsed. The 1s interval exists ONLY while a run is live —
   // render-if-nonzero applied to timers, not just to text. Without the
   // guard every card would hold a ticking interval forever.
   const [now, setNow] = useState(() => Date.now());
+  // 1s while a run is live (the elapsed row moves); 60s while an idle
+  // card shows a "last run N ago" line, which would otherwise freeze at
+  // whatever `now` happened to be when the card mounted. No timer at all
+  // when the card shows neither — render-if-nonzero, applied to timers.
+  const needsFastTick = isRunning;
+  const needsSlowTick = !isRunning && !!last;
   useEffect(() => {
-    if (!isRunning) return;
-    const h = window.setInterval(() => setNow(Date.now()), 1000);
+    if (!needsFastTick && !needsSlowTick) return;
+    const period = needsFastTick ? 1000 : 60_000;
+    const h = window.setInterval(() => setNow(Date.now()), period);
     return () => window.clearInterval(h);
-  }, [isRunning]);
+  }, [needsFastTick, needsSlowTick]);
 
   const startedLabel = run
     ? new Date(run.started_ms).toLocaleTimeString(undefined, {
@@ -217,7 +231,7 @@ export function AgentCard({
           design.md's signal budget. The status-bar chip carries the
           COUNT; identity and duration live here, on the thing you are
           looking at. Render-if-nonzero: absent entirely when idle. */}
-      {run && (
+      {run && !runsUnknown && (
         <div
           role="status"
           style={{
@@ -236,7 +250,12 @@ export function AgentCard({
               t("card.run.interrupted")}
         </div>
       )}
-      {runsUnknown && !run && (
+      {/* Unknown OUTRANKS a cached run. The hook deliberately keeps the
+          last known list through a failed poll so a live run does not
+          blink out — but presenting that stale row as a confident
+          "Running", with a ticking clock, is the failure this module
+          exists to prevent. */}
+      {runsUnknown && (
         <div style={{ fontSize: "var(--fs-xs)", color: "var(--warn)" }}>
           {t("card.run.unknown")}
         </div>
@@ -337,9 +356,11 @@ export function AgentCard({
           the button — never in a tooltip. Only the RUNNING lock is
           explained; `mutating` is a sub-second state nobody needs a
           sentence about. */}
-      {!isDraft && isRunning && (
+      {!isDraft && (isRunning || runsUnknown) && (
         <div style={{ fontSize: "var(--fs-xs)", color: "var(--fg-faint)" }}>
-          {t("card.run.runNowDisabled", { started: startedLabel })}
+          {isRunning
+            ? t("card.run.runNowDisabled", { started: startedLabel })
+            : t("card.run.runNowUnknown")}
         </div>
       )}
 

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -260,3 +260,38 @@ export interface NameValidationDto {
   error: string | null;
   already_taken: boolean;
 }
+
+/** A run directory that has recorded no result yet.
+ *
+ *  Mirrors `claudepot_core::agent::liveness::InFlightRun`. `interrupted`
+ *  is not a failure state to hide — it means the run died without
+ *  recording an outcome, and the pane must say that rather than pick
+ *  between "running" and "fine". */
+export type AgentRunState = "running" | "interrupted";
+
+export interface InFlightRun {
+  agent_id: string;
+  run_id: string;
+  /** Epoch ms. Elapsed is computed client-side from this, so a slow
+   *  poll never makes the displayed clock stutter. */
+  started_ms: number;
+  state: AgentRunState;
+}
+
+/** The most recent run that recorded a result. */
+export interface LastRun {
+  run_id: string;
+  ended_ms: number;
+  exit_code: number;
+  duration_ms: number;
+}
+
+/** One agent's full run state, from a single poll.
+ *
+ *  `last: null` means "never completed a run" — a different statement
+ *  from "the last run failed", and rendered differently. */
+export interface AgentRunStatus {
+  agent_id: string;
+  in_flight: InFlightRun | null;
+  last: LastRun | null;
+}

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -294,4 +294,10 @@ export interface AgentRunStatus {
   agent_id: string;
   in_flight: InFlightRun | null;
   last: LastRun | null;
+  /** This agent's run data could not be read. When true the two fields
+   *  above are NOT trustworthy — render "can't determine", never idle. */
+  unreadable: boolean;
+  /** Set only on the synthetic sentinel returned when the agents root
+   *  itself is unreadable. */
+  root_error?: string | null;
 }

--- a/src/types/ops.ts
+++ b/src/types/ops.ts
@@ -57,7 +57,34 @@ export type OpKind =
   | "session_move"
   | "account_login"
   | "account_register"
-  | "verify_all";
+  | "verify_all"
+  /** Manual "Run Now" of an agent. Absent from this union until
+   *  2026-08-18, which is why `RunningOpsChip`'s `verb()` switch had no
+   *  arm for it and TypeScript raised nothing: a switch is only
+   *  exhaustive over the union it is given. A live agent run was counted
+   *  by the chip and rendered with an undefined verb. */
+  | "agent_run";
+
+/** Every `OpKind`, as a runtime value. Exists so a test can assert that
+ *  each one renders a label — a `switch` is exhaustive only over the
+ *  union it is handed, so an `OpKind` missing from the union above
+ *  produced no compile error and an undefined verb at runtime. Keep in
+ *  lockstep with `OpKind`; the test below fails if this list and the
+ *  union diverge. */
+export const OP_KINDS = [
+  "repair_resume",
+  "repair_rollback",
+  "move_project",
+  "clean_projects",
+  "session_prune",
+  "session_slim",
+  "session_share",
+  "session_move",
+  "account_login",
+  "account_register",
+  "verify_all",
+  "agent_run",
+] as const satisfies readonly OpKind[];
 
 /** Phase ids emitted by `session_move_with_progress`. Stable contract
  *  with `crates/claudepot-core/src/session_move.rs`. */

--- a/src/types/ops.ts
+++ b/src/types/ops.ts
@@ -45,32 +45,15 @@ export interface JournalFlags {
 /** One of "running" | "pending" | "stale" | "abandoned". */
 export type JournalStatus = "running" | "pending" | "stale" | "abandoned";
 
-/** Kind of long-running op currently tracked by the backend. */
-export type OpKind =
-  | "repair_resume"
-  | "repair_rollback"
-  | "move_project"
-  | "clean_projects"
-  | "session_prune"
-  | "session_slim"
-  | "session_share"
-  | "session_move"
-  | "account_login"
-  | "account_register"
-  | "verify_all"
-  /** Manual "Run Now" of an agent. Absent from this union until
-   *  2026-08-18, which is why `RunningOpsChip`'s `verb()` switch had no
-   *  arm for it and TypeScript raised nothing: a switch is only
-   *  exhaustive over the union it is given. A live agent run was counted
-   *  by the chip and rendered with an undefined verb. */
-  | "agent_run";
-
-/** Every `OpKind`, as a runtime value. Exists so a test can assert that
- *  each one renders a label — a `switch` is exhaustive only over the
- *  union it is handed, so an `OpKind` missing from the union above
- *  produced no compile error and an undefined verb at runtime. Keep in
- *  lockstep with `OpKind`; the test below fails if this list and the
- *  union diverge. */
+/** Every `OpKind`, as a runtime value — and the single source of truth.
+ *
+ *  `OpKind` is DERIVED from this list rather than declared beside it. An
+ *  earlier revision declared both and reconciled them with
+ *  `satisfies readonly OpKind[]`, which proves every entry IS an
+ *  `OpKind` but says nothing about completeness — so a union member
+ *  missing from the array compiled cleanly and silently dropped out of
+ *  the label-coverage test. Deriving makes the two unrepresentable
+ *  apart. */
 export const OP_KINDS = [
   "repair_resume",
   "repair_rollback",
@@ -83,8 +66,14 @@ export const OP_KINDS = [
   "account_login",
   "account_register",
   "verify_all",
+  /** Manual "Run Now" of an agent. Absent from this list until
+   *  2026-08-18, which is why `RunningOpsChip`'s `verb()` switch had no
+   *  arm for it and TypeScript raised nothing. */
   "agent_run",
-] as const satisfies readonly OpKind[];
+] as const;
+
+/** Kind of long-running op currently tracked by the backend. */
+export type OpKind = (typeof OP_KINDS)[number];
 
 /** Phase ids emitted by `session_move_with_progress`. Stable contract
  *  with `crates/claudepot-core/src/session_move.rs`. */


### PR DESCRIPTION
The first real use of the `agent` noun exposed three defects at once. A
monthly watch agent ran for **14m 46s**; the pane showed nothing for the
last ten of them, and `Run Now` sat enabled and clickable throughout.

## Root cause

Running state was renderer-local optimism: set on click, cleared by a
five-minute timer. A real run takes ~15 minutes, so the card returned to
idle two thirds of the way through and invited a second concurrent run.
A reload lost it. And a **cron-fired run — the entire reason the noun
exists — set the flag never** and was invisible for its whole life.

## The design

State is **observed**, from two independent signals: a run directory
without `result.json`, and a `run.pid` checked against the process table.

Both are needed. The first alone has two causes — alive, or died hard —
and collapsing them renders a crashed run as "Running 3 days". The
unknown gets its own state (`Interrupted`) rather than being folded into
either confident answer, which also covers every run directory predating
this change for free.

Surfaces follow `design.md`'s live-surface table: the card carries
contextual liveness (what, how long), the status-bar chip keeps the count
and gains the `agent_run` label it was missing. One ambient row per
event, per the signal budget.

## Audit

Three rounds of `cc-suite:audit-fix` with Codex as auditor: **26 findings
fixed** (12 → 8 → 6). Rounds never went quiet, so this converged on the
round limit rather than on cleanliness.

Each round found defects in the previous round's fixes:

| | |
|---|---|
| A fix that did nothing | the unreadable-root sentinel had an empty `agent_id` by construction, cards look up by id, and `root_error` wasn't in the DTO — produced, serialized, dropped |
| Overshoot, then undershoot | round 2: unknown liveness locked Edit/Delete, trapping the agent you needed to repair. Round 3: but a *live* run must lock them, since `agents_remove` deletes the directory the shim is writing |
| TOCTOU, twice | check-liveness-then-spawn, then check-then-insert. Only `insert_if_no_agent_run` closes it |
| One of a three-instance class | removed one `rd.flatten()`, called it closed; two were live |
| A lock that could never release | unbounded poll → `finally` never runs → `loaded` false forever → every agent permanently unrunnable |

## Known gap, stated

`RunningOps` is in-process, so a run started by launchd or the CLI
bypasses the atomic guard. Named in the code comment rather than papered
over; closing it needs a per-agent lock file.

## Verification

`cargo test --workspace` · `pnpm test` **1347 passed** · `tsc --noEmit` ·
clippy `-D warnings` ×4 crates · `cargo fmt --check` · `check:catalogs` ·
`verify-docs` · `verify-cc-parity` 12/12 · `repo-invariants`

Plan and status trail: `dev-docs/agents-run-visibility-plan.md`.
