### PR TITLE
An orphaned run must not shadow the agent forever

### DIFF
--- a/crates/claudepot-core/src/agent/liveness.rs
+++ b/crates/claudepot-core/src/agent/liveness.rs
@@ -310,7 +310,15 @@ pub fn last_run(agent_dir: &Path) -> Result<Option<LastRun>, ScanError> {
 
 /// Per-agent run status for every agent in the live data directory.
 pub fn scan_status_live(check: &dyn ProcessCheck) -> Vec<AgentRunStatus> {
-    let root = crate::paths::claudepot_data_dir().join("agents");
+    // Resolved through `paths` so it honours `CLAUDEPOT_DATA_DIR` and
+    // the test-isolation guard rather than rebuilding `$HOME/.claudepot`.
+    scan_status_in(&crate::paths::claudepot_data_dir().join("agents"), check)
+}
+
+/// [`scan_status_live`] against an explicit root, so the state machine
+/// can be tested against a fixture tree instead of the developer's live
+/// data directory.
+pub fn scan_status_in(root: &Path, check: &dyn ProcessCheck) -> Vec<AgentRunStatus> {
     let rd = match std::fs::read_dir(&root) {
         Ok(rd) => rd,
         // A missing agents root is a real zero: no agent has ever been
@@ -363,6 +371,24 @@ pub fn scan_status_live(check: &dyn ProcessCheck) -> Vec<AgentRunStatus> {
         let (last, last_bad) = match last_run(&dir) {
             Ok(l) => (l, false),
             Err(_) => (None, true),
+        };
+        // A candidate that predates the newest COMPLETED run is not in
+        // flight — it is an orphan, and the newer completed run is the
+        // current truth.
+        //
+        // Without this an interrupted directory shadows the agent
+        // forever: "no result.json" had no upper bound on age, so a run
+        // killed at 07:14 (an app update, a reboot, a kill -9) kept
+        // reporting `Interrupted` over a run that succeeded at 07:36,
+        // and the card could never show "Last run …" again until
+        // someone pruned the directory by hand.
+        //
+        // `Interrupted` remains correct — but only when nothing newer
+        // finished. That is the difference between "this agent is
+        // broken right now" and "this agent was interrupted once".
+        let in_flight = match (in_flight, &last) {
+            (Some(f), Some(l)) if f.started_ms < l.ended_ms => None,
+            (f, _) => f,
         };
         out.push(AgentRunStatus {
             agent_id: id,
@@ -618,6 +644,74 @@ mod tests {
             got[0].state,
             RunState::Interrupted,
             "a pid that postdates the run is not the run"
+        );
+    }
+
+    /// The defect this rule exists for, reproduced from a real machine:
+    /// a run orphaned at 07:14 (killed by an app update) kept reporting
+    /// `Interrupted` over a run that SUCCEEDED at 07:36, because "in
+    /// flight" was defined as "no result.json" with no bound on age. The
+    /// card could never show "Last run …" again.
+    #[test]
+    fn an_orphan_older_than_the_newest_completed_run_is_superseded() {
+        let t = TempDir::new().unwrap();
+        let agents = t.path();
+        let a = agents.join("agent-a");
+
+        // Orphan first: no result.json, no pid → Interrupted on its own.
+        mk_run(&a, "orphan", None, false);
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        // Then a run that completed successfully, AFTER it.
+        let done = mk_run(&a, "done", Some("1"), true);
+        fs::write(
+            done.join("result.json"),
+            r#"{"exit_code":0,"duration_ms":1016600}"#,
+        )
+        .unwrap();
+
+        // On its own the orphan is still Interrupted — that classification
+        // is unchanged and correct.
+        let raw = scan_agent_dir("a", &a, &alive(&[])).unwrap();
+        assert_eq!(raw.len(), 1);
+        assert_eq!(raw[0].state, RunState::Interrupted);
+
+        // But the status the pane consumes must not report it, because a
+        // newer run finished.
+        let got = scan_status_in(agents, &alive(&[]));
+        let st = got.iter().find(|s| s.agent_id == "agent-a").unwrap();
+        assert!(
+            st.in_flight.is_none(),
+            "a superseded orphan must not shadow the completed run: {:?}",
+            st.in_flight
+        );
+        assert_eq!(st.last.as_ref().unwrap().exit_code, 0);
+        assert_eq!(st.last.as_ref().unwrap().duration_ms, 1016600);
+    }
+
+    /// The other half: an orphan with nothing newer IS the current state.
+    /// Suppressing it would hide a genuinely broken agent.
+    #[test]
+    fn an_orphan_with_no_newer_completed_run_is_still_reported() {
+        let t = TempDir::new().unwrap();
+        let agents = t.path();
+        let a = agents.join("agent-a");
+
+        let done = mk_run(&a, "done", Some("1"), true);
+        fs::write(
+            done.join("result.json"),
+            r#"{"exit_code":0,"duration_ms":10}"#,
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        // Orphan is NEWER than the completed run.
+        mk_run(&a, "orphan", None, false);
+
+        let got = scan_status_in(agents, &alive(&[]));
+        let st = got.iter().find(|s| s.agent_id == "agent-a").unwrap();
+        assert_eq!(
+            st.in_flight.as_ref().map(|r| r.state),
+            Some(RunState::Interrupted),
+            "a newer orphan is the current state and must be reported"
         );
     }
 

--- a/crates/claudepot-core/src/agent/shim.rs
+++ b/crates/claudepot-core/src/agent/shim.rs
@@ -110,6 +110,7 @@ printf '%s' '{prompt_b64}' | {decode_cmd} \
 EXIT=$?
 set -e
 END_TS=$(date -u +%s)
+RECORD_FAILED=""
 
 # `|| true` keeps a failed `_record-run` from aborting the shim
 # before it re-raises the real `claude -p` exit code below
@@ -124,7 +125,32 @@ END_TS=$(date -u +%s)
   --start "$START_TS" \
   --end "$END_TS" \
   --trigger scheduled \
-  --run-dir "$RUN_DIR" 2>"$RUN_DIR/record-run.log" || true
+  --run-dir "$RUN_DIR" 2>"$RUN_DIR/record-run.log" || RECORD_FAILED=$?
+
+# Leave evidence from the SHELL, not from the callee.
+#
+# The `||` above exists so a failed recorder cannot swallow the real
+# `claude -p` exit code. The comment further up claims `_record-run`
+# drops its own breadcrumb on failure — but that breadcrumb is written
+# BY the recorder, so it cannot exist for the cases where the recorder
+# never got far enough to write anything: the binary mid-replacement by
+# the updater, an OOM kill, a crash during start.
+#
+# Observed 2026-08-18: a run whose `claude -p` completed normally was
+# left with no result.json and no breadcrumb, because `_record-run` was
+# invoked at the moment the app bundle was being swapped. The run then
+# read as an orphan indefinitely, indistinguishable from one that never
+# finished.
+#
+# This branch runs in the shell that survived, so it lands whatever
+# happened to the callee.
+if [ -n "$RECORD_FAILED" ] && [ ! -f "$RUN_DIR/result.json" ]; then
+  echo "record-run failed with exit $RECORD_FAILED and wrote no result.json" > "$RUN_DIR/record-run-error.txt" 2>/dev/null || true
+  echo "run_id=$RUN_ID" >> "$RUN_DIR/record-run-error.txt" 2>/dev/null || true
+  echo "claude_exit=$EXIT" >> "$RUN_DIR/record-run-error.txt" 2>/dev/null || true
+  echo "started=$START_TS ended=$END_TS" >> "$RUN_DIR/record-run-error.txt" 2>/dev/null || true
+  echo "see record-run.log in this directory" >> "$RUN_DIR/record-run-error.txt" 2>/dev/null || true
+fi
 
 exit $EXIT
 "#,
@@ -844,5 +870,43 @@ mod tests {
                 .contains(r"\program files\claude\claude.exe"),
             "windows shim baked in an absolute Program Files path"
         );
+    }
+
+    /// A failed `_record-run` must leave evidence written by the SHELL.
+    /// The recorder's own breadcrumb cannot cover the cases that matter
+    /// — a binary replaced by the updater, an OOM kill, a crash before
+    /// it writes anything — because in those it never runs far enough to
+    /// write. Observed on a real machine 2026-08-18: a run whose
+    /// `claude -p` completed normally left no result.json and no
+    /// breadcrumb, and then read as an orphan indefinitely.
+    #[test]
+    fn a_failed_record_run_leaves_a_shell_written_breadcrumb() {
+        let a = auto();
+        let (segs, env) = inputs();
+        let s = render_unix(
+            &a,
+            &ShimInputs {
+                binary_abs_path: "/usr/local/bin/claude",
+                claudepot_cli_abs_path: "/Users/me/.claudepot/bin/claudepot",
+                agent_dir: "/tmp/agent",
+                path_segments: &segs,
+                extra_env: &env,
+            },
+        );
+        assert!(
+            s.contains("RECORD_FAILED"),
+            "the recorder's exit status must be captured, not discarded"
+        );
+        assert!(
+            s.contains("record-run-error.txt"),
+            "the shell must write the breadcrumb itself"
+        );
+        assert!(
+            s.contains("! -f \"$RUN_DIR/result.json\""),
+            "breadcrumb only when no result was actually produced"
+        );
+        // The real `claude -p` status must still be what the shim
+        // returns — a broken recorder may not mask it.
+        assert!(s.trim_end().ends_with("exit $EXIT"));
     }
 }


### PR DESCRIPTION
Reported from a real machine: the Agents card read **"Interrupted"** for an
agent whose most recent run had **succeeded** (exit 0, 17 minutes).

Two independent defects, one of them introduced by the run-visibility
feature itself.

## The display defect

"In flight" was defined as *"no `result.json`"* with **no bound on age**, so
a run directory orphaned at any point in the past outranked every completed
run after it — permanently. A run killed at 07:14 kept reporting
`Interrupted` over a run that finished at 07:36, and the card could never
show "Last run …" again until someone pruned the directory by hand.

The missing rule: an in-flight candidate **older than the newest completed
run** is an orphan, and the newer completed run is the current truth.
`Interrupted` stays correct when nothing newer finished — that is the
difference between *"this agent is broken right now"* and *"this agent was
interrupted once"*, which the original collapsed. Both directions are
tested; suppressing the second would hide a genuinely broken agent.

**This survived 26 audit findings across three rounds.** Every round asked
whether a single run was *classified* correctly; none asked whether a
correctly-classified `Interrupted` should still be *reported* once a newer
run finished. Right per-run, wrong per-agent.

## The silent failure that produced the orphan

The orphan's `stdout.log` holds a complete terminal `result` event — that
run finished normally, 19 turns, 410 s. Its `_record-run` callback fired 14
minutes later, at the moment the updater was replacing the app bundle it
invokes, and wrote neither `result.json` nor the `record-run-error.txt`
breadcrumb.

The shim's own comment claimed that breadcrumb covered this case. It cannot:
the breadcrumb is written **by the recorder**, so it is absent for exactly
the failures where the recorder never gets far enough to write — a binary
mid-replacement, an OOM kill, a crash on start. The `|| true` then discarded
the exit status, leaving no evidence at all.

The shim now captures the recorder's status and writes the breadcrumb
**itself, from the shell that survived**, whatever happened to the callee.
The real `claude -p` exit code is still what propagates.

## Verification

`cargo test --workspace` · `pnpm test` 1347 passed · `tsc --noEmit` ·
clippy `-D warnings` ×4 crates · `check:catalogs` · `verify-docs` ·
`repo-invariants`

Also adds `scan_status_in` so the state machine is tested against a fixture
tree rather than the developer's live data directory.
